### PR TITLE
feat: Update Android JavaScriptCore

### DIFF
--- a/packages/flagship/android/app/build.gradle
+++ b/packages/flagship/android/app/build.gradle
@@ -156,6 +156,16 @@ repositories {
 
 }
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.name == 'android-jsc') {
+                details.useTarget group: details.requested.group, name: 'android-jsc-intl', version: 'r224109'
+            }
+        }
+    }
+}
+
 dependencies {
     compile 'com.google.android.gms:play-services-base:15.+'
     compile 'com.google.android.gms:play-services-gcm:15.+'

--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -25,6 +25,10 @@ allprojects {
             url "$rootDir/../node_modules/react-native/android"
         }
         maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/../node_modules/jsc-android/dist"
+        }
+        maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
@@ -33,7 +37,7 @@ allprojects {
 
 ext {
     buildToolsVersion = "26.0.3"
-    minSdkVersion = 16
+    minSdkVersion = 21
     compileSdkVersion = 26
     targetSdkVersion = 26
     supportLibVersion = "26.1.0"

--- a/packages/flagship/package.json
+++ b/packages/flagship/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "fs-extra": "^7.0.0",
     "glob": "^7.1.2",
+    "jsc-android": "224109.x.x",
     "node-suspect": "^0.1.1",
     "react": "^16.3.2",
     "react-native": "^0.55.4",

--- a/packages/fstestproject/package.json
+++ b/packages/fstestproject/package.json
@@ -34,6 +34,7 @@
     "@brandingbrand/fssalesforce": "^0.1.0",
     "@brandingbrand/fsturnto": "^0.1.0",
     "@brandingbrand/fsups": "^0.1.0",
+    "jsc-android": "224109.x.x",
     "react": "^16.3.2",
     "react-native": "^0.55.4",
     "react-native-i18n": "^2.0.15"
@@ -46,7 +47,8 @@
       "react-native*",
       "**/fsapp",
       "**/fsapp/react-native*",
-      "**/fsapp/react-native*/**"
+      "**/fsapp/react-native*/**",
+      "jsc-android"
     ]
   }
 }

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -35,6 +35,7 @@
     "@brandingbrand/fsweb": "^0.1.0",
     "@brandingbrand/react-native-leanplum": "^0.1.1",
     "credit-card-type": "^7.0.0",
+    "jsc-android": "224109.x.x",
     "lodash-es": "^4.17.10",
     "react": "^16.3.2",
     "react-native": "^0.55.4",
@@ -75,6 +76,7 @@
       "**/fsapp",
       "**/fsapp/react-native*",
       "**/fsapp/react-native*/**",
+      "jsc-android",
       "**/fsshopify",
       "**/fsshopify/react-native*",
       "**/fsshopify/react-native*/**"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7167,6 +7167,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@224109.x.x:
+  version "224109.1.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
+
 jsdom@^11.5.1:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"


### PR DESCRIPTION
The FSI18n package makes use of some newer JS features that do not exist in the default JSC included with React Native.

@DanielClayton can you take a quick look over the Android changes?