### PR TITLE
fix(fscomponents): actionbar sample styles cleaned up

### DIFF
--- a/packages/pirateship/src/screens/ActionBarSample.tsx
+++ b/packages/pirateship/src/screens/ActionBarSample.tsx
@@ -5,6 +5,7 @@ import PSScreenWrapper from '../components/PSScreenWrapper';
 import { NavigatorStyle, ScreenProps } from '../lib/commonTypes';
 import { navBarTabLanding } from '../styles/Navigation';
 import { ActionBar, ActionBarProps, Button } from '@brandingbrand/fscomponents';
+import { palette } from '../styles/variables';
 
 type Screen = import ('react-native-navigation').Screen;
 
@@ -15,6 +16,9 @@ const styles = StyleSheet.create({
   buttons: {
     width: 250,
     margin: 5
+  },
+  title: {
+    color: palette.onPrimary
   }
 });
 
@@ -22,12 +26,13 @@ const triggerButton = () => {
   Alert.alert('Button Pressed');
 };
 
-const renderButton = (): JSX.Element => {
+const renderButton = (title: string): JSX.Element => {
   return (
     <Button
       onPress={triggerButton}
-      title='Button Title'
+      title={title}
       style={styles.buttons}
+      titleStyle={styles.title}
     />
   );
 };
@@ -51,8 +56,8 @@ class ActionBarSample extends Component<ActionBarSampleScreenProps> {
           <ActionBar
             separatorWidth={10}
           >
-            {renderButton()}
-            {renderButton()}
+            {renderButton('watch now')}
+            {renderButton('browse favorites')}
           </ActionBar>
         </View>
       </PSScreenWrapper>


### PR DESCRIPTION
changed button title colors to 'onPrimary' so now readable (was black on green, now white).

BEFORE: 
![simulator screen shot - iphone x - 2019-03-04 at 13 16 07](https://user-images.githubusercontent.com/3064557/53753707-e4171f00-3e7f-11e9-9bd0-c7b1ce0e1da9.png)

AFTER:
![simulator screen shot - iphone x - 2019-03-04 at 11 32 41](https://user-images.githubusercontent.com/3064557/53747507-651aea00-3e71-11e9-80d9-3f936b6a4bfd.png)

