### PR TITLE
refactor(pirateship): psbutton to sfc no memo

### DIFF
--- a/packages/pirateship/src/components/PSButton.tsx
+++ b/packages/pirateship/src/components/PSButton.tsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Button, ButtonProps } from '@brandingbrand/fscomponents';
 
 import { palette } from '../styles/variables';
 
-export default class PSButton extends Component<ButtonProps> {
-  render(): React.ReactNode {
-    return <Button palette={palette} {...this.props} />;
-  }
-}
+const PSButton = (props: ButtonProps) => {
+  return <Button palette={palette} {...props} />;
+};
+
+export default PSButton;


### PR DESCRIPTION
Didn't apply memo because its props are low volume, and probably not worth the memoization.