### PR TITLE
fix(fsapp): On web dev menu, go back before refreshing

### DIFF
--- a/packages/fsapp/src/components/DevMenu.web.tsx
+++ b/packages/fsapp/src/components/DevMenu.web.tsx
@@ -191,8 +191,11 @@ export default class DevMenu extends Component<GenericScreenProp, DevMenuState> 
 
   switchToSelectedEnv = () => {
     EnvSwitcher.envName = this.state.selectedEnv;
+    this.dismissModal();
     if (typeof window !== 'undefined' && window.location && window.location.reload) {
-      window.location.reload();
+      setTimeout(() => {
+        window.location.reload();
+      }, 0);
     }
   }
 


### PR DESCRIPTION
Going back before reloading makes it reload the page that loaded the environment switcher, rather than the environment switcher itself.