### PR TITLE
fix(fsshopify): fix shopifydatasource test

### DIFF
--- a/packages/fsshopify/src/__tests__/ShopifyDataSource.test.ts
+++ b/packages/fsshopify/src/__tests__/ShopifyDataSource.test.ts
@@ -4,6 +4,7 @@ const mockDirName = __dirname;
 jest.mock('react-native', () => {
   return {
     default: {},
+    requireNativeComponent: () => false,
     NativeModules: {
       ReactNativePayments: {}
     },


### PR DESCRIPTION
Resolves build issue in https://github.com/brandingbrand/flagship/pull/3

The new version of react-native-payments introduced by Greenkeeper uses ReactNative.requireNativeComponent to import native UI widgets. Because the ShopifyDataSource test mocks react-native, we need to mock this method as well to prevent the test from erroring.