### PR TITLE
fix: attempt to fix greenkeeper-lockfile ci issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ jobs:
     - export PATH=$HOME/.yarn/bin:$PATH
     - node --version
     - yarn --version
-    - yarn global add greenkeeper-lockfile@2
-    before_script: greenkeeper-lockfile-update
+    before_script: ./node_modules/.bin/greenkeeper-lockfile-update
     script: yarn prepare || travis_terminate 1
-    after_script: greenkeeper-lockfile-upload
+    after_script: ./node_modules/.bin/greenkeeper-lockfile-upload
   - script:
     - yarn prepare:fscodestyle
     - yarn lint || travis_terminate 1

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "ts-loader": "^4.3.0",
     "typedoc": "^0.11.1",
     "typedoc-plugin-monorepo": "^0.1.0",
-    "typescript": "^2.9.1"
+    "typescript": "^2.9.1",
+    "greenkeeper-lockfile": "^2.4.0"
   },
   "greenkeeper": {
     "commitMessages": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5118,7 +5118,7 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
-fast-glob@^2.0.2:
+fast-glob@^2.0.2, fast-glob@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.2.tgz#71723338ac9b4e0e2fff1d6748a2a13d5ed352bf"
   dependencies:
@@ -5724,6 +5724,20 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+greenkeeper-lockfile@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-2.4.0.tgz#98f5449e0a5d402ee4f0ed4413bb1b1920f1da9e"
+  dependencies:
+    fast-glob "^2.2.0"
+    greenkeeper-monorepo-definitions "^1.0.0"
+    lodash "^4.17.4"
+    require-relative "^0.8.7"
+    semver "^5.3.0"
+
+greenkeeper-monorepo-definitions@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/greenkeeper-monorepo-definitions/-/greenkeeper-monorepo-definitions-1.4.0.tgz#4946b4b55be57ae604fd715ecb5cc85a518542a3"
 
 "growl@~> 1.10.0":
   version "1.10.5"
@@ -10327,6 +10341,10 @@ require-from-string@^2.0.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Attempt to fix CI issues with greenkeeper-lockfile by following the suggestion of adding it as a devDependency instead of attempting to add it as a global to yarn.