### PR TITLE
fix(pirateship): remove old react-native-navigation version

### DIFF
--- a/packages/flagship/android/app/src/main/java/com/brandingbrand/reactnative/and/flagship/MainApplication.java
+++ b/packages/flagship/android/app/src/main/java/com/brandingbrand/reactnative/and/flagship/MainApplication.java
@@ -51,6 +51,7 @@ public class MainApplication extends NavigationApplication {
         return "index";
     }
 
+    @Override
     protected UIImplementationProvider getUIImplementationProvider() {
         return new UIImplementationProvider() {
             @Override

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -41,7 +41,7 @@
     "react-native-device-info": "^0.22.0",
     "react-native-htmlview": "^0.13.0",
     "react-native-i18n": "^2.0.15",
-    "react-native-navigation": "^1.1.469",
+    "react-native-navigation": "^1.1.483",
     "react-native-push-notification": "^3.1.1",
     "react-native-safe-area": "^0.4.1",
     "react-native-sensitive-info": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5690,16 +5690,6 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -7930,9 +7920,9 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-3.1.1.tgz#ef609811e3bc28970eac2884eece64d167830d17"
+memoize-one@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -8249,7 +8239,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -9868,12 +9858,6 @@ react-native-masked-text@^1.7.1:
     "@types/react-native" "*"
     moment "2.19.3"
     tinymask "^1.0.2"
-
-react-native-navigation@^1.1.469:
-  version "1.1.473"
-  resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.473.tgz#f0f8c6d9d2c88b120bab1d20b73860f3a0c3c92f"
-  dependencies:
-    lodash "4.x.x"
 
 react-native-navigation@^1.1.483:
   version "1.1.483"
@@ -11628,11 +11612,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-"true-case-path@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.2.tgz#7ec91130924766c7f573be3020c34f8fdfd00d62"
+"true-case-path@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-1.0.3.tgz#f813b5a8c86b40da59606722b144e3225799f47d"
   dependencies:
-    glob "^6.0.4"
+    glob "^7.1.2"
 
 ts-jest@^22.4.6:
   version "22.4.6"


### PR DESCRIPTION
https://github.com/brandingbrand/flagship/pull/186 is not fixed if `react-native-navigation@^1.1.469` is being used anywhere. PirateShip appears to be the only place where it was being used so this should fix it. I also added the `@Override` annotation back in to `flagship/MainApplication.java` and it shouldn't cause any problems now.