### PR TITLE
fix(fsapp): Expose getApplication functionality for SSR

### DIFF
--- a/packages/fsapp/src/fsapp/FSApp.web.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.web.tsx
@@ -7,7 +7,9 @@ import DevMenu from '../components/DevMenu';
 export class FSApp extends FSAppBase {
   constructor(appConfig: AppConfigType) {
     super(appConfig);
-    this.startApp();
+    if (!appConfig.serverSide) {
+      this.startApp();
+    }
   }
 
   registerScreens(): void {

--- a/packages/fsapp/src/fsapp/FSAppBase.tsx
+++ b/packages/fsapp/src/fsapp/FSAppBase.tsx
@@ -1,4 +1,5 @@
 import { AppConfigType } from '../types';
+import { AppRegistry } from 'react-native';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import configureStore from '../store/configureStore';
 
@@ -12,6 +13,21 @@ export abstract class FSAppBase {
     this.api = new FSNetwork(appConfig.remote || {});
     this.store = configureStore(appConfig.initialState, appConfig.reducers);
     this.registerScreens();
+  }
+
+  getApp(): any {
+    // @ts-ignore: Is set in react-native-web
+    if (AppRegistry.getApplication) {
+      // @ts-ignore: Is set in react-native-web
+      return AppRegistry.getApplication('Flagship', {
+        initialProps: {
+          appConfig: this.appConfig,
+          api: this.api,
+          store: this.store
+        }
+      });
+    }
+    return undefined;
   }
 
   abstract registerScreens(): void;

--- a/packages/fsapp/src/lib/env-switcher.web.ts
+++ b/packages/fsapp/src/lib/env-switcher.web.ts
@@ -6,14 +6,23 @@ class WebEnvSwitcher {
   defaultAppEnv: string = __DEFAULT_ENV__ || 'prod';
 
   get envName(): string {
-    const storedEnvName = localStorage.getItem(this.storageKey);
+    let storedEnvName;
+    try {
+      storedEnvName = localStorage.getItem(this.storageKey);
+    } catch (e) {
+      return '';
+    }
 
     return storedEnvName || this.defaultAppEnv;
   }
 
   set envName(name: string) {
     if (typeof name === 'string') {
-      localStorage.setItem(this.storageKey, name);
+      try {
+        localStorage.setItem(this.storageKey, name);
+      } catch (e) {
+        return;
+      }
     }
   }
 

--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -66,6 +66,7 @@ export interface AppConfigType {
   analytics?: Analytics;
   devMenuScreens?: Screen[];
   popToRootOnTabPressAndroid?: boolean;
+  serverSide?: boolean;
 }
 
 export interface NavButton {


### PR DESCRIPTION
Also allows setting serverSide config option to prevent the application from being run and adds a safety check to accessing localStorage.
When running server side, we don't want to run the application, we just want to render it once, so running it eats up resources unnecessarily.