### PR TITLE
style(pirateship): primary to purple accent to blue

### DIFF
--- a/packages/fscomponents/src/styles/variables.ts
+++ b/packages/fscomponents/src/styles/variables.ts
@@ -22,13 +22,15 @@ export const color = {
   green: '#227d74',
   yellow: '#dab10e',
   white: '#ffffff',
-  red: '#d0021b'
+  red: '#d0021b',
+  blue: '#0065FF',
+  purple: '#3F0F3F'
 };
 
 export const palette = {
-  primary: color.green,
+  primary: color.purple,
   secondary: color.darkGray,
-  accent: color.yellow,
+  accent: color.blue,
   error: color.red,
   background: color.white,
   surface: grays.one,

--- a/packages/pirateship/src/styles/variables.ts
+++ b/packages/pirateship/src/styles/variables.ts
@@ -20,13 +20,15 @@ export const color = {
   green: '#227d74',
   yellow: '#dab10e',
   white: '#ffffff',
-  red: '#d0021b'
+  red: '#d0021b',
+  blue: '#0065FF',
+  purple: '#3F0F3F'
 };
 
 export const palette = {
-  primary: color.green,
+  primary: color.purple,
   secondary: color.darkGray,
-  accent: color.yellow,
+  accent: color.blue,
   error: color.red,
   background: color.white,
   surface: grays.one,


### PR DESCRIPTION
updating the primary and accent colors, formerly 'hospital' green and harvest yellow:
![simulator screen shot - iphone x - 2019-03-02 at 19 10 44](https://user-images.githubusercontent.com/41645989/53689380-815c4100-3d22-11e9-8c4c-38575c348719.png)![simulator screen shot - iphone x - 2019-03-02 at 19 10 55](https://user-images.githubusercontent.com/41645989/53689381-815c4100-3d22-11e9-9335-159995145072.png)![simulator screen shot - iphone x - 2019-03-02 at 19 10 30](https://user-images.githubusercontent.com/41645989/53689382-815c4100-3d22-11e9-88e4-f76d13245fde.png)
