### PR TITLE
fix(fscomponents): make font-weight optional in CategoryBox/CategoryLine

### DIFF
--- a/packages/fscomponents/src/components/CategoryBox.tsx
+++ b/packages/fscomponents/src/components/CategoryBox.tsx
@@ -19,6 +19,7 @@ export interface CategoryBoxProps extends CommerceTypes.Category {
   style?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
   underlayColor?: string;
+  noFontWeight?: boolean;
 }
 
 export class CategoryBox extends PureComponent<CategoryBoxProps> {
@@ -34,7 +35,8 @@ export class CategoryBox extends PureComponent<CategoryBoxProps> {
       style,
       title,
       titleStyle,
-      underlayColor
+      underlayColor,
+      noFontWeight
     } = this.props;
 
     return (
@@ -45,7 +47,7 @@ export class CategoryBox extends PureComponent<CategoryBoxProps> {
       >
         <View style={S.boxInner}>
           {showImage && image && <Image source={image} style={imageStyle} />}
-          <Text style={[S.boxText, titleStyle]}>
+          <Text style={[!noFontWeight && S.fontWeight, S.boxText, titleStyle]}>
             {title}
           </Text>
         </View>

--- a/packages/fscomponents/src/components/CategoryLine.tsx
+++ b/packages/fscomponents/src/components/CategoryLine.tsx
@@ -26,6 +26,7 @@ export interface CategoryLineProps extends CommerceTypes.Category {
   style?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
   underlayColor?: string;
+  noFontWeight?: boolean;
 }
 
 export class CategoryLine extends PureComponent<CategoryLineProps> {
@@ -47,7 +48,8 @@ export class CategoryLine extends PureComponent<CategoryLineProps> {
       style,
       title,
       titleStyle,
-      underlayColor
+      underlayColor,
+      noFontWeight
     } = this.props;
 
     return (
@@ -59,7 +61,7 @@ export class CategoryLine extends PureComponent<CategoryLineProps> {
       >
         <View style={S.rowInner}>
           {showImage && image && <Image source={image} style={imageStyle} />}
-          <Text style={[S.buttonText, titleStyle]}>
+          <Text style={[!noFontWeight && S.fontWeight, S.buttonText, titleStyle]}>
             {title}
           </Text>
           {showAccessory && accessorySrc &&

--- a/packages/fscomponents/src/styles/CategoryBox.ts
+++ b/packages/fscomponents/src/styles/CategoryBox.ts
@@ -16,7 +16,9 @@ export const style = StyleSheet.create({
     alignItems: 'center'
   },
   boxText: {
-    fontSize: 15,
+    fontSize: 15
+  },
+  fontWeight: {
     fontWeight: '500'
   }
 });

--- a/packages/fscomponents/src/styles/CategoryLine.ts
+++ b/packages/fscomponents/src/styles/CategoryLine.ts
@@ -23,7 +23,9 @@ export const style = StyleSheet.create({
   buttonText: {
     flex: 1,
     fontSize: 15,
-    fontWeight: '500',
     paddingLeft: 10
+  },
+  fontWeight: {
+    fontWeight: '500'
   }
 });


### PR DESCRIPTION
Assigning `fontWeight` to text that uses a custom font removes the custom font on Android. This makes the `fontWeight` style optional in the CategoryBox and CategoryLine components.