### PR TITLE
fix(flagship): runs jscenter() last in build.gradle/repos

### DIFF
--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -19,7 +19,6 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
@@ -32,6 +31,7 @@ allprojects {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Fixed per this issue when android build failed:

https://forum.ionicframework.com/t/could-not-find-play-services-basement-aar-com-google-android-gms-play-services-basement/145529

moves jcenter() to end of:
```
 allprojects {
   repositories {
  
  }
}
```

in android/build.bgradle