### PR TITLE
fix(pirateship): Don't pass review datasource to screen as a prop

### DIFF
--- a/packages/pirateship/src/components/PSProductDetail.tsx
+++ b/packages/pirateship/src/components/PSProductDetail.tsx
@@ -725,8 +725,7 @@ class PSProductDetailComponent extends Component<
         'ProductDetailReviews',
         'Reviews (' + commerceData.review.total + ')',
         {
-          reviewQuery: { ids: commerceData.id, limit: 2 },
-          reviewDataSource: this.props.reviewDataSource
+          reviewQuery: { ids: commerceData.id }
         }
       );
     }

--- a/packages/pirateship/src/screens/ProductDetailReviews.tsx
+++ b/packages/pirateship/src/screens/ProductDetailReviews.tsx
@@ -6,10 +6,10 @@ import { NavButton, NavigatorStyle, ScreenProps } from '../lib/commonTypes';
 import { backButton } from '../lib/navStyles';
 import { navBarNoTabs } from '../styles/Navigation';
 import translate, { translationKeys } from '../lib/translations';
+import { reviewDataSource } from '../lib/datasource';
 
 export interface ProductDetailReviewsProps extends ScreenProps {
   reviewQuery: import ('@brandingbrand/fscommerce').ReviewTypes.ReviewQuery;
-  reviewDataSource: import ('@brandingbrand/fscommerce').ReviewDataSource;
 }
 
 export default class ProductDetailReviews extends Component<ProductDetailReviewsProps> {
@@ -29,7 +29,7 @@ export default class ProductDetailReviews extends Component<ProductDetailReviews
       <PSScreenWrapper hideGlobalBanner={true}>
         <PSProductDetailReviews
           reviewQuery={this.props.reviewQuery}
-          reviewDataSource={this.props.reviewDataSource}
+          reviewDataSource={reviewDataSource}
         />
       </PSScreenWrapper>
     );


### PR DESCRIPTION
PassProps get serialized into query string parameters on web, so passing
the review data source (a class/function) into the new screen does not
work on web. Also, removed some debugging code that was accidentally
left in.