### PR TITLE
fix(fsapp): devMenu path override and web screen wrapper update

### DIFF
--- a/packages/fsapp/src/fsapp/FSApp.web.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.web.tsx
@@ -15,6 +15,9 @@ export class FSApp extends FSAppBase {
   registerScreens(): void {
     if (this.shouldShowDevMenu()) {
       this.appConfig.screens.devMenu = DevMenu as any;
+      if (this.appConfig.devMenuPath) {
+        this.appConfig.screens.devMenu.path = this.appConfig.devMenuPath;
+      }
     }
 
     AppRegistry.registerComponent('Flagship', () => App);

--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -67,6 +67,7 @@ export interface AppConfigType {
   devMenuScreens?: Screen[];
   popToRootOnTabPressAndroid?: boolean;
   serverSide?: boolean;
+  devMenuPath?: string;
 }
 
 export interface NavButton {


### PR DESCRIPTION
Allows setting devMenuPath in the config to override the path that the dev menu is displayed on web. Also updates the web screen wrapper to more-closely match the native version's functionality and will suppress the link to the dev menu with the same logic used to determine if the screen should be added to the list.