### PR TITLE
chore: update @types/credit-card-type to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@storybook/addon-viewport": "4.0.0-alpha.11",
     "@storybook/addons": "4.0.0-alpha.11",
     "@storybook/react": "4.0.0-alpha.11",
-    "@types/credit-card-type": "^5.0.1",
+    "@types/credit-card-type": "^7.0.0",
     "@types/i18n-js": "^3.0.0",
     "@types/jest": "^23.0.0",
     "@types/jwt-decode": "^2.2.1",

--- a/packages/pirateship/src/components/PSCreditCardForm.tsx
+++ b/packages/pirateship/src/components/PSCreditCardForm.tsx
@@ -11,7 +11,7 @@ const months = require('../../assets/months.json');
 const icons: { [key in CardBrand]?: ImageRequireSource } = {
   'american-express': require('../../assets/images/amex.png'),
   discover: require('../../assets/images/discover.png'),
-  'master-card': require('../../assets/images/mastercard.png'),
+  mastercard: require('../../assets/images/mastercard.png'),
   visa: require('../../assets/images/visa.png')
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,9 +998,9 @@
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
 
-"@types/credit-card-type@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/credit-card-type/-/credit-card-type-5.0.1.tgz#2108f36c31cb4bdd6c5ba5ad276f9f29a03c1b2f"
+"@types/credit-card-type@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/credit-card-type/-/credit-card-type-7.0.0.tgz#d484dae9c4c27fb7da73efb9880d936a680ab9c2"
 
 "@types/events@*":
   version "1.2.0"


### PR DESCRIPTION
Update types for credit-card-type to match the version of the package used.

This also fixes `master-card` to be `mastercard` as used in the package.

Closes #194