### PR TITLE
refactor(fsproductdetail): to func component

### DIFF
--- a/packages/fsproductdetail/src/components/ProductDetail.tsx
+++ b/packages/fsproductdetail/src/components/ProductDetail.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { FunctionComponent } from 'react';
 import { Platform, Text, View } from 'react-native';
 
 import {
@@ -19,20 +19,22 @@ export interface UnwrappedProductDetailProps {
 export type ProductDetailProduct = CommerceTypes.Product;
 export type ProductDetailProps = UnwrappedProductDetailProps & WithProductDetailProviderProps;
 
-class ProductDetail extends Component<UnwrappedProductDetailProps & WithProductDetailProps> {
-  render(): JSX.Element {
-    const data = JSON.stringify(this.props.commerceData, null, 2);
-    if (Platform.OS === 'web') {
-      return <pre>{data}</pre>;
-    } else {
-      return (
-        <View>
-          <Text>{data}</Text>
-        </View>
-      );
-    }
+const ProductDetail: FunctionComponent<UnwrappedProductDetailProps
+& WithProductDetailProps> = props => {
+  const data = JSON.stringify(props.commerceData, null, 2);
+
+  if (Platform.OS === 'web') {
+    return <pre>{data}</pre>;
+
+  } else {
+    return (
+      <View>
+        <Text>{data}</Text>
+      </View>
+    );
   }
-}
+
+};
 
 export default withProductDetailData<UnwrappedProductDetailProps>(
   async (DataSource: CommerceDataSource, props: UnwrappedProductDetailProps) => {

--- a/packages/fsproductdetail/src/components/ProductDetailProvider.tsx
+++ b/packages/fsproductdetail/src/components/ProductDetailProvider.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ComponentClass } from 'react';
+import React, { Component, ComponentClass, FunctionComponent } from 'react';
 import { compose } from 'redux';
 import { cloneDeep, isEqual, set } from 'lodash-es';
 
@@ -54,12 +54,12 @@ export type WithProductDetailState<
  *
  * @template T The type of product data that will be provided. Defaults to `Product`
  *
- * @param {ComponentClass<P & WithProductDetailProps>} WrappedComponent A component to wrap and
+ * @param {FunctionComponent<P & WithProductDetailProps>} WrappedComponent A component to wrap and
  * provide product detail data to as props.
  * @returns {ComponentClass<P & WithProductDetailProviderProps>} A high order component.
  */
 export type ProductDetailWrapper<P, T extends CommerceTypes.Product = CommerceTypes.Product> = (
-  WrappedComponent: ComponentClass<P & WithProductDetailProps<T>>
+  WrappedComponent: FunctionComponent<P & WithProductDetailProps<T>>
 ) => ComponentClass<P & WithProductDetailProviderProps<T>>;
 
 /**
@@ -85,11 +85,12 @@ export default function withProductDetailData<
    * A function that wraps a a component and returns a new high order component. The wrapped
    * component will be given product detail data as props.
    *
-   * @param {ComponentClass<P & WithProductDetailProps>} WrappedComponent A component to wrap and
+   * @param {FunctionComponent<P & WithProductDetailProps>} WrappedComponent A component to wrap and
    * provide product detail data to as props.
    * @returns {ComponentClass<P & WithProductDetailProviderProps>} A high order component.
    */
-  return (WrappedComponent: ComponentClass<P & WithProductDetailProps<T>>) => {
+  return (WrappedComponent: FunctionComponent<P & WithProductDetailProps<T>> |
+    FunctionComponent<P & WithProductDetailProps<T>>) => {
     class ProductDetailProvider extends Component<ResultProps, WithProductDetailState<T>> {
       async componentDidUpdate(prevProps: ResultProps): Promise<void> {
         const { commerceToReviewMap, reviewDataSource } = this.props;


### PR DESCRIPTION
Switching **ClassComponent** interface in provider component's props for wrapped component (in this case ProductDetail.tsx) to **FunctionComponent** will be a common pattern in other packages (fscart).