### PR TITLE
fix(flagship): restore android init to prior version

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -74,6 +74,10 @@ export function handler(argv: HandlerArgs): void {
   // Run react-native link
   link.link(configuration)
     .then(() => {
+      if (doAndroid) {
+        modules.android(projectPackageJSON, configuration);
+      }
+
       if (doIOS) {
         cocoapods.install();
       }
@@ -145,8 +149,6 @@ function initAndroid(
   if (!configuration.disableDevFeature) {
     android.addDevMenuFlag(configuration);
   }
-
-  modules.android(packageJSON, configuration);
 
   helpers.logInfo('finished Android initialization');
 }


### PR DESCRIPTION
Running android failed after #280; this restores the order of operation for Android modules back to its previous behavior.