### PR TITLE
fix(pirateship): corrects semver for rn touch id

### DIFF
--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -52,7 +52,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "^5.1.0",
     "react-native-svg": "^8.0.0",
-    "react-native-touch-id": "^4.0.1",
+    "react-native-touch-id": "~4.0.0",
     "react-redux": "^5.0.7",
     "tcomb-form-native": "^0.6.12"
   },


### PR DESCRIPTION
blocks auto yarn upgrade of pirateship's **react-native-touch-id** dependency to v 4.0.1 which included breaking changes with their own incorrect semver resulting in `TouchId undefined` errors in **PSSignInForm.tsx**. This Sticks us at 4.0.0 with tilde semver `~4.0.0`.

Fixes: https://github.com/brandingbrand/flagship/issues/492
which is breaking builds/linting