### PR TITLE
fix(pirateship): ignore yoga in template podspec

### DIFF
--- a/packages/flagship/ios/Podfile
+++ b/packages/flagship/ios/Podfile
@@ -39,7 +39,9 @@ target 'FLAGSHIP' do
   # dependency from pods.
   post_install do |installer|
     installer.pods_project.targets.each do |target|
-      if target.name == "React"
+      targets_to_ignore = %w(React yoga)
+
+      if targets_to_ignore.include? target.name
         target.remove_from_project
       end
     end


### PR DESCRIPTION
The new build system in Xcode 10 is throwing a duplicate "provides" error when archiving a Flagship app. This adds logic to the template Podspec that removes yoga from the project.

We should have someone with iOS expertise review our entire default Podspec to see if we're including unnecessary modules (this seems to be the case from my untrained eyes) but in the meantime this fixes the archive problem.

Solution from this discussion: https://github.com/facebook/react-native/issues/20492#issuecomment-422958184