### PR TITLE
fix: Require project to provide app center token

### DIFF
--- a/packages/flagship/src/lib/modules/react-native-code-push.ts
+++ b/packages/flagship/src/lib/modules/react-native-code-push.ts
@@ -7,8 +7,6 @@ import {
   logInfo
 } from '../../helpers';
 
-const kBrandingBrandAppCenterToken = '0fd777da29f2545597bf45c20149b087eaba5f3b';
-
 /**
  * Patches Android for the module.
  *
@@ -16,6 +14,14 @@ const kBrandingBrandAppCenterToken = '0fd777da29f2545597bf45c20149b087eaba5f3b';
  */
 export function android(configuration: Config): void {
   logInfo('patching Android for react-native-codepush');
+
+  if (!(configuration.codepush
+        && configuration.codepush.appCenterToken)
+  ) {
+    logError('codepush.appCenterToken must be specified in project config');
+
+    return process.exit(1);
+  }
 
   const assetsPath = path.android.assetsPath();
   const appCenterConfigPath = path.resolve(assetsPath, 'appcenter-config.json');
@@ -69,7 +75,11 @@ export function android(configuration: Config): void {
   // Include the readonly Branding Brand app center token ONLY in development
   // builds
   if (!configuration.disableDevFeature) {
-    nativeConstants.addAndroid(configuration, 'AppCenterToken', kBrandingBrandAppCenterToken);
+    nativeConstants.addAndroid(
+      configuration,
+      'AppCenterToken',
+      configuration.codepush.appCenterToken
+    );
   }
 
   fs.update(
@@ -89,6 +99,14 @@ export function android(configuration: Config): void {
  */
 export function ios(configuration: Config): void {
   logInfo('patching iOS for react-native-codepush');
+
+  if (!(configuration.codepush
+        && configuration.codepush.appCenterToken)
+  ) {
+    logError('codepush.appCenterToken must be specified in project config');
+
+    return process.exit(1);
+  }
 
   const appCenterConfigPath = path.resolve(
     path.ios.nativeProjectPath(configuration),
@@ -115,6 +133,6 @@ export function ios(configuration: Config): void {
   // Include the readonly Branding Brand app center token ONLY in development
   // builds
   if (!configuration.disableDevFeature) {
-    nativeConstants.addIOS(configuration, 'AppCenterToken', kBrandingBrandAppCenterToken);
+    nativeConstants.addIOS(configuration, 'AppCenterToken', configuration.codepush.appCenterToken);
   }
 }

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -17,6 +17,7 @@ export interface Config {
   googleMapApiKey: string;
 
   codepush?: {
+    appCenterToken: string;
     android: CodepushConfig;
     ios: CodepushConfig;
   };


### PR DESCRIPTION
Previously flagship was using private branding brand app center token for authentication.
This solution requires you to self manage app center token, which allows teams outside Branding Brand organization to use code push.