### PR TITLE
fix(pirateship): disable strict version checking for google services

### DIFF
--- a/packages/flagship/src/lib/modules/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/react-native-firebase.ts
@@ -44,7 +44,9 @@ export function android(configuration: Config): void {
     `$1\n    ${firebaseDep}`
   );
 
-  gradleAppBuild += '\napply plugin: \'com.google.gms.google-services\'\n';
+  gradleAppBuild += '\napply plugin: \'com.google.gms.google-services\'';
+  // tslint:disable-next-line:ter-max-len
+  gradleAppBuild += '\ncom.google.gms.googleservices.GoogleServicesPlugin.config.disableVersionCheck = true\n';
   gradleAppBuild = gradleAppBuild.replace(/compile /g, 'implementation ');
   gradleAppBuild = gradleAppBuild.replace(/compile\(/g, 'implementation(');
   fs.writeFileSync(path.android.gradlePath(), gradleAppBuild);


### PR DESCRIPTION
react-native-firebase defaults to version 16 of Firebase Android dependencies, while react-native-push-notifications defaults to version 17 because there's no version 16 of one of its dependencies, firebase messaging. Android build will fail due to this version mismatch. This disables strict version checking by the Google libraries.