### PR TITLE
fix(flagship): pin android.support libs to 27

### DIFF
--- a/packages/flagship/android/app/build.gradle
+++ b/packages/flagship/android/app/build.gradle
@@ -171,8 +171,8 @@ dependencies {
     implementation 'com.google.android.gms:play-services-gcm:15.+'
     implementation 'com.google.android.gms:play-services-maps:15.+'
     implementation 'com.google.android.gms:play-services-wallet:15.+'
-    implementation "com.android.support:appcompat-v7:27.1.0"
-    implementation 'com.android.support:support-v4:26.1.0'
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.android.support:support-v4:${rootProject.ext.supportLibVersion}"
 
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 


### PR DESCRIPTION
Updates the android.support dependencies in build.gradle to use supportLibVersion constant which is currently set to 27.1.1.

Note: the upgrade to support lib 27 was dictated by RN: https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#tooling-updates