### PR TITLE
fix(fscomponents): Allow partial reviewIndicatorProps to be passed

### DIFF
--- a/packages/fscomponents/src/components/ReviewItem.tsx
+++ b/packages/fscomponents/src/components/ReviewItem.tsx
@@ -41,7 +41,7 @@ export interface ReviewItemProps extends ReviewTypes.Review {
   recommendedRowStyle?: StyleProp<ViewStyle>;
 
   // children
-  reviewIndicatorProps?: ReviewIndicatorProps;
+  reviewIndicatorProps?: Partial<ReviewIndicatorProps>;
   moreTextProps?: MoreTextProps;
 
   // buttons

--- a/packages/fscomponents/src/components/ReviewsList.tsx
+++ b/packages/fscomponents/src/components/ReviewsList.tsx
@@ -10,7 +10,7 @@ export interface ReviewsListProps {
   reviewStyle?: import ('@brandingbrand/fsfoundation').Dictionary<StyleProp<TextStyle | ViewStyle>>;
 
   // chidlren
-  reviewIndicatorProps?: ReviewIndicatorProps;
+  reviewIndicatorProps?: Partial<ReviewIndicatorProps>;
   moreTextProps?: MoreTextProps;
   recommendedImage?: ImageURISource;
   verifiedImage?: ImageURISource;

--- a/packages/fscomponents/src/components/ReviewsSummary.tsx
+++ b/packages/fscomponents/src/components/ReviewsSummary.tsx
@@ -20,7 +20,7 @@ export interface ReviewsSummaryProps {
   averageStyle?: StyleProp<TextStyle>;
   recommendStyle?: StyleProp<TextStyle>;
   rowStyle?: StyleProp<ViewStyle>;
-  reviewIndicatorProps?: ReviewIndicatorProps;
+  reviewIndicatorProps?: Partial<ReviewIndicatorProps>;
   hideReviewIndicatorSubtitle?: boolean;
   reviewIndicatorSubtitle?: string;
   reviewIndicatorRowStyle?: StyleProp<ViewStyle>;
@@ -36,7 +36,7 @@ export class ReviewsSummary extends Component<ReviewsSummaryProps> {
       style,
       base= 5,
       recommend,
-      reviewIndicatorProps= {},
+      reviewIndicatorProps = {},
       countStyle,
       averageStyle,
       recommendStyle,


### PR DESCRIPTION
ReviewItem, ReviewList, and ReviewSummary all set the required ReviewIndicator props, so their
reviewIndicatorProps prop should allow a partial set of properties.