### PR TITLE
fix(flagship): use pod helper to avoid ci errors in firebase

### DIFF
--- a/packages/flagship/src/lib/modules/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/react-native-firebase.ts
@@ -1,7 +1,6 @@
-const { execSync } = require('child_process');
-
 import * as path from '../path';
 import * as fs from '../fs';
+import * as pods from '../cocoapods';
 import { Config } from '../../types';
 import {
   logError,
@@ -138,17 +137,12 @@ export function ios(configuration: Config): void {
   }
 
   // Add Firebase pod to Podfile
-  let podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
+  const podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
   const firebasePod = `pod 'Firebase/Core'`;
 
   if (podfile.indexOf(firebasePod) === -1) {
-    fs.removeSync(path.ios.podfilePath() + '.lock');
-
-    podfile = podfile.replace(/(target\s+?.+?do)/, `$1\n  ${firebasePod}`);
-    fs.writeFileSync(path.ios.podfilePath(), podfile);
-
-    execSync('pod install', { cwd: path.resolve('ios') });
-
+    pods.add(path.ios.podfilePath(), [firebasePod]);
+    pods.install();
     logInfo('updated Podfile with Firebase pod');
   }
 


### PR DESCRIPTION
Flagship init is used as part of our CI process on non-Mac machines. The Pod helper checks for the correct environment before running pod install. This replaces manual pod install with the helper for the Firebase module.