### PR TITLE
fix(pirateship): fixes empty cart title color to secondary dark gray

### DIFF
--- a/packages/pirateship/src/screens/Cart.tsx
+++ b/packages/pirateship/src/screens/Cart.tsx
@@ -36,7 +36,8 @@ const CartStyle = StyleSheet.create({
     fontWeight: 'bold'
   },
   title: {
-    marginTop: 15
+    marginTop: 15,
+    color: palette.secondary
   },
   cartContainer: {
     marginHorizontal: 15
@@ -204,9 +205,9 @@ const icons = {
 
 export interface CartScreenProps
   extends ScreenProps,
-    AccountProps,
-    CartProps,
-    RecentlyViewedProps {}
+  AccountProps,
+  CartProps,
+  RecentlyViewedProps { }
 
 class Cart extends Component<CartScreenProps> {
   static navigatorStyle: NavigatorStyle = navBarFullBleed;


### PR DESCRIPTION
- used existing grays.eight, the variable set to palette.secondary: hex '#343434'