### PR TITLE
fix(fscomponents): fix review summary percent recommend

### DIFF
--- a/packages/fscomponents/src/components/ReviewsSummary.tsx
+++ b/packages/fscomponents/src/components/ReviewsSummary.tsx
@@ -72,7 +72,7 @@ export class ReviewsSummary extends Component<ReviewsSummaryProps> {
         <View style={[S.row, rowStyle]}>
           <Text style={[S.recommendStyle, recommendStyle]}>
             {FSI18n.string(translationKeys.flagship.reviews.recommendCount, {
-              recommendPercent: FSI18n.percent(recommend)
+              recommendPercent: recommend
             })}
           </Text>
         </View>


### PR DESCRIPTION
for an input of ’80’,  review summary was showing ‘8000%%’, now it will show ’80%’