### PR TITLE
fix(flagship): updates/fixes to init script

### DIFF
--- a/packages/flagship/src/lib/link.ts
+++ b/packages/flagship/src/lib/link.ts
@@ -25,7 +25,7 @@ export async function link(configuration: Config): Promise<boolean | object> {
     configuration.codepush.ios.deploymentKey;
 
   // Spawn react-native link
-  const spawned = spawn('react-native', ['link'], {
+  const spawned = spawn('react-native', ['link', '--verbose'], {
     cwd: path.project.path(),
     shell: os.win
   });
@@ -37,8 +37,6 @@ export async function link(configuration: Config): Promise<boolean | object> {
       .wait('What is your CodePush deployment key for iOS (hit <ENTER> to ignore)')
       .sendline(iosDeploymentKey)
       .sendEof();
-  } else {
-    spawned.sendEof();
   }
 
   return new Promise<boolean | object>((resolve, reject) => {


### PR DESCRIPTION
There appears to be a bug in how node-suspect, the library we're using to interact with the command line during the init process, handles output buffers. The symptom is hanging when running init while using Node 8. For whatever reason, forcing react-native link into --verbose mode resolves this issue.

This also removes an extraneous sendEof() command that's not necessary when CodePush is not enabled for a project.