### PR TITLE
fix(fscomponents): make grid column separator visible

### DIFF
--- a/packages/fscomponents/src/components/Grid.tsx
+++ b/packages/fscomponents/src/components/Grid.tsx
@@ -34,12 +34,12 @@ const gridStyle = StyleSheet.create({
   },
   rowSeparator: {
     width: '100%',
-    height: StyleSheet.hairlineWidth,
+    height: 1,
     backgroundColor: '#8E8E8E'
   },
   columnSeparator: {
     height: '100%',
-    width: StyleSheet.hairlineWidth,
+    width: 1,
     backgroundColor: '#8E8E8E'
   },
   scrollTopButtonContainer: {


### PR DESCRIPTION
column separator was not showing up in pirateship. changed width from ‘hairlineWidth’ to 1. user can still configure it to hairline width if they so choose through optional columnSeparatorStyle prop.