### PR TITLE
chore: set lerna force publish on all packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,8 @@
       "conventionalCommits": true,
       "message": "chore(release): publish %s",
       "allowBranch": "master",
-      "npmClient": "npm"
+      "npmClient": "npm",
+      "forcePublish": "*"
     }
   }
 }


### PR DESCRIPTION
Per the documentation this will publish all packages regardless of whether there were changes in each. This is intended behavior as we prefer to keep all package version numbers in sync.