### PR TITLE
chore: update tslint to 5.11.0

### DIFF
--- a/packages/fscodestyle/package.json
+++ b/packages/fscodestyle/package.json
@@ -10,8 +10,8 @@
     "tsc:watch": "tsc -w --preserveWatchOutput"
   },
   "dependencies": {
-    "tslint": "^5.10.0",
-    "tslint-eslint-rules": "^5.3.1",
+    "tslint": "^5.11.0",
+    "tslint-eslint-rules": "^5.4.0",
     "tslint-react": "^3.6.0"
   },
   "publishConfig": {

--- a/packages/fscodestyle/tslint.json
+++ b/packages/fscodestyle/tslint.json
@@ -101,7 +101,6 @@
     "no-unexpected-multiline": true,
     "no-unnecessary-type-assertion": true,
     "no-unsafe-any": false,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-requires": false,
     "object-literal-key-quotes": [

--- a/packages/fsi18n/package.json
+++ b/packages/fsi18n/package.json
@@ -10,6 +10,7 @@
     "tsc:watch": "tsc -w --preserveWatchOutput"
   },
   "dependencies": {
+    "@brandingbrand/fscommerce": "^0.1.0",
     "decimal.js": "^10.0.1",
     "i18n-js": "^3.0.8",
     "lodash-es": "^4.17.10",
@@ -17,8 +18,5 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
-  },
-  "devDependencies": {
-    "@brandingbrand/fscommerce": "^0.1.0"
   }
 }

--- a/packages/fsmockdatasources/package.json
+++ b/packages/fsmockdatasources/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@brandingbrand/fscommerce": "^0.1.0",
+    "@brandingbrand/fsfoundation": "^0.1.0",
     "decimal.js": "^10.0.1",
     "faker": "^4.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11648,17 +11648,17 @@ tslib@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint-eslint-rules@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz#10dec4361df0b3e4385d91ff8e0226bda4ec2ad4"
+tslint-eslint-rules@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz#e488cc9181bf193fe5cd7bfca213a7695f1737b5"
   dependencies:
     doctrine "0.7.2"
     tslib "1.9.0"
-    tsutils "2.8.0"
+    tsutils "^3.0.0"
 
 tslint-react@^3.6.0:
   version "3.6.0"
@@ -11666,9 +11666,9 @@ tslint-react@^3.6.0:
   dependencies:
     tsutils "^2.13.1"
 
-tslint@^5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
+tslint@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -11681,17 +11681,23 @@ tslint@^5.10.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
-  dependencies:
-    tslib "^1.7.1"
-
-tsutils@^2.12.1, tsutils@^2.13.1:
+tsutils@^2.13.1:
   version "2.27.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.1.tgz#ab0276ac23664f36ce8fd4414daec4aebf4373ee"
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^2.27.2:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.0.0.tgz#0c5070a17a0503e056da038c48b5a1870a50a9ad"
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
- Update tslint to 5.11.0
- Update tslint-eslint-rules to 5.4.0

This adds support for TypeScript 3.0, which means the linter now picks up on type imports. Since these are directly exported in the `.d.ts` files they should be included as a dependency.

This change also removes the `no-unused-variable` rule which was deprecated in tslint 5.11.0.