### PR TITLE
chore: temporarily remove web demo from build:docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ship:compile-android": "lerna run --stream --scope @brandingbrand/pirateship compile-android",
     "ship:compile-web": "lerna run --stream --scope @brandingbrand/pirateship compile-web",
     "build:docs": "typedoc --tsconfig ./tsconfig/tsconfig.docs.json",
-    "docs": "run-s build:docs build:storybook ship:build-web-demo"
+    "docs": "run-s build:docs build:storybook"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.1.2",


### PR DESCRIPTION
The build-web-demo step of Travis is consistently causing a JS heap error. This removes this step so that we aren't blocked on deploying urgent fixes.

Logged this as an issue here: https://github.com/brandingbrand/flagship/issues/331 