### PR TITLE
refactor(pirateship): Use TS 2.9 type imports for RN Navigation

### DIFF
--- a/packages/pirateship/src/components/PSProductDetail.tsx
+++ b/packages/pirateship/src/components/PSProductDetail.tsx
@@ -7,8 +7,6 @@ import {
   View
 } from 'react-native';
 import { cloneDeep, find, findIndex } from 'lodash-es';
-import { Navigator } from 'react-native-navigation';
-
 import {
   Loading,
   ReviewIndicator,
@@ -40,6 +38,8 @@ import {
   CommerceTypes,
   ReviewDataSource
 } from '@brandingbrand/fscommerce';
+
+type Navigator = import ('react-native-navigation').Navigator;
 
 const icons = {
   zoom: require('../../assets/images/icon-zoom.png'),

--- a/packages/pirateship/src/components/PSProductIndex.tsx
+++ b/packages/pirateship/src/components/PSProductIndex.tsx
@@ -9,8 +9,6 @@ import {
 } from 'react-native';
 
 import React, { Component } from 'react';
-import { Navigator } from 'react-native-navigation';
-
 import { CommerceTypes } from '@brandingbrand/fscommerce';
 import { ProductIndex, ProductIndexSearch } from '@brandingbrand/fsproductindex';
 
@@ -24,6 +22,8 @@ import PSFilterActionBar from '../components/PSFilterActionBar';
 import { FilterItem, ProductItem } from '@brandingbrand/fscomponents';
 import { border, color, fontSize, palette } from '../styles/variables';
 import translate, { translationKeys } from '../lib/translations';
+
+type Navigator = import ('react-native-navigation').Navigator;
 
 const window = Dimensions.get('window');
 

--- a/packages/pirateship/src/components/PSRecentlyViewedCarousel.tsx
+++ b/packages/pirateship/src/components/PSRecentlyViewedCarousel.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Navigator } from 'react-native-navigation';
 import {
   StyleProp,
   StyleSheet,
@@ -12,6 +11,8 @@ import PSProductCarousel from './PSProductCarousel';
 import { border, palette } from '../styles/variables';
 import { CommerceTypes } from '@brandingbrand/fscommerce';
 import translate, { translationKeys } from '../lib/translations';
+
+type Navigator = import ('react-native-navigation').Navigator;
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/pirateship/src/lib/commonTypes.ts
+++ b/packages/pirateship/src/lib/commonTypes.ts
@@ -1,18 +1,14 @@
 import { ImageURISource } from 'react-native';
-import {
-  Navigator,
-  NavigatorButton,
-  NavigatorStyle,
-  PushedScreen
-} from 'react-native-navigation';
+export type PushedScreen<P> = import ('react-native-navigation').PushedScreen<P>;
+export type NavigatorStyle = import ('react-native-navigation').NavigatorStyle;
 
 export interface ScreenProps {
-  navigator: Navigator;
+  navigator: import ('react-native-navigation').Navigator;
   onNav: (handler: (event: any) => void) => void;
 }
 
 export interface NavButton {
-  button: NavigatorButton;
+  button: import ('react-native-navigation').NavigatorButton;
   action: (params: any) => void;
 }
 
@@ -21,5 +17,3 @@ export interface GridItem {
   image: ImageURISource;
   path: string;
 }
-
-export { NavigatorStyle, PushedScreen };

--- a/packages/pirateship/src/lib/shortcuts.ts
+++ b/packages/pirateship/src/lib/shortcuts.ts
@@ -1,4 +1,4 @@
-import { Navigator } from 'react-native-navigation';
+type Navigator = import ('react-native-navigation').Navigator;
 
 export const openSignInModal = (navigator: Navigator) => () => {
   navigator.showModal({

--- a/packages/pirateship/src/screens/Development.tsx
+++ b/packages/pirateship/src/screens/Development.tsx
@@ -8,7 +8,7 @@ import Row from '../components/PSRow';
 import { NavigatorStyle, ScreenProps } from '../lib/commonTypes';
 import { navBarDefault } from '../styles/Navigation';
 import withAccount, { AccountProps } from '../providers/accountProvider';
-import { Screen } from 'react-native-navigation';
+type Screen = import ('react-native-navigation').Screen;
 
 const screens: Screen[] = [
   { title: 'Product Index', screen: 'ProductIndex' },


### PR DESCRIPTION
Importing react-native-navigation breaks compiliation for web. We're
only using it for its type definitions in these places, so we can use
the new typescript type imports to get around this.