### PR TITLE
fix:  Define property googlePlayServicesVersion

### DIFF
--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -37,6 +37,7 @@ ext {
     compileSdkVersion = 26
     targetSdkVersion = 26
     supportLibVersion = "26.1.0"
+    googlePlayServicesVersion = "15.0.1" // Needed for react-native-camera & react-native-maps
 }
 
 // Force subprojects to use the same SDK and build tools


### PR DESCRIPTION
React-native-camera & react-native-maps are requiring googlePlayServicesVersion to be 15.0.1.

Fixes:
#213 
#212 