### PR TITLE
refactor(pirateship): psrowheader to stateless function component

### DIFF
--- a/packages/pirateship/src/components/PSRowHeader.tsx
+++ b/packages/pirateship/src/components/PSRowHeader.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { FunctionComponent } from 'react';
 
 import {
   StyleProp,
@@ -29,12 +29,12 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class PSRowHeader extends Component<PSRowHeaderProps> {
-  render(): JSX.Element {
-    return (
-      <View style={[styles.view, this.props.style]}>
-        <Text style={[styles.title, this.props.titleStyle]}>{this.props.title}</Text>
-      </View>
-    );
-  }
-}
+const PSRowHeader: FunctionComponent<PSRowHeaderProps> = (props): JSX.Element => {
+  return (
+    <View style={[styles.view, props.style]}>
+      <Text style={[styles.title, props.titleStyle]}>{props.title}</Text>
+    </View>
+  );
+};
+
+export default PSRowHeader;


### PR DESCRIPTION
Testable in pirateship:

![psrowheader](https://user-images.githubusercontent.com/3064557/54536283-ce692580-4966-11e9-8200-6d82a41f21fd.png)
