### PR TITLE
refactor(fscategory): grid and list to sfc

### DIFF
--- a/packages/fscategory/src/components/CategoryGrid.tsx
+++ b/packages/fscategory/src/components/CategoryGrid.tsx
@@ -1,14 +1,14 @@
 import { CategoryBox, Grid } from '@brandingbrand/fscomponents';
-import React, { Component } from 'react';
+import React, { SFC } from 'react';
 import { ListRenderItemInfo } from 'react-native';
 import { UnwrappedCategoryProps } from './Category';
 import { CommerceTypes, WithCommerceDataProps } from '@brandingbrand/fscommerce';
 
-export default class CategoryGrid extends Component<
-  UnwrappedCategoryProps & WithCommerceDataProps<CommerceTypes.Category>
-> {
-  renderItem = ({ item }: ListRenderItemInfo<CommerceTypes.Category>) => {
-    const { categoryItemProps, onNavigate, renderCategoryItem } = this.props;
+const CategoryGrid: SFC<UnwrappedCategoryProps & WithCommerceDataProps<CommerceTypes.Category>
+> = props => {
+
+  const renderItem = ({ item }: ListRenderItemInfo<CommerceTypes.Category>) => {
+    const { categoryItemProps, onNavigate, renderCategoryItem } = props;
 
     if (renderCategoryItem) {
       return renderCategoryItem(item);
@@ -21,26 +21,28 @@ export default class CategoryGrid extends Component<
         {...categoryItemProps}
       />
     );
+  };
+
+  const {
+    commerceData,
+    columns,
+    categoryGridProps
+  } = props;
+
+  if (commerceData && commerceData.categories) {
+    return (
+      <Grid
+        data={commerceData.categories}
+        columns={columns}
+        renderItem={renderItem}
+        {...categoryGridProps}
+      />
+    );
   }
 
-  render(): React.ReactNode {
-    const {
-      commerceData,
-      columns,
-      categoryGridProps
-    } = this.props;
+  return null;
 
-    if (commerceData && commerceData.categories) {
-      return (
-        <Grid
-          data={commerceData.categories}
-          columns={columns}
-          renderItem={this.renderItem}
-          {...categoryGridProps}
-        />
-      );
-    }
+};
 
-    return null;
-  }
-}
+export default CategoryGrid;
+

--- a/packages/fscategory/src/components/CategoryList.tsx
+++ b/packages/fscategory/src/components/CategoryList.tsx
@@ -1,34 +1,17 @@
 import { CategoryLine } from '@brandingbrand/fscomponents';
-import React, { Component } from 'react';
+import React from 'react';
 import { FlatList, ListRenderItemInfo } from 'react-native';
 import { CommerceTypes, WithCommerceDataProps } from '@brandingbrand/fscommerce';
 
 import { style as S } from '../styles/Category';
 import { UnwrappedCategoryProps } from './Category';
 
-export default class CategoryList extends Component<
-  UnwrappedCategoryProps & WithCommerceDataProps<CommerceTypes.Category>
-> {
-  render(): React.ReactNode {
-    const { listStyle, commerceData } = this.props;
+const CategoryList: React.SFC<UnwrappedCategoryProps
+& WithCommerceDataProps<CommerceTypes.Category>> = props => {
+  const { listStyle, commerceData } = props;
 
-    if (commerceData && commerceData.categories) {
-      return (
-        <FlatList
-          style={[S.list, listStyle]}
-          data={commerceData.categories}
-          renderItem={this.renderItem}
-          keyExtractor={this.keyExtractor}
-          {...this.props.listViewProps}
-        />
-      );
-    }
-
-    return null;
-  }
-
-  private renderItem = ({ item }: ListRenderItemInfo<CommerceTypes.Category>) => {
-    const { categoryItemProps, onNavigate, renderCategoryItem } = this.props;
+  const renderItem = ({ item }: ListRenderItemInfo<CommerceTypes.Category>) => {
+    const { categoryItemProps, onNavigate, renderCategoryItem } = props;
 
     if (renderCategoryItem) {
       return renderCategoryItem(item);
@@ -41,13 +24,29 @@ export default class CategoryList extends Component<
         {...categoryItemProps}
       />
     );
-  }
+  };
 
-  private keyExtractor = (item: CommerceTypes.Category, index: number): string => {
-    if (this.props.listViewProps && this.props.listViewProps.keyExtractor) {
-      return this.props.listViewProps.keyExtractor(item, index);
+  const keyExtractor = (item: CommerceTypes.Category, index: number): string => {
+    if (props.listViewProps && props.listViewProps.keyExtractor) {
+      return props.listViewProps.keyExtractor(item, index);
     }
 
     return item.id;
+  };
+
+  if (commerceData && commerceData.categories) {
+    return (
+      <FlatList
+        style={[S.list, listStyle]}
+        data={commerceData.categories}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        {...props.listViewProps}
+      />
+    );
   }
-}
+
+  return null;
+};
+
+export default CategoryList;


### PR DESCRIPTION
Converted list and grid components to stateless functional components. Can be tested in **fstestproject**. Category component requires class for lifecycle methods (till hooks in React 16.8).