### PR TITLE
chore(fsweb): upgrade babel-plugin-react-native-web to 0.10.0

### DIFF
--- a/packages/fsweb/package.json
+++ b/packages/fsweb/package.json
@@ -12,7 +12,7 @@
     "autoprefixer": "^8.6.2",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
-    "babel-plugin-react-native-web": "^0.9.0",
+    "babel-plugin-react-native-web": "^0.10.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react-native": "^4.0.0",


### PR DESCRIPTION
"babel-plugin-react-native-web": "^0.10.0", tests well with yarn dev:storybook

duplicate of closed ticket: https://github.com/brandingbrand/flagship/pull/210