### PR TITLE
fix(pirateship): clean up demandware product descriptions

### DIFF
--- a/packages/pirateship/src/lib/commerceCloudMiddleware.ts
+++ b/packages/pirateship/src/lib/commerceCloudMiddleware.ts
@@ -3,7 +3,7 @@ import { CommerceTypes } from '@brandingbrand/fscommerce';
 export const commerceCloudMiddleware = {
   fetchProduct: (data: any, normalized: CommerceTypes.Product): CommerceTypes.Product => {
     if (!normalized.description) {
-      normalized.description = data.long_description;
+      normalized.description = (data.long_description || '').replace(/\s+<li/g, '<li');
     }
 
     return normalized;


### PR DESCRIPTION
The html in the product descriptions coming from Demandware has spacing between <li> elements which is rendered as such by react-native-htmlview. This updates the Demandware middleware to remove spaces before <li elements in product descriptions.