### PR TITLE
fix(fscomponents): make grid column & row separators visible

### DIFF
--- a/packages/fscomponents/src/components/Grid.tsx
+++ b/packages/fscomponents/src/components/Grid.tsx
@@ -34,12 +34,12 @@ const gridStyle = StyleSheet.create({
   },
   rowSeparator: {
     width: '100%',
-    height: StyleSheet.hairlineWidth,
+    height: 1,
     backgroundColor: '#8E8E8E'
   },
   columnSeparator: {
     height: '100%',
-    width: StyleSheet.hairlineWidth,
+    width: 1,
     backgroundColor: '#8E8E8E'
   },
   scrollTopButtonContainer: {


### PR DESCRIPTION
closes issue #178 
width still configurable by the user through rowSeparatorStyle & columnSeparatorStyle props