### PR TITLE
fix(pirateship): Fix demo web app build script

### DIFF
--- a/packages/pirateship/scripts/buildWebDemo.sh
+++ b/packages/pirateship/scripts/buildWebDemo.sh
@@ -7,4 +7,4 @@ fi
 
 yarn run init web
 cd web
-yarn run build --output-public-path '/flagship/web-demo' --output-path '../../../docs/web-demo'
+yarn run build --output-public-path '/flagship/web-demo/' --output-path '../../../docs/web-demo'


### PR DESCRIPTION
Needed a trailing slash at the end of the public-path variable so paths would be concatenated
correctly