### PR TITLE
feat(fscomponents): Add right icon/button support to search bar

### DIFF
--- a/packages/fscomponents/src/components/SearchBar.tsx
+++ b/packages/fscomponents/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import {
   Animated,
   Image,
+  ImageSourcePropType,
   ImageStyle,
   ImageURISource,
   StyleProp,
@@ -54,6 +55,12 @@ export interface SearchBarProps {
 
   cancelButtonWidth?: number;
   cancelButtonAlwaysVisible?: boolean;
+
+  showRightBtnIcon?: boolean;
+  rightBtnIcon?: ImageSourcePropType;
+  onRightBtnPress?: () => void;
+  rightBtnStyle?: StyleProp<ViewStyle>;
+  rightBtnIconStyle?: StyleProp<ImageStyle>;
 }
 
 export interface SearchBarState {
@@ -144,7 +151,34 @@ export class SearchBar extends PureComponent<SearchBarProps, SearchBarState> {
           underlineColorAndroid='transparent'
           {...inputProps}
         />
+        {this.renderRightBtnIcon()}
       </View>
+    );
+  }
+
+  renderRightBtnIcon = () => {
+    const {
+      showRightBtnIcon,
+      rightBtnIcon,
+      onRightBtnPress,
+      rightBtnIconStyle,
+      rightBtnStyle
+    } = this.props;
+
+    if (!showRightBtnIcon || !rightBtnIcon) {
+      return null;
+    }
+
+    const icon = <Image source={rightBtnIcon} style={rightBtnIconStyle} resizeMode='contain' />;
+
+    if (!onRightBtnPress) {
+      return icon;
+    }
+
+    return (
+      <TouchableOpacity style={rightBtnStyle} onPress={onRightBtnPress}>
+        {icon}
+      </TouchableOpacity>
     );
   }
 


### PR DESCRIPTION
Adds an optional right icon button to the search bar. Can be used to implement addtional search
functionality, such as a bar code scanner.

Example:
![screen shot 2018-09-26 at 6 15 52 am](https://user-images.githubusercontent.com/3847536/46073700-a933f100-c153-11e8-910d-aa0e21454193.png)
