### PR TITLE
fix(fsengagement): add flag to enable forced resync

### DIFF
--- a/packages/fsengagement/src/EngagementService.ts
+++ b/packages/fsengagement/src/EngagementService.ts
@@ -133,8 +133,8 @@ export class EngagementService {
   }
 
   // @TODO: does the profile need to be resynced anytime during a session?
-  async getProfile(accountId?: string): Promise<string> {
-    if (this.profileId && this.profileData) {
+  async getProfile(accountId?: string, forceProfileSync?: boolean): Promise<string> {
+    if (this.profileId && this.profileData && !forceProfileSync) {
       return Promise.resolve(this.profileId);
     }
 


### PR DESCRIPTION
@bweissbart 

If we first getProfile as an anonymous user, then later login and getProfile again it will simply return your stored profile info without making another request.  This allows us to pass a flag to force the syncing of  the profile (forces request to engagement api to sync username/email with profileId).