### PR TITLE
feat(fsshopify): add setshippingaddress and align types

### DIFF
--- a/packages/fsshopify/src/ShopifyDataSource.ts
+++ b/packages/fsshopify/src/ShopifyDataSource.ts
@@ -92,6 +92,13 @@ export default class ShopifyDataSource extends DataSourceBase
     return Promise.reject(kErrorMessageNotImplemented);
   }
 
+  async setShippingAddress(
+    address: FSCommerceTypes.Address,
+    cartId?: string
+  ): Promise<Types.ShopifyCheckoutData> {
+    return Promise.reject(kErrorMessageNotImplemented);
+  }
+
   async setShipmentAddress(
     options: Types.ShippingAddressOptions
   ): Promise<Types.ShopifyCheckoutData> {

--- a/packages/fsshopify/src/customTypes.ts
+++ b/packages/fsshopify/src/customTypes.ts
@@ -69,16 +69,16 @@ export interface ShopifyProductIndex extends ShopifyPageInfo, CommerceTypes.Prod
 }
 
 export interface ShopifyMailingAddressInput {
-  address1: string;
-  address2: string;
-  city: string;
-  company: string;
-  country: string;
-  firstName: string;
-  lastName: string;
-  phone: string;
-  province: string;
-  zip: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  company?: string;
+  country?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  province?: string;
+  zip?: string;
 }
 
 export interface GooglePayShippingOptionsModalProps {

--- a/packages/fsshopify/src/denormalizers/address.ts
+++ b/packages/fsshopify/src/denormalizers/address.ts
@@ -1,0 +1,17 @@
+import { CommerceTypes } from '@brandingbrand/fscommerce';
+import { ShopifyMailingAddressInput } from '../customTypes';
+
+export function mailingAddressInput(address: CommerceTypes.Address): ShopifyMailingAddressInput {
+  return {
+    address1: address.address1,
+    address2: address.address2,
+    city: address.city,
+    company: address.companyName,
+    country: address.countryCode,
+    firstName: address.firstName,
+    lastName: address.lastName,
+    phone: address.phone,
+    province: address.stateCode,
+    zip: address.postalCode
+  };
+}

--- a/packages/fsshopify/src/denormalizers/index.ts
+++ b/packages/fsshopify/src/denormalizers/index.ts
@@ -1,0 +1,1 @@
+export * from './address';

--- a/packages/fsshopify/src/mixins/ShopifyCartDataSource.ts
+++ b/packages/fsshopify/src/mixins/ShopifyCartDataSource.ts
@@ -20,6 +20,7 @@ import {
 import { Platform } from 'react-native';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import { Navigator } from 'react-native-navigation';
+import { mailingAddressInput as mailingAddressInputDenormalizer } from '../denormalizers';
 
 const kErrorMessageNotImplemented = 'not implemented';
 
@@ -124,13 +125,22 @@ export class ShopifyCartDataSource extends DataSourceBase
     return Normalizers.cart(response, this.config.storeCurrencyCode);
   }
 
+  async setShippingAddress(
+    address: FSCommerceTypes.Address,
+    cartId?: string
+  ): Promise<ShopifyTypes.ShopifyCheckoutData> {
+    const shopifyAddress = mailingAddressInputDenormalizer(address);
+    const checkoutId = cartId || await this.getOrStartCart();
+    const response = await this.api.checkoutShippingAddressUpdate(checkoutId, shopifyAddress);
+
+    return Normalizers.cart(response, this.config.storeCurrencyCode);
+  }
+
   async setShipmentAddress(
     options: ShopifyTypes.ShippingAddressOptions
   ): Promise<ShopifyTypes.ShopifyCheckoutData> {
-    const checkoutId = options.cartId || await this.getOrStartCart();
-    const response = await this.api.checkoutShippingAddressUpdate(checkoutId, options.address);
-
-    return Normalizers.cart(response, this.config.storeCurrencyCode);
+    // Shopify doesn't have a concept of shipments so we can't use the ShippingAddressOptions type
+    throw new Error('setShipmentAddress not implemented; use setShippingAddress instead');
   }
 
   async setShipmentMethod(

--- a/packages/fsshopify/src/util/ShopifyAPI.ts
+++ b/packages/fsshopify/src/util/ShopifyAPI.ts
@@ -267,22 +267,8 @@ export default class ShopifyAPI {
 
   async checkoutShippingAddressUpdate(
     checkoutId: string,
-    address: ResponseTypes.ShopifyAddress
+    shippingAddress: ShopifyMailingAddressInput
   ): Promise<ResponseTypes.ShopifyCheckout> {
-    // convert to ShopifyMailingAddressInput type
-    const shippingAddress: ShopifyMailingAddressInput = {
-      address1: address.address1,
-      address2: address.address2 || '',
-      city: address.city,
-      company: address.company,
-      country: address.countryCode,
-      firstName: address.firstName,
-      lastName: address.lastName,
-      phone: address.phone || '',
-      province: address.province,
-      zip: address.postalCode
-    };
-
     const response = await this.postQuery(`
       mutation checkoutShippingAddressUpdate(
         $shippingAddress: MailingAddressInput!,


### PR DESCRIPTION
BREAKING CHANGE: This implements a setShippingAddress method in ShopifyCartDataSource and marks setShipmentAddress as not implemented. setShipmentAddress expects a shipmentId, which is not implemented by Shopify. This also corrects the ShopifyMailingAddressInput type which did not correctly define optional types.