### PR TITLE
chore(flagship): ignore react, rn, rnn in greenkeeper prs

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,12 @@
     "commitMessages": {
       "dependencyUpdate": "fix: update ${dependency} to version ${version}",
       "devDependencyUpdate": "chore: update ${dependency} to version ${version}"
-    }
+    },
+    "ignore": [
+      "react",
+      "react-native",
+      "react-native-navigation"
+    ]
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
'react'
'react-native'
'react-native-navigation'

...are all being updated by engineers currently so we can skip auto PRs from greenkeeper about them for now.
https://greenkeeper.io/docs.html#ignoring-dependencies