### PR TITLE
feat(fsapp): Add environment switcher for web

### DIFF
--- a/packages/fsapp/src/fsapp/FSApp.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.tsx
@@ -8,12 +8,6 @@ import NativeConstants from '../lib/native-constants';
 import { FSAppBase } from './FSAppBase';
 import DevMenu from '../components/DevMenu';
 
-import EnvSwitcher from '../lib/env-switcher';
-// @ts-ignore project_env_index ignore and will be changed by init
-import projectEnvs from '../../project_env_index';
-
-export const env: any = projectEnvs[`${EnvSwitcher.envName}`] || projectEnvs.prod;
-
 export class FSApp extends FSAppBase {
   constructor(appConfig: AppConfigType) {
     super(appConfig);

--- a/packages/fsapp/src/fsapp/FSApp.web.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.web.tsx
@@ -4,8 +4,6 @@ import { FSAppBase } from './FSAppBase';
 import App from '../components/DrawerRouter.web';
 import DevMenu from '../components/DevMenu';
 
-export const env: any = {};
-
 export class FSApp extends FSAppBase {
   constructor(appConfig: AppConfigType) {
     super(appConfig);

--- a/packages/fsapp/src/index.ts
+++ b/packages/fsapp/src/index.ts
@@ -1,4 +1,9 @@
 import * as FSAppTypes from './types';
-import { env, FSApp } from './fsapp/FSApp';
+import { FSApp } from './fsapp/FSApp';
+
+import EnvSwitcher from './lib/env-switcher';
+// @ts-ignore project_env_index ignore and will be changed by init
+import projectEnvs from '../project_env_index';
+const env = projectEnvs[`${EnvSwitcher.envName}`] || projectEnvs.prod;
 
 export { env, FSApp, FSAppTypes };

--- a/packages/fsapp/src/lib/env-switcher.web.ts
+++ b/packages/fsapp/src/lib/env-switcher.web.ts
@@ -1,0 +1,23 @@
+class WebEnvSwitcher {
+  storageKey: string = 'envName';
+
+  get envName(): string {
+    const storedEnvName = localStorage.getItem(this.storageKey);
+
+    return storedEnvName || 'prod';
+  }
+
+  set envName(name: string) {
+    if (typeof name === 'string') {
+      localStorage.setItem(this.storageKey, name);
+    }
+  }
+
+  // Match the native version's method for type reasons
+  async setEnv(name: string): Promise<void> {
+    this.envName = name;
+  }
+}
+
+const EnvSwitcher = new WebEnvSwitcher();
+export default EnvSwitcher;


### PR DESCRIPTION
Stores the currently selected environment in local storage. If no key
exists or the environment name is invalid, it defaults to prod.