### PR TITLE
refactor(pirateship): pshalfmodal to stateless function component

### DIFF
--- a/packages/pirateship/src/components/PSHalfModal.tsx
+++ b/packages/pirateship/src/components/PSHalfModal.tsx
@@ -1,22 +1,19 @@
-import React, { Component } from 'react';
-
+import React, { FunctionComponent } from 'react';
 import {
   StyleSheet,
   Text,
   View
 } from 'react-native';
-
 import { ModalHalfScreen } from '@brandingbrand/fscomponents';
-
 import { border, fontSize } from '../styles/variables';
 
 export interface PSHalfModalProps {
   title: string;
   onClose: () => void;
   visible: boolean;
-
   renderLeftItem?: () => JSX.Element;
   renderRightItem?: () => JSX.Element;
+  children?: any;
 }
 
 const styles = StyleSheet.create({
@@ -48,27 +45,27 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class PSHalfModal extends Component<PSHalfModalProps> {
-  render(): JSX.Element {
-    return (
-      <ModalHalfScreen onRequestClose={this.props.onClose} visible={this.props.visible}>
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text style={styles.title}>{this.props.title}</Text>
-            {this.props.renderLeftItem && (
-              <View style={styles.leftItem}>
-                {this.props.renderLeftItem()}
-              </View>
-            )}
-            {this.props.renderRightItem && (
-              <View style={styles.rightItem}>
-                {this.props.renderRightItem()}
-              </View>
-            )}
-          </View>
-          {this.props.children}
+const PSHalfModal: FunctionComponent<PSHalfModalProps> = (props): JSX.Element => {
+  return (
+    <ModalHalfScreen onRequestClose={props.onClose} visible={props.visible}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{props.title}</Text>
+          {props.renderLeftItem && (
+            <View style={styles.leftItem}>
+              {props.renderLeftItem()}
+            </View>
+          )}
+          {props.renderRightItem && (
+            <View style={styles.rightItem}>
+              {props.renderRightItem()}
+            </View>
+          )}
         </View>
-      </ModalHalfScreen>
-    );
-  }
-}
+        {props.children}
+      </View>
+    </ModalHalfScreen>
+  );
+};
+
+export default PSHalfModal;

--- a/packages/pirateship/src/screens/Development.tsx
+++ b/packages/pirateship/src/screens/Development.tsx
@@ -16,7 +16,8 @@ const screens: Screen[] = [
   { title: 'Action Bar', screen: 'ActionBarSample' },
   { title: 'BreadCrumbs', screen: 'BreadCrumbsSample' },
   { title: 'Image With Overlay', screen: 'ImageWithOverlaySample' },
-  { title: 'Cart Count', screen: 'CartCountSample'}
+  { title: 'Cart Count', screen: 'CartCountSample'},
+  { title: 'PS Half Modal', screen: 'EmailSignUp' }
 ];
 
 export interface DevelopmentScreenState {

--- a/packages/pirateship/src/screens/EmailSignUp.tsx
+++ b/packages/pirateship/src/screens/EmailSignUp.tsx
@@ -23,7 +23,6 @@ import PSButton from '../components/PSButton';
 import PSHalfModal from '../components/PSHalfModal';
 import { EMAIL_REGEX } from '../lib/constants';
 import translate, { translationKeys } from '../lib/translations';
-
 export interface EmailSignUpState {
   descriptionText?: string;
   modalVisible: boolean;
@@ -47,7 +46,10 @@ const FIELD_OPTIONS = {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: palette.surface
+    backgroundColor: palette.surface,
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    paddingTop: 100
   },
   cmsImage: {
     marginBottom: 14


### PR DESCRIPTION
PSHalfModal refactored to stateless functional component and testable in development menu: enter email for promos, etc. results in a half-modal success message. Did not 'memo'-ize given low frequency of props being changed and not worth the extra computational time.
![53767536-1fc3e000-3ea4-11e9-8e0c-47bfe5d59957](https://user-images.githubusercontent.com/3064557/54638016-68f95f80-4a60-11e9-87a4-123c7892b98c.png)
