### PR TITLE
fix(fsapp): Fix parsing of query string passprops

### DIFF
--- a/packages/fsapp/src/components/screenWrapper.web.tsx
+++ b/packages/fsapp/src/components/screenWrapper.web.tsx
@@ -112,7 +112,7 @@ export default function wrapScreen(
 
       if (location && location.search) {
         passProps = {
-          ...qs.parse(location.search),
+          ...qs.parse(location.search, { ignoreQueryPrefix: true }),
           ...match.params
         };
       }


### PR DESCRIPTION
The first passed property always included the ? query string delimiter (eg. `?categoryId`)