### PR TITLE
feat(fscomponents): Custom styling for swatch show more/less

### DIFF
--- a/packages/fscomponents/src/components/Swatches.tsx
+++ b/packages/fscomponents/src/components/Swatches.tsx
@@ -31,6 +31,8 @@ export interface SwatchesProps extends SwatchStyle {
   labelContainerStyle?: StyleProp<ViewStyle>;
   labelTitleStyle?: StyleProp<TextStyle>;
   labelValueStyle?: StyleProp<TextStyle>;
+  showingMoreStyle?: StyleProp<ViewStyle>;
+  showingLessStyle?: StyleProp<ViewStyle>;
   renderLabel?: (swatch: any) => void;
 
   onChangeSwatch?: (swatch: any) => void;
@@ -227,16 +229,18 @@ export class Swatches extends Component<SwatchesProps, SwatchesState> {
   render(): JSX.Element {
     const {
       items,
-      style,
+      label,
       maxSwatches,
-      label
+      showingLessStyle,
+      showingMoreStyle,
+      style
     } = this.props;
 
     const { shouldShowMoreLess, showMore } = this.state;
     const { swatch } = this.state.selected;
 
     let displayItems = [...items];
-    if (shouldShowMoreLess && !showMore) {
+    if (shouldShowMoreLess && !showMore && (maxSwatches === undefined || maxSwatches > 0)) {
       // Show Less
       displayItems = displayItems.slice(0, maxSwatches);
     }
@@ -244,8 +248,10 @@ export class Swatches extends Component<SwatchesProps, SwatchesState> {
     return (
       <View>
         {label && this._renderLabel(swatch)}
-        <View style={[S.container, style]}>
-          {displayItems.map(this._renderSwatch)}
+        <View>
+          <View style={[S.container, showMore ? showingMoreStyle : showingLessStyle, style]}>
+            {displayItems.map(this._renderSwatch)}
+          </View>
           {this._renderMoreLess()}
         </View>
       </View>

--- a/packages/fscomponents/src/components/Swatches.tsx
+++ b/packages/fscomponents/src/components/Swatches.tsx
@@ -249,7 +249,11 @@ export class Swatches extends Component<SwatchesProps, SwatchesState> {
       <View>
         {label && this._renderLabel(swatch)}
         <View>
-          <View style={[S.container, showMore ? showingMoreStyle : showingLessStyle, style]}>
+          <View
+            style={[S.container, showMore ? showingMoreStyle : showingLessStyle, style]}
+            // @ts-ignore className is only used for web
+            className={'swatch-scroll ' + (showMore ? 'showing-more' : 'showing-less')}
+          >
             {displayItems.map(this._renderSwatch)}
           </View>
           {this._renderMoreLess()}


### PR DESCRIPTION
Allows setting maxSwatches to 0 or negative to continue showing all swatches even when show less is selected. This also allows specific styling for the container when less or more is selected. This does slightly alter the behavior because the style is applied to a view wrapping just the swatches and not the more/less selection.