### PR TITLE
feat(pirateship): refactor pdp to allow for inline reloading

### DIFF
--- a/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
@@ -46,7 +46,9 @@ export class BazaarvoiceDataSource extends AbstractReviewDataSource implements R
         return [{
           id,
           reviews: data.Results.map(BazaarvoiceNormalizer.review),
-          statistics: BazaarvoiceNormalizer.reviewStatistics(data.Includes.Products[id]),
+          statistics: data.Includes
+            && data.Includes.Products
+            && BazaarvoiceNormalizer.reviewStatistics(data.Includes.Products[id]),
           page: (data.Offset / data.Limit) + 1,
           limit: data.Limit,
           total: data.TotalResults


### PR DESCRIPTION
Previously a new screen had to be pushed whenever a user selected a different swatch. This removes the product and review providers and retrieves the data inline, allowing the same screen to be updated with new product data.