### PR TITLE
docs: add link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 <p align="center">
-  <img alt="Flagship"
-    src="https://user-images.githubusercontent.com/556070/39432976-bd8520f4-4c62-11e8-863b-fe7ee694a4a0.png"
-    height="250">
+  <a href="https://brandingbrand.github.io/flagship/">
+    <img alt="Flagship"
+      src="https://user-images.githubusercontent.com/556070/39432976-bd8520f4-4c62-11e8-863b-fe7ee694a4a0.png"
+      height="250">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Add a link to the documentation in the logo of the README