### PR TITLE
Add keys ios

### DIFF
--- a/packages/flagship/src/add-keys-ios.ts
+++ b/packages/flagship/src/add-keys-ios.ts
@@ -23,46 +23,60 @@ const importedProfilePath =
 const keychainName = process.env.KEYCHAIN || 'login.keychain';
 const keychainPwd = process.env.KEYCHAIN_PWD;
 const keychain = `~/Library/Keychains/${keychainName}`;
-console.log(`keychain is ${keychain}`);
-exec(`security create-keychain -p '${keychainPwd}' ${keychainName}`);
-exec(`security default-keychain -s ${keychainName}`);
-exec(`security unlock-keychain -p '${keychainPwd}' ${keychainName}`);
-exec(`security set-keychain-settings -t 3600 -u ${keychainName}`);
+console.log(`creating ${keychain}`);
+try {
+  exec(`security create-keychain -p '${keychainPwd}' ${keychainName}`);
+} catch (e) {
+  console.log(`error creating ${keychain}`);
+}
+exec(`security default-keychain -s ${keychainName}`, { stdio: [0, 1, 2] });
+exec(`security unlock-keychain -p '${keychainPwd}' ${keychainName}`, { stdio: [0, 1, 2] });
+exec(`security set-keychain-settings -t 3600 -u ${keychainName}`, { stdio: [0, 1, 2] });
 
-// add certificates and provisioning profiles to computer
+// add certificates and provisioning profiles to build environment
+// import wwdr
+console.log(`\nimporting ${buildConfig.wwdrCert}`);
 exec(
   `security import ${certificatePath}/${buildConfig.wwdrCert}.cer -k ${keychain} \
--T /usr/bin/codesign || true`
+-T /usr/bin/codesign || true`, { stdio: [0, 1, 2] }
 );
 
-// add keys for store build
 // - import project .cer
+console.log(`\nimporting ${buildConfig.distributionCert} certificate`);
 exec(
   `security import ${certificatePath}/${buildConfig.distributionCert}.cer -k ${keychain} \
--T /usr/bin/codesign -A || true`
+-T /usr/bin/codesign -A || true`, { stdio: [0, 1, 2] }
 );
+
 // - import project .p12
+console.log(`\nimporting ${buildConfig.distributionCert} .p12`);
 exec(
   `security import ${certificatePath}/${buildConfig.distributionCert}.p12 -k ${keychain} \
--P '${buildConfig.distributionPwd}' -T /usr/bin/codesign -A || true`
+-P '${buildConfig.distributionPwd}' -T /usr/bin/codesign -A || true`, { stdio: [0, 1, 2] }
 );
+
 // - import project .mobileprovision
-const uuid = exec(
-  `grep UUID -A1 -a ${profilePath}/${buildConfig.distributionCert}.mobileprovision | \
-  grep -io "[-A-Z0-9]\\{36\\}"`
-);
-fs.copyFileSync(
-  `${profilePath}/${buildConfig.distributionCert}.mobileprovision`,
-  `${importedProfilePath}/${uuid.toString().trim()}.mobileprovision`
-);
+console.log(`\nimporting ${buildConfig.distributionCert} provisioning profile`);
+try {
+  const uuid = exec(
+    `grep UUID -A1 -a ${profilePath}/${buildConfig.distributionCert}.mobileprovision | \
+    grep -io "[-A-Z0-9]\\{36\\}"`
+  );
+  fs.copyFileSync(
+    `${profilePath}/${buildConfig.distributionCert}.mobileprovision`,
+    `${importedProfilePath}/${uuid.toString().trim()}.mobileprovision`
+  );
+  console.log('1 provisioning profile imported.\n');
+} catch (e) {
+  console.log(`error importing ${buildConfig.distributionCert} provisioning profile\n`);
+}
 
 exec(
-  `security set-key-partition-list -S apple-tool:,apple: -s -k '${keychainPwd}' ${keychain}`
+  `security set-key-partition-list -S apple-tool:,apple: -s -k '${keychainPwd}' ${keychain}`,
+  { stdio: [0, 1, 2] }
 )
 
-console.log(
-  `\nDONE: iOS certificates and provisioning profiles added for [${buildConfig.distributionCert}]\n`
-);
+console.log(`\nDONE: iOS certificates and provisioning profiles added.\n`);
 
 process.exit();
 

--- a/packages/flagship/src/add-keys-ios.ts
+++ b/packages/flagship/src/add-keys-ios.ts
@@ -38,7 +38,7 @@ exec(
   `security import ${certificatePath}/${buildConfig.distributionCert}.p12 -k ${keychain} \
 -P '${buildConfig.distributionPwd}' -T /usr/bin/codesign -A || true`
 );
-// - import .mobileproviosn
+// - import .mobileprovision
 exec(
   `uuid=\`grep UUID -A1 -a \
 ${profilePath}/${buildConfig.distributionCert}.mobileprovision \

--- a/packages/flagship/src/add-keys-ios.ts
+++ b/packages/flagship/src/add-keys-ios.ts
@@ -30,26 +30,26 @@ exec(
 // add keys for store build
 // - import project .cer
 exec(
-  `security import ${certificatePath}/${buildConfig.deployScheme}.cer -k ${keychain} \
+  `security import ${certificatePath}/${buildConfig.distributionCert}.cer -k ${keychain} \
 -T /usr/bin/codesign -A || true`
 );
 // - import project .p12
 exec(
-  `security import ${certificatePath}/${buildConfig.deployScheme}.p12 -k ${keychain} \
+  `security import ${certificatePath}/${buildConfig.distributionCert}.p12 -k ${keychain} \
 -P "Branders1234$" -T /usr/bin/codesign -A || true`
 );
 // - import .mobileproviosn
 exec(
   `uuid=\`grep UUID -A1 -a \
-${profilePath}/${buildConfig.deployScheme}.mobileprovision \
+${profilePath}/${buildConfig.distributionCert}.mobileprovision \
 | grep -io "[-A-Z0-9]\\{36\\}"\`
   cp \
-${profilePath}/${buildConfig.deployScheme}.mobileprovision \
+${profilePath}/${buildConfig.distributionCert}.mobileprovision \
 ~/Library/MobileDevice/Provisioning\\ Profiles/$uuid.mobileprovision`
 );
 
 console.log(
-  `\nDONE: iOS certificates and provisioning profiles added for [${buildConfig.deployScheme}]\n`
+  `\nDONE: iOS certificates and provisioning profiles added for [${buildConfig.distributionCert}]\n`
 );
 
 process.exit();

--- a/packages/flagship/src/add-keys-ios.ts
+++ b/packages/flagship/src/add-keys-ios.ts
@@ -23,7 +23,7 @@ console.log(`keychain is ${keychain}`);
 
 // add certificates and provisioning profiles to computer
 exec(
-  `security import ${certificatePath}/apple.cer -k ${keychain} \
+  `security import ${certificatePath}/${buildConfig.wwdrCert}.cer -k ${keychain} \
 -T /usr/bin/codesign || true`
 );
 

--- a/packages/flagship/src/add-keys-ios.ts
+++ b/packages/flagship/src/add-keys-ios.ts
@@ -36,7 +36,7 @@ exec(
 // - import project .p12
 exec(
   `security import ${certificatePath}/${buildConfig.distributionCert}.p12 -k ${keychain} \
--P "Branders1234$" -T /usr/bin/codesign -A || true`
+-P '${buildConfig.distributionPwd}' -T /usr/bin/codesign -A || true`
 );
 // - import .mobileproviosn
 exec(


### PR DESCRIPTION
**This PR removes hardcoded values in the `add-keys-ios.ts` script:**
* Reliance on a separate repo that houses iOS certificates and profiles
* Passwords

**The intended use case:** 
A project utilizing Flagship will contain the appropriate iOS certificates and profiles in a top-level directory in the project itself (see message in https://github.com/brandingbrand/flagship/commit/f3736fe3403b81c5657c9c01a082ef1290957dc3).