### PR TITLE
chore: update greenkeeper-lockfile to brandingbrand fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "typedoc": "^0.11.1",
     "typedoc-plugin-monorepo": "^0.1.0",
     "typescript": "^2.9.1",
-    "greenkeeper-lockfile": "^2.4.0"
+    "@brandingbrand/greenkeeper-lockfile": "^0.0.1"
   },
   "greenkeeper": {
     "commitMessages": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,6 +463,16 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
+"@brandingbrand/greenkeeper-lockfile@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@brandingbrand/greenkeeper-lockfile/-/greenkeeper-lockfile-0.0.1.tgz#fcdfdbff529aed0eb78ae2719c726f001f2d13ce"
+  dependencies:
+    fast-glob "^2.2.0"
+    greenkeeper-monorepo-definitions "^1.0.0"
+    lodash "^4.17.4"
+    require-relative "^0.8.7"
+    semver "^5.3.0"
+
 "@brandingbrand/react-native-adobe-marketing-cloud@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@brandingbrand/react-native-adobe-marketing-cloud/-/react-native-adobe-marketing-cloud-0.1.0.tgz#1fafb93989c6547df0994929f22e3ed482c276cc"
@@ -5724,16 +5734,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-greenkeeper-lockfile@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/greenkeeper-lockfile/-/greenkeeper-lockfile-2.4.0.tgz#98f5449e0a5d402ee4f0ed4413bb1b1920f1da9e"
-  dependencies:
-    fast-glob "^2.2.0"
-    greenkeeper-monorepo-definitions "^1.0.0"
-    lodash "^4.17.4"
-    require-relative "^0.8.7"
-    semver "^5.3.0"
 
 greenkeeper-monorepo-definitions@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
greenkeer-lockfile is erring for Flagship CI but doesn't have any error trapping/logging so all we see is "command failed". This wraps all the exec statements in try/catch blocks that console logs stderr to hopefully get more information.