### PR TITLE
chore: fix yarn.lock for react-native-svg

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9901,9 +9901,9 @@ react-native-sensitive-info@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-native-sensitive-info/-/react-native-sensitive-info-5.1.0.tgz#1655c482f99c80023a23b2d9adab1ae260b1988a"
 
-react-native-svg@^6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-6.5.2.tgz#1105896b8873b0856821b18daa0c6898cea6c00c"
+react-native-svg@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-7.0.3.tgz#1ced56f4f6e96ad95374d66706390f51fa86bea7"
   dependencies:
     color "^2.0.1"
     lodash "^4.16.6"


### PR DESCRIPTION
Fix out of sync yarn.lock after updating react-native-svg