### PR TITLE
fix(pirateship): add missing rn payments dependency

### DIFF
--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -44,6 +44,7 @@
     "react-native-htmlview": "^0.13.0",
     "react-native-i18n": "^2.0.15",
     "react-native-navigation": "1.1.483",
+    "react-native-payments": "0.7.0",
     "react-native-push-notification": "^3.1.1",
     "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "^5.1.0",
@@ -64,7 +65,8 @@
       "react-native-sensitive-info",
       "react-native-safe-area",
       "react-native-push-notification",
-      "react-native-svg"
+      "react-native-svg",
+      "react-native-payments"
     ],
     "webTitle": "PirateShip"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10671,7 +10671,7 @@ react-native-open-settings@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-native-open-settings/-/react-native-open-settings-1.0.1.tgz#1c0ae3d25fd3fd6de94b6d538333d47245cc5a0c"
 
-react-native-payments@^0.7.0:
+react-native-payments@0.7.0, react-native-payments@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-native-payments/-/react-native-payments-0.7.0.tgz#fbb933cbc23ef771113efca0c2c4e415fe6a2071"
   dependencies:


### PR DESCRIPTION
fsshopify added react-native-payments as a dependency for end projects. This adds a react-native-payments dependency to pirateship; it has to be pinned to the same version as in fsshopify in order for RN native modules to resolve it properly.