### PR TITLE
feat(flagship): add module install script for react-native-firebase

### DIFF
--- a/packages/flagship/src/lib/modules/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/react-native-firebase.ts
@@ -1,0 +1,156 @@
+const { execSync } = require('child_process');
+
+import * as path from '../path';
+import * as fs from '../fs';
+import { Config } from '../../types';
+import {
+  logError,
+  logInfo,
+  logWarn
+} from '../../helpers';
+
+export function android(configuration: Config): void {
+  if (!(configuration.firebase
+        && configuration.firebase.android
+        && configuration.firebase.android.googleServicesJsonFile)
+  ) {
+    logError('firebase.android.googleServicesJsonFile must be specified in project config');
+
+    return process.exit(1);
+  }
+
+  // Copy google-services.json to <project root>/android
+  const jsonFilePath = path.project.resolve(configuration.firebase.android.googleServicesJsonFile);
+  fs.copySync(jsonFilePath, path.resolve('android', 'app', 'google-services.json'));
+  logInfo('copied google-services.json into ./android/');
+
+  // Disable aapt2 because it's not compatible with the Firebase install. Add
+  // android.enableAapt2=false to gradle.properties
+  let gradleProps = fs.readFileSync(path.android.gradlePropertiesPath(), { encoding: 'utf8' });
+  gradleProps += '\nandroid.enableAapt2=false\n';
+  fs.writeFileSync(path.android.gradlePropertiesPath(), gradleProps);
+  logInfo('disabled aapt2 in gradle.properties');
+
+  // Add dependencies to /android/app/build.gradle and replace compile command with implementation
+  // command due to Gradle 3 changes
+  const firebaseDep = `
+    implementation 'com.google.android.gms:play-services-base:15.0.1'
+    implementation 'com.google.firebase:firebase-core:16.0.1'
+      `;
+
+  let gradleAppBuild = fs.readFileSync(path.android.gradlePath(), { encoding: 'utf8' });
+
+  gradleAppBuild = gradleAppBuild.replace(
+    /(compile.+?native-device-info[^}]+?})/,
+    `$1\n    ${firebaseDep}`
+  );
+
+  gradleAppBuild += '\napply plugin: \'com.google.gms.google-services\'\n';
+  gradleAppBuild = gradleAppBuild.replace(/compile /g, 'implementation ');
+  gradleAppBuild = gradleAppBuild.replace(/compile\(/g, 'implementation(');
+  fs.writeFileSync(path.android.gradlePath(), gradleAppBuild);
+  logInfo('updated ./android/app/build.gradle');
+
+  // Add dependencies to /android/build.gradle and update gradle version to 3.1.3
+  let gradleBuild = fs.readFileSync(path.resolve('android', 'build.gradle'), { encoding: 'utf8' });
+  const servicesDep = `classpath 'com.google.gms:google-services:4.0.1'`;
+
+  if (gradleBuild.indexOf(servicesDep) > -1) {
+    return logWarn('Firebase already imported into Android project');
+  }
+
+  gradleBuild = gradleBuild.replace(/(dependencies\s*?{\s*?$)/m, `$1\n        ${servicesDep}`);
+
+  gradleBuild = gradleBuild.replace(
+    /(buildscript[\s\S]+?repositories\s*?{)/,
+    `$1\n        google()`
+  );
+
+  gradleBuild = gradleBuild.replace(
+    /(allprojects[\s\S]+?repositories[\s\S]+?mavenLocal\s*?\(\s*?\))/,
+    `$1\n        google()`
+  );
+
+  gradleBuild = gradleBuild.replace(
+    /(com\.android\.tools\.build:gradle:)[\d\.]+/,
+    '$13.1.3'
+  );
+
+  fs.writeFileSync(path.resolve('android', 'build.gradle'), gradleBuild);
+  logInfo('updated ./android/build.gradle');
+
+  // Update MainApplication.java
+  let mainApplication = fs.readFileSync(
+    path.android.mainApplicationPath(configuration),
+    { encoding: 'utf8' }
+  );
+
+  mainApplication = mainApplication.replace(
+    /(import io.invertase.firebase.RNFirebasePackage;)/,
+    '$1\nimport io.invertase.firebase.analytics.RNFirebaseAnalyticsPackage;'
+  );
+
+  mainApplication = mainApplication.replace(
+    /(new RNFirebasePackage\(\),)/,
+    '$1\n            new RNFirebaseAnalyticsPackage(),'
+  );
+
+  fs.writeFileSync(path.android.mainApplicationPath(configuration), mainApplication);
+  logInfo('updated MainApplication.java');
+
+  logInfo('finished updating Android for Firebase');
+}
+
+export function ios(configuration: Config): void {
+  if (!(configuration.firebase
+      && configuration.firebase.ios
+      && configuration.firebase.ios.googleServicesPlistFile)
+   ) {
+    logError('firebase.ios.googleServicesPlistFile must be specified in project config');
+
+    return process.exit(1);
+  }
+
+  // Copy GoogleService-Info.plist into ./ios/
+  fs.copySync(
+    configuration.firebase.ios.googleServicesPlistFile,
+    path.resolve(path.ios.nativeProjectPath(configuration), 'GoogleService-Info.plist')
+  );
+  logInfo('copied GoogleService-Info.plist to ./ios/');
+
+  let appDelegate = fs.readFileSync(
+    path.ios.appDelegatePath(configuration),
+    { encoding: 'utf-8' }
+  );
+
+  // Update AppDelegate.m with Firebase import and initialization
+  const firebaseImport = '#import <Firebase.h>';
+
+  if (appDelegate.indexOf(firebaseImport) === -1) {
+    appDelegate = firebaseImport + '\n' + appDelegate;
+    appDelegate = appDelegate.replace(
+      /(didFinishLaunchingWithOptions[\s\S]+?{)/,
+      '$1\n  [FIRApp configure];'
+    );
+
+    fs.writeFileSync(path.ios.appDelegatePath(configuration), appDelegate);
+    logInfo('Updated AppDelegate.m');
+  }
+
+  // Add Firebase pod to Podfile
+  let podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
+  const firebasePod = `pod 'Firebase/Core'`;
+
+  if (podfile.indexOf(firebasePod) === -1) {
+    fs.removeSync(path.ios.podfilePath() + '.lock');
+
+    podfile = podfile.replace(/(target\s+?.+?do)/, `$1\n  ${firebasePod}`);
+    fs.writeFileSync(path.ios.podfilePath(), podfile);
+
+    execSync('pod install', { cwd: path.resolve('ios') });
+
+    logInfo('updated Podfile with Firebase pod');
+  }
+
+  logInfo('finished updating iOS for firebase');
+}

--- a/packages/flagship/src/lib/path.ts
+++ b/packages/flagship/src/lib/path.ts
@@ -93,6 +93,15 @@ function getInfoPlistPath(configuration: Config): string {
 }
 
 /**
+ * Returns the path to AppDelegate.m file.
+ * @param {object} configuration The project configuration.
+ * @returns {string} The path
+ */
+function getAppDelegatePath(configuration: Config): string {
+  return resolvePathFromProject('ios', configuration.name, 'AppDelegate.m');
+}
+
+/**
  * Returns the path to the Podfile.
  * @returns {string} The path to the Podfile.
  */
@@ -257,6 +266,7 @@ export const project = {
 };
 
 export const ios = {
+  appDelegatePath: getAppDelegatePath,
   fastfilePath: getFastfilePathIOS,
   infoPlistPath: getInfoPlistPath,
   podfilePath: getPodfilePath,

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -19,6 +19,15 @@ export interface Config {
     accountKey: string;
   };
 
+  firebase?: {
+    ios?: {
+      googleServicesPlistFile: string;
+    };
+    android?: {
+      googleServicesJsonFile: string;
+    };
+  };
+
   exceptionDomains: {
     domain: string;
     value: string;


### PR DESCRIPTION
This adds a script to perform the necessary actions to install base Firebase and Firebase Analytics on iOS and Android. As with the other module scripts, it'll be run only when a particular dependency exists on a project, in this case react-native-firebase.

Requires the following to be added to the end project's config:

```
{
  firebase: {
    ios: {
      googleServicesPlistFile: '<path to GoogleService-Info.plist>'
    },
    android: {
      googleServicesJsonFile: '<path to google-services.json>'
    }
}
```