### PR TITLE
feat: Add flags for setting env/dev when using webpack

### DIFF
--- a/packages/fsapp/src/lib/env-switcher.web.ts
+++ b/packages/fsapp/src/lib/env-switcher.web.ts
@@ -1,10 +1,14 @@
+// __DEFAULT_ENV__ is injected by webpack.
+declare const __DEFAULT_ENV__: string;
+
 class WebEnvSwitcher {
   storageKey: string = 'envName';
+  defaultAppEnv: string = __DEFAULT_ENV__ || 'prod';
 
   get envName(): string {
     const storedEnvName = localStorage.getItem(this.storageKey);
 
-    return storedEnvName || 'prod';
+    return storedEnvName || this.defaultAppEnv;
   }
 
   set envName(name: string) {

--- a/packages/fsweb/webpack.config.js
+++ b/packages/fsweb/webpack.config.js
@@ -172,7 +172,8 @@ module.exports = function(env, options) {
         filename: 'static/css/[name].[hash:8].css'
       }),
       new webpack.DefinePlugin({
-        __DEV__: false
+        __DEV__: env.enableDev ? true : false,
+        __DEFAULT_ENV__: JSON.stringify(env.defaultEnvName)
       }),
       new UglifyJsPlugin({
         test: /.m?[jt]sx?/,

--- a/packages/pirateship/scripts/buildWebDemo.sh
+++ b/packages/pirateship/scripts/buildWebDemo.sh
@@ -7,4 +7,4 @@ fi
 
 yarn run init web
 cd web
-yarn run build --output-public-path '/flagship/web-demo/' --output-path '../../../docs/web-demo'
+yarn run build --output-public-path '/flagship/web-demo/' --output-path '../../../docs/web-demo' --env.enableDev=true --env.defaultEnvName=mock


### PR DESCRIPTION
Can now use a couple new env options with webpack
--env.enableDev to control if __DEV__ is set
--env.defaultEnvName to specify an environment when using webpack