### PR TITLE
refactor(fscomponents): cartcount to sfc w memo and demo

### DIFF
--- a/packages/fscomponents/src/components/CartCount.tsx
+++ b/packages/fscomponents/src/components/CartCount.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { FunctionComponent, memo } from 'react';
 
 import {
   Image,
@@ -75,25 +75,25 @@ const styles = StyleSheet.create({
   }
 });
 
-export class CartCount extends PureComponent<CartCountProps> {
-  render(): JSX.Element {
-    const textPosition = this.props.textPosition || 'center';
+export const CartCount: FunctionComponent<CartCountProps> = memo((props): JSX.Element => {
 
-    return (
-      <View style={[styles.container, this.props.style]}>
-        <Image
-          resizeMode='contain'
-          style={[styles.image, this.props.cartImageStyle]}
-          source={this.props.cartImage || DEFAULT_CART_IMAGE}
-        />
-        {this.props.count && (
-          <Text
-            style={[styles.text, styles[textPosition], this.props.textStyle]}
-          >
-            {this.props.count}
-          </Text>
-        )}
-      </View>
-    );
-  }
-}
+  const textPosition = props.textPosition || 'center';
+
+  return (
+    <View style={[styles.container, props.style]}>
+      <Image
+        resizeMode='contain'
+        style={[styles.image, props.cartImageStyle]}
+        source={props.cartImage || DEFAULT_CART_IMAGE}
+      />
+      {props.count && (
+        <Text
+          style={[styles.text, styles[textPosition], props.textStyle]}
+        >
+          {props.count}
+        </Text>
+      )}
+    </View>
+  );
+
+});

--- a/packages/pirateship/src/screens.tsx
+++ b/packages/pirateship/src/screens.tsx
@@ -30,6 +30,7 @@ import BreadCrumbsSample from './screens/BreadCrumbsSample';
 import AccordionSample from './screens/AccordionSample';
 import ActionBarSample from './screens/ActionBarSample';
 import ImageWithOverlaySample from './screens/ImageWithOverlaySample';
+import CartCountSample from './screens/CartCountSample';
 
 export default {
   Shop,
@@ -60,5 +61,6 @@ export default {
   BreadCrumbsSample,
   AccordionSample,
   ActionBarSample,
-  ImageWithOverlaySample
+  ImageWithOverlaySample,
+  CartCountSample
 };

--- a/packages/pirateship/src/screens/CartCountSample.tsx
+++ b/packages/pirateship/src/screens/CartCountSample.tsx
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import { StyleSheet, View } from 'react-native';
+import PSScreenWrapper from '../components/PSScreenWrapper';
+import { NavigatorStyle, ScreenProps } from '../lib/commonTypes';
+import { navBarTabLanding } from '../styles/Navigation';
+import { CartCount, CartCountProps, TextPositions } from '@brandingbrand/fscomponents';
+
+type Screen = import ('react-native-navigation').Screen;
+
+const cartIcon = require('../../assets/images/cart-tab-icon.png');
+
+// const positions = ['topLeft', 'topRight', 'center', 'bottomLeft', 'bottomRight'];
+
+export interface CartCountSampleScreenProps extends ScreenProps, CartCountProps {}
+
+const styles = StyleSheet.create({
+  row: {
+    padding: 15,
+    alignItems: 'center'
+  }
+});
+
+class CartCountSample extends Component<CartCountSampleScreenProps> {
+  static navigatorStyle: NavigatorStyle = navBarTabLanding;
+
+  render(): JSX.Element {
+
+    const { navigator } = this.props;
+
+
+    return (
+      <PSScreenWrapper
+        hideGlobalBanner={true}
+        navigator={navigator}
+      >
+        <View style={styles.row}>
+          <CartCount
+            textPosition={'topRight' as TextPositions}
+            count={8}
+            cartImage={cartIcon}
+          />
+        </View>
+        <View style={styles.row}>
+          <CartCount
+            textPosition={'topLeft' as TextPositions}
+            count={2}
+            cartImage={cartIcon}
+          />
+        </View>
+        <View style={styles.row}>
+          <CartCount
+            textPosition={'bottomRight' as TextPositions}
+            count={5}
+            cartImage={cartIcon}
+          />
+        </View>
+      </PSScreenWrapper>
+    );
+  }
+
+  goTo = (screen: Screen) => () => {
+    this.props.navigator.push(screen);
+  }
+}
+
+export default CartCountSample;

--- a/packages/pirateship/src/screens/Development.tsx
+++ b/packages/pirateship/src/screens/Development.tsx
@@ -15,7 +15,8 @@ const screens: Screen[] = [
   { title: 'Accordion', screen: 'AccordionSample' },
   { title: 'Action Bar', screen: 'ActionBarSample' },
   { title: 'BreadCrumbs', screen: 'BreadCrumbsSample' },
-  { title: 'Image With Overlay', screen: 'ImageWithOverlaySample' }
+  { title: 'Image With Overlay', screen: 'ImageWithOverlaySample' },
+  { title: 'Cart Count', screen: 'CartCountSample'}
 ];
 
 export interface DevelopmentScreenState {


### PR DESCRIPTION
Adding react.memo as it started as a PureComponent. Also built a demo screen in Development menu:
![simulator screen shot - iphone x - 2019-03-04 at 16 34 33](https://user-images.githubusercontent.com/3064557/53764487-70830b00-3e9b-11e9-8cc0-ce90d86f2594.png)
