### PR TITLE
fix(flagship): run pod install after react-native link

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -72,16 +72,10 @@ export function handler(argv: HandlerArgs): void {
   }
 
   // Run react-native link
-  link
-    .link(configuration)
+  link.link(configuration)
     .then(() => {
-      if (doAndroid) {
-        modules.android(projectPackageJSON, configuration);
-      }
-
       if (doIOS) {
         cocoapods.install();
-        modules.ios(projectPackageJSON, configuration);
       }
     })
     .catch(err => {
@@ -152,6 +146,8 @@ function initAndroid(
     android.addDevMenuFlag(configuration);
   }
 
+  modules.android(packageJSON, configuration);
+
   helpers.logInfo('finished Android initialization');
 }
 
@@ -204,6 +200,8 @@ function initIOS(
   if (!configuration.disableDevFeature) {
     ios.addDevMenuFlag(configuration);
   }
+
+  modules.ios(packageJSON, configuration);
 
   helpers.logInfo('finished iOS initialization');
 }

--- a/packages/flagship/src/lib/modules/react-native-adobe-analytics.ts
+++ b/packages/flagship/src/lib/modules/react-native-adobe-analytics.ts
@@ -47,7 +47,6 @@ export async function ios(config: Config): Promise<void> {
 
   if (podfile.indexOf(adobeSdk) === -1) {
     pods.add(path.ios.podfilePath(), [adobeSdk]);
-    pods.install();
     logInfo('updated Podfile with Adobe Mobile SDK');
   }
 

--- a/packages/flagship/src/lib/modules/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/react-native-firebase.ts
@@ -143,7 +143,6 @@ export function ios(configuration: Config): void {
 
   if (podfile.indexOf(firebasePod) === -1) {
     pods.add(path.ios.podfilePath(), [firebasePod]);
-    pods.install();
     logInfo('updated Podfile with Firebase pod');
   }
 

--- a/packages/flagship/src/lib/modules/react-native-leanplum.ts
+++ b/packages/flagship/src/lib/modules/react-native-leanplum.ts
@@ -1,5 +1,6 @@
 import * as path from '../path';
 import * as fs from '../fs';
+import * as pods from '../cocoapods';
 import { Config } from '../../types';
 import { logInfo } from '../../helpers';
 
@@ -10,7 +11,7 @@ const kRepository = `maven { url 'https://repo.leanplum.com/' }`;
  *
  * @param {object} configuration The project configuration.
  */
-exports.android = function installAndroid(configuration: Config): void {
+export function android(configuration: Config): void {
   logInfo('patching Android for react-native-leanplum');
 
   // Add the repository to the project repositories.
@@ -22,3 +23,12 @@ exports.android = function installAndroid(configuration: Config): void {
     'new RNLeanplumPackage(application)'
   );
 };
+
+/**
+ * Patches iOS for the module.
+ *
+ * @param {object} configuration The project configuration.
+ */
+export function ios(configuration: Config): void {
+  pods.add(path.ios.podfilePath(), [`pod "Leanplum-iOS-SDK", '2.1.0'`]);
+}


### PR DESCRIPTION
- Removed duplicate places where pod install was running
- Updated module patch scripts so they run before `react-native link`
- Run `pod install` after `react-native link`