### PR TITLE
fix(fsshopify): Make fsshopify work on web

### DIFF
--- a/packages/fsshopify/src/customTypes.ts
+++ b/packages/fsshopify/src/customTypes.ts
@@ -48,6 +48,13 @@ export interface ShopifyConfig {
   domain: string;
   storefrontAccessToken: string;
   googlePayPublicKey?: string;
+
+  /**
+   * The name of the registered screen that will be used to
+   * display the Google Pay Shipping Options modal
+   */
+  googlePayScreenName?: string;
+
   iosMerchantIdentifier?: string;
 
   /**

--- a/packages/fsshopify/src/mixins/ShopifyCartDataSource.ts
+++ b/packages/fsshopify/src/mixins/ShopifyCartDataSource.ts
@@ -16,7 +16,7 @@ import {
   PaymentMethodData,
   PaymentOptions,
   PaymentRequest
-} from 'react-native-payments';
+} from '../util/react-native-payments';
 import { Platform } from 'react-native';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import { Navigator } from 'react-native-navigation';
@@ -376,9 +376,14 @@ export class ShopifyCartDataSource extends DataSourceBase
         throw new ShopifyAPIError('unable to update shipping method and request options');
       }
 
+      if (!this.config.googlePayScreenName) {
+        throw new Error('You must provide the name of the screen to ' +
+          'be used for the Google Pay Shipping Options Modal');
+      }
+
       // need to show modal here to present the user with shipping options
       navigator.showModal({
-        screen: 'GooglePayShippingOptionsModal',
+        screen: this.config.googlePayScreenName,
         title: 'Google Pay',
         passProps: {
           datasource: this,

--- a/packages/fsshopify/src/util/DataSourceBase.ts
+++ b/packages/fsshopify/src/util/DataSourceBase.ts
@@ -2,9 +2,6 @@ import * as Types from '../customTypes';
 import * as ShopifyResponseTypes from '../util/ShopifyResponseTypes';
 import ShopifyAPIError from './ShopifyAPIError';
 import ShopifyAPI from './ShopifyAPI';
-import { Navigation } from 'react-native-navigation';
-import gpayshippingoption from '../components/GooglePayShippingOptionsModal';
-import { AppRegistry } from 'react-native';
 
 export default class DataSourceBase {
   api: ShopifyAPI;
@@ -24,16 +21,9 @@ export default class DataSourceBase {
     this.api = new ShopifyAPI(config.domain, config.storefrontAccessToken);
     this.googlePayKey = config.googlePayPublicKey;
     this.iosMerchantIdentifier = config.iosMerchantIdentifier;
-
-    // if google pay is configured, push the default shipping options modal if the app has not
-    // already registered a custom one
-    if (this.googlePayKey) {
-      const registered = !!AppRegistry.getRunnable('GooglePayShippingOptionsModal');
-      if (!registered) {
-        Navigation.registerComponent('GooglePayShippingOptionsModal', (): any => {
-          return gpayshippingoption;
-        });
-      }
+    if (this.googlePayKey && !config.googlePayScreenName) {
+      throw new Error('You must provide the name of the screen to ' +
+        'be used for the Google Pay Shipping Options Modal');
     }
   }
 

--- a/packages/fsshopify/src/util/react-native-payments.ts
+++ b/packages/fsshopify/src/util/react-native-payments.ts
@@ -1,0 +1,1 @@
+export * from 'react-native-payments';

--- a/packages/fsshopify/src/util/react-native-payments.web.ts
+++ b/packages/fsshopify/src/util/react-native-payments.web.ts
@@ -8,8 +8,16 @@ type PaymentRequestUpdateEvent = import ('react-native-payments').PaymentRequest
 
 export class PaymentRequest implements PaymentRequestInterface {
   id: string = '';
-  shippingAddress: null = null;
-  shippingOption: null = null;
+  shippingAddress: null | PaymentAddress = null;
+  shippingOption: null | string = null;
+
+  constructor(
+    methodData: PaymentMethodData[],
+    details?: PaymentDetailsInit,
+    options?: PaymentOptions
+  ) {
+    throw new Error('Unsupported');
+  }
 
   async show(): Promise<PaymentResponse> {
     throw new Error('Unsupported');

--- a/packages/fsshopify/src/util/react-native-payments.web.ts
+++ b/packages/fsshopify/src/util/react-native-payments.web.ts
@@ -1,0 +1,32 @@
+export type PaymentDetailsInit = import ('react-native-payments').PaymentDetailsInit;
+export type PaymentMethodData = import ('react-native-payments').PaymentMethodData;
+export type PaymentOptions = import ('react-native-payments').PaymentOptions;
+
+type PaymentRequestInterface = import ('react-native-payments').PaymentRequest;
+type PaymentResponse = import ('react-native-payments').PaymentResponse;
+type PaymentRequestUpdateEvent = import ('react-native-payments').PaymentRequestUpdateEvent;
+
+export class PaymentRequest implements PaymentRequestInterface {
+  id: string = '';
+  shippingAddress: null = null;
+  shippingOption: null = null;
+
+  async show(): Promise<PaymentResponse> {
+    throw new Error('Unsupported');
+  }
+
+  async abort(): Promise<void> {
+    throw new Error('Unsupported');
+  }
+
+  async canMakePayments(): Promise<boolean> {
+    return false;
+  }
+
+  addEventListener(
+    eventName: 'shippingaddresschange' | 'shippingoptionchange',
+    fn: (e: PaymentRequestUpdateEvent) => void
+  ): void {
+    throw new Error('Unsupported');
+  }
+}


### PR DESCRIPTION
- Mock out react-native-payments
- Don't auto-register Google Pay Shipping Options Modal (should be
handled in the project). The screen name of the modal is to be passed in
as a config option.