### PR TITLE
chore: update to greenkeeper-lockfile 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,12 @@ install:
 jobs:
   include:
   - script: commitlint-travis || travis_terminate 1
-  - before_install: yarn global add greenkeeper-lockfile@1
+  - before_install:
+    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
+    - export PATH=$HOME/.yarn/bin:$PATH
+    - node --version
+    - yarn --version
+    - yarn global add greenkeeper-lockfile@2
     before_script: greenkeeper-lockfile-update
     script: yarn prepare || travis_terminate 1
     after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
greenkeeper-lockfile version 2 adds support for monorepos