### PR TITLE
feat(fsengagement): remove prelink react-native-fcm

### DIFF
--- a/packages/fsengagement/package.json
+++ b/packages/fsengagement/package.json
@@ -18,10 +18,5 @@
     "react-native-navigation": "1.1.483",
     "react-native-video": "^3.2.1",
     "uuid-js": "0.7.5"
-  },
-  "rnpm": {
-    "commands": {
-      "prelink": "react-native link react-native-fcm"
-    }
   }
 }


### PR DESCRIPTION
@bweissbart We found that if you have prelink in one of the packages, it will hang the init of the app.  Removing it allowed the init process to finish normally.