### PR TITLE
fix(fsengagement): fix crashing when trying to view event item

### DIFF
--- a/packages/fsengagement/src/inboxblocks/EventCard.tsx
+++ b/packages/fsengagement/src/inboxblocks/EventCard.tsx
@@ -75,7 +75,7 @@ export default class EventCard extends Component<ComponentProps> {
       messageId: this.props.id
     });
     this.props.navigator.push({
-      screen: 'LayoutBuilder',
+      screen: 'EngagementComp',
       navigatorStyle: {
         navBarHidden: true
       },

--- a/packages/fsengagement/src/inboxblocks/FeaturedTopCard.tsx
+++ b/packages/fsengagement/src/inboxblocks/FeaturedTopCard.tsx
@@ -47,7 +47,7 @@ export default class Card extends Component<ComponentProps> {
       messageId: this.props.id
     });
     this.props.navigator.push({
-      screen: 'LayoutBuilder',
+      screen: 'EngagementComp',
       navigatorStyle: {
         navBarHidden: true
       },


### PR DESCRIPTION
`screen: LayoutBuilder` was mistakenly left in, causing a crash when clicking on an event type.  Needs to be changed to `EngagementComp`.