### PR TITLE
fix: Fix react-native-navigation version

### DIFF
--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -20,7 +20,7 @@
     "react-native": "^0.55.4",
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^0.22.0",
-    "react-native-navigation": "^1.1.483",
+    "react-native-navigation": "1.1.483",
     "react-native-restart": "^0.0.7",
     "react-native-sensitive-info": "^5.1.0",
     "react-redux": "^5.0.7",

--- a/packages/fsshopify/package.json
+++ b/packages/fsshopify/package.json
@@ -19,7 +19,7 @@
     "decimal.js": "^10.0.1",
     "react": "^16.3.2",
     "react-native": "^0.55.4",
-    "react-native-navigation": "^1.1.483",
+    "react-native-navigation": "1.1.483",
     "react-native-payments": "^0.7.0"
   },
   "devDependencies": {

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -42,7 +42,7 @@
     "react-native-device-info": "^0.22.0",
     "react-native-htmlview": "^0.13.0",
     "react-native-i18n": "^2.0.15",
-    "react-native-navigation": "^1.1.483",
+    "react-native-navigation": "1.1.483",
     "react-native-push-notification": "^3.1.1",
     "react-native-safe-area": "^0.4.1",
     "react-native-sensitive-info": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9863,7 +9863,7 @@ react-native-masked-text@^1.7.1:
     moment "2.19.3"
     tinymask "^1.0.2"
 
-react-native-navigation@^1.1.483:
+react-native-navigation@1.1.483:
   version "1.1.483"
   resolved "https://registry.yarnpkg.com/react-native-navigation/-/react-native-navigation-1.1.483.tgz#e97c8a80bb7c784383e99c94a4f8df0622c4627d"
   dependencies:


### PR DESCRIPTION
* Fix react-native-navigation version

From https://github.com/wix/react-native-navigation, "Version 1.1.483 supports react-native >= 0.48 up to react-native 0.56 Version 1.1.484 supports react-native >= 0.57."