### PR TITLE
fix(fscomponents): make clear what is image and what is overlay

### DIFF
--- a/packages/fscomponents/src/components/__stories__/ImageWithOverlay.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ImageWithOverlay.story.tsx
@@ -11,8 +11,6 @@ import {
 } from '@storybook/addon-knobs/react';
 import { ImageWithOverlay } from '../ImageWithOverlay';
 
-const homeBanner = require('./assets/images/center.png');
-
 const defaultImageStyle = {
   width: 375,
   height: 200
@@ -30,13 +28,13 @@ const positions = [
   'topRight'
 ];
 
-const overlay = <Text>Overlay</Text>;
+const overlay = <Text style={{fontSize: 30, fontWeight: 'bold'}}>Text Overlay</Text>;
 
 storiesOf('ImageWithOverlay', module)
   .add('basic usage', () => (
     <ImageWithOverlay
       imageProps={{
-        source: homeBanner,
+        source: { uri: 'https://placehold.it/375x150' },
         style: defaultImageStyle
       }}
       overlay={overlay}


### PR DESCRIPTION
In current form, the image with overlay storybook is not clear. It seems like the "Banner Text" may be overlay, but that is incorrect ("banner text" is actually part of example image file), the text overlay is actually a barely visible "overlay" text blob currently invisible in bottom left corner:
![screen shot 2019-02-11 at 4 55 57 pm](https://user-images.githubusercontent.com/23608557/52596602-b0b41800-2e1e-11e9-8f08-84389692d01a.png)
This image and text combination makes it clear what is image, what is overlay
![screen shot 2019-02-11 at 4 56 30 pm](https://user-images.githubusercontent.com/23608557/52596626-c1648e00-2e1e-11e9-9487-00ff1e3a1c4a.png)
