### PR TITLE
fix(fslocator) update react-native-maps to use BB repo

### DIFF
--- a/packages/fslocator/package.json
+++ b/packages/fslocator/package.json
@@ -20,7 +20,7 @@
     "react": "^16.3.2",
     "react-native": "^0.55.4",
     "react-native-geocoder": "^0.5.0",
-    "react-native-maps": "^0.21.0",
+    "react-native-maps": "https://github.com/brandingbrand/react-native-maps.git#0.21.0-gradle2",
     "react-native-open-settings": "^1.0.1",
     "react-native-permissions": "^1.1.1"
   },


### PR DESCRIPTION
**Ticket:** https://jira.brandingbrand.com/browse/

## Description
react-native-maps version in use was throwing an error 'Invariant Violation: Native component for "AIRMap" does not exist'

updating to use https://github.com/brandingbrand/react-native-maps#0.21.0-gradle2 fixes this issue

## Test
build a project that includes fslocator
app should not fail during yarn run ios

