### PR TITLE
fix(fsapp): Don't navigate when switching envs

### DIFF
--- a/packages/fsapp/src/components/DevMenu.web.tsx
+++ b/packages/fsapp/src/components/DevMenu.web.tsx
@@ -191,8 +191,8 @@ export default class DevMenu extends Component<GenericScreenProp, DevMenuState> 
 
   switchToSelectedEnv = () => {
     EnvSwitcher.envName = this.state.selectedEnv;
-    if (typeof window !== 'undefined' && window.location && window.location.assign) {
-      window.location.assign('/');
+    if (typeof window !== 'undefined' && window.location && window.location.reload) {
+      window.location.reload();
     }
   }
 


### PR DESCRIPTION
Instead of navigating to `/` after switching environments, only reload the current page. This avoids the assumption that the app will be served from the root directory.