### PR TITLE
fix(fscomponents): use undefined as Swatches defaultValue

### DIFF
--- a/packages/fscomponents/src/components/AddToCart.tsx
+++ b/packages/fscomponents/src/components/AddToCart.tsx
@@ -197,7 +197,7 @@ export class AddToCart extends PureComponent<AddToCartProps, AddToCartState> {
                   key={index}
                   title={option.name}
                   items={option.values}
-                  defaultValue={defaultOption ? defaultOption.value : null}
+                  defaultValue={defaultOption ? defaultOption.value : undefined}
                   onChangeSwatch={this.updateOption.bind(this, option.id)}
                   {...swatchesProps}
                 />


### PR DESCRIPTION
Swatches `defaultValue` is defined as an optional so `undefined` should be used instead of `null` to indicate no `defaultValue`.