### PR TITLE
refactor(fscomponents): actionbar w generic props type

### DIFF
--- a/packages/fscomponents/src/components/ActionBar.tsx
+++ b/packages/fscomponents/src/components/ActionBar.tsx
@@ -3,7 +3,7 @@
  * of configurable width (props.separatorWidth) between each child.
  */
 
-import React, {ReactNode} from 'react';
+import React, { FunctionComponent, ReactNode } from 'react';
 
 import {
   StyleProp,
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
   }
 });
 
-export const ActionBar = (props: ActionBarProps): JSX.Element => {
+export const ActionBar: FunctionComponent<ActionBarProps> = (props): JSX.Element => {
   const numChildren = React.Children.count(props.children);
   const separatorStyle = { width: props.separatorWidth || DEFAULT_SEPARATOR_WIDTH };
 


### PR DESCRIPTION
This updates the component to use const componentName: FunctionComponent<ComponentProps> pattern as with the other SFCs.