### PR TITLE
fix(fscomponents): Fixes for IE11

### DIFF
--- a/packages/fsapp/src/components/DrawerRouter.web.tsx
+++ b/packages/fsapp/src/components/DrawerRouter.web.tsx
@@ -153,12 +153,14 @@ export default class DrawerRouter extends Component<PropType, AppStateTypes> {
         overflowX: 'hidden'
       },
       appDrawerDefault: {
-        flex: 1
+        flex: 1,
+        flexBasis: 'auto'
       },
       container: {
         transitionDuration: drawerDuration,
         width: '100%',
-        flex: 1
+        flex: 1,
+        flexBasis: 'auto'
       },
       containerDrawerLeftOpen: {
         marginLeft: drawerWidth

--- a/packages/fsapp/src/components/screenWrapper.tsx
+++ b/packages/fsapp/src/components/screenWrapper.tsx
@@ -11,7 +11,8 @@ import EnvSwitcher from '../lib/env-switcher';
 
 const styles = StyleSheet.create({
   screenContainer: {
-    flex: 1
+    flex: 1,
+    flexBasis: 'auto'
   },
   devNoteContainer: {
     position: 'absolute',

--- a/packages/fsapp/src/components/screenWrapper.web.tsx
+++ b/packages/fsapp/src/components/screenWrapper.web.tsx
@@ -9,7 +9,8 @@ import { AppConfigType, DrawerConfig } from '../types';
 
 const styles = StyleSheet.create({
   screenContainer: {
-    flex: 1
+    flex: 1,
+    flexBasis: 'auto'
   },
   devNoteContainer: {
     position: 'absolute',

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -43,6 +43,7 @@ const S = StyleSheet.create({
     borderTopWidth: 2,
     borderLeftWidth: 2,
     borderColor: 'black',
+    borderBottomColor: 'transparent',
     transform: [
       {
         rotate: '-45deg'
@@ -55,6 +56,7 @@ const S = StyleSheet.create({
     borderTopWidth: 2,
     borderRightWidth: 2,
     borderColor: 'black',
+    borderLeftColor: 'transparent',
     transform: [
       {
         rotate: '45deg'
@@ -242,6 +244,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
           onTouchStart={this.handleTouchStart}
           onTouchEnd={this.handleTouchEnd}
           onTouchMove={this.handleTouchMove}
+          style={{ flexBasis: 'auto' }}
         >
           <View
             style={{ width: this.props.centerMode ? this.props.peekSize : 0 }}

--- a/packages/fscomponents/src/components/ReviewsList.tsx
+++ b/packages/fscomponents/src/components/ReviewsList.tsx
@@ -34,7 +34,11 @@ export class ReviewsList extends Component<ReviewsListProps> {
     } = this.props;
 
     return (
-      <ScrollView>
+      <ScrollView
+        style={{
+          flexBasis: 'auto'
+        }}
+      >
         {reviews.map((review, key) => {
           return (
             <ReviewItem


### PR DESCRIPTION
IE11 hates its `flex-basis: 0`s. It also does some weird things with rotated arrows, and this removes the thin border line that appears on them in the Multicarousel.