### PR TITLE
fix(fscomponents): default show arrow on cms banner carousel story

### DIFF
--- a/packages/fscomponents/src/components/__stories__/CMSBannerCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/CMSBannerCarousel.story.tsx
@@ -14,7 +14,8 @@ const provider = new CoreContentManagementSystemProvider({
 });
 
 const defaultCarouselProps = {
-  height: 200
+  height: 200,
+  showArrow: true
 };
 
 storiesOf('CMSBannerCarousel', module)


### PR DESCRIPTION
we need the arrow to be able to toggle through the banners on web