### PR TITLE
fix(fscheckout): Recalculate slider position when itemWidth changes

### DIFF
--- a/packages/fscheckout/src/components/StepTracker.tsx
+++ b/packages/fscheckout/src/components/StepTracker.tsx
@@ -87,11 +87,14 @@ export default class StepTracker extends Component<StepTrackerProps, StepTracker
     }
   }
 
-  componentDidUpdate(prevProps: StepTrackerProps): void {
+  componentDidUpdate(prevProps: StepTrackerProps, prevState: StepTrackerState): void {
     const prevActiveStep = prevProps.steps.findIndex(step => step.status === 'active');
     const currActiveStep = this.props.steps.findIndex(step => step.status === 'active');
 
-    if (prevActiveStep !== currActiveStep) {
+    const prevItemWidth = prevState.itemWidth;
+    const currItemWidth = this.state.itemWidth;
+
+    if (prevActiveStep !== currActiveStep || prevItemWidth !== currItemWidth) {
       if (this.props.animated) {
         Animated.timing(this.sliderPosition, {
           useNativeDriver: true,


### PR DESCRIPTION
Solves a condition where the step indicator is not updated when the item width changes (ie. step
count changes) or if the active step is changed before the component calculates the itemWidth.