### PR TITLE
fix(fscomponents): remove accessible prop to stop focus

### DIFF
--- a/packages/fscomponents/src/components/ReviewIndicator.tsx
+++ b/packages/fscomponents/src/components/ReviewIndicator.tsx
@@ -127,7 +127,6 @@ export class ReviewIndicator extends PureComponent<ReviewIndicatorProps> {
     return (
       <View
         style={[S.container, style]}
-        accessible={true}
         accessibilityLabel={label}
       >
         {newArray(itemData.full).map(v => (


### PR DESCRIPTION
-removing accessible prop from wrapping view so the component can be skipped in tab order