### PR TITLE
style(fscomponents): modalhalfscreen vertical position

### DIFF
--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -28,6 +28,7 @@
     "react-id-swiper": "^1.6.6",
     "react-native": "0.57.8",
     "react-native-masked-text": "^1.7.1",
+    "react-native-status-bar-height": "^2.3.1",
     "react-native-svg": "^8.0.0",
     "react-native-swiper": "^1.5.13",
     "react-native-web-modal": "^1.0.1",

--- a/packages/pirateship/src/components/PSHalfModal.tsx
+++ b/packages/pirateship/src/components/PSHalfModal.tsx
@@ -1,22 +1,20 @@
-import React, { Component } from 'react';
-
+import React, { FunctionComponent } from 'react';
 import {
   StyleSheet,
   Text,
   View
 } from 'react-native';
-
-import { ModalHalfScreen } from '@brandingbrand/fscomponents';
-
+import { ModalHalfScreen, VerticalPosition } from '@brandingbrand/fscomponents';
 import { border, fontSize } from '../styles/variables';
 
 export interface PSHalfModalProps {
   title: string;
   onClose: () => void;
   visible: boolean;
-
   renderLeftItem?: () => JSX.Element;
   renderRightItem?: () => JSX.Element;
+  children?: any;
+  verticalPosition?: VerticalPosition;
 }
 
 const styles = StyleSheet.create({
@@ -48,27 +46,31 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class PSHalfModal extends Component<PSHalfModalProps> {
-  render(): JSX.Element {
-    return (
-      <ModalHalfScreen onRequestClose={this.props.onClose} visible={this.props.visible}>
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text style={styles.title}>{this.props.title}</Text>
-            {this.props.renderLeftItem && (
-              <View style={styles.leftItem}>
-                {this.props.renderLeftItem()}
-              </View>
-            )}
-            {this.props.renderRightItem && (
-              <View style={styles.rightItem}>
-                {this.props.renderRightItem()}
-              </View>
-            )}
-          </View>
-          {this.props.children}
+const PSHalfModal: FunctionComponent<PSHalfModalProps> = (props): JSX.Element => {
+  return (
+    <ModalHalfScreen
+      onRequestClose={props.onClose}
+      visible={props.visible}
+      verticalPosition={props.verticalPosition}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{props.title}</Text>
+          {props.renderLeftItem && (
+            <View style={styles.leftItem}>
+              {props.renderLeftItem()}
+            </View>
+          )}
+          {props.renderRightItem && (
+            <View style={styles.rightItem}>
+              {props.renderRightItem()}
+            </View>
+          )}
         </View>
-      </ModalHalfScreen>
-    );
-  }
-}
+        {props.children}
+      </View>
+    </ModalHalfScreen>
+  );
+};
+
+export default PSHalfModal;

--- a/packages/pirateship/src/screens/Development.tsx
+++ b/packages/pirateship/src/screens/Development.tsx
@@ -15,8 +15,9 @@ const screens: Screen[] = [
   { title: 'Accordion', screen: 'AccordionSample' },
   { title: 'Action Bar', screen: 'ActionBarSample' },
   { title: 'BreadCrumbs', screen: 'BreadCrumbsSample' },
-  { title: 'Image With Overlay', screen: 'ImageWithOverlaySample' },
-  { title: 'Cart Count', screen: 'CartCountSample'}
+  { title: 'ImageWithOverlay', screen: 'ImageWithOverlaySample' },
+  { title: 'CartCount', screen: 'CartCountSample'},
+  { title: 'ModalHalfScreen', screen: 'EmailSignUp' }
 ];
 
 export interface DevelopmentScreenState {

--- a/packages/pirateship/src/screens/EmailSignUp.tsx
+++ b/packages/pirateship/src/screens/EmailSignUp.tsx
@@ -9,7 +9,7 @@ import {
 
 // @ts-ignore TODO: Add types for tcomb-form-native
 import * as tcomb from 'tcomb-form-native';
-import { CMSBannerStacked, Form } from '@brandingbrand/fscomponents';
+import { CMSBannerStacked, Form, VerticalPosition } from '@brandingbrand/fscomponents';
 
 import { NavButton, NavigatorStyle, ScreenProps } from '../lib/commonTypes';
 import { backButton } from '../lib/navStyles';
@@ -23,10 +23,13 @@ import PSButton from '../components/PSButton';
 import PSHalfModal from '../components/PSHalfModal';
 import { EMAIL_REGEX } from '../lib/constants';
 import translate, { translationKeys } from '../lib/translations';
-
 export interface EmailSignUpState {
   descriptionText?: string;
   modalVisible: boolean;
+}
+
+export interface EmailSignUpProps extends ScreenProps {
+  verticalPosition?: VerticalPosition;
 }
 
 const FIELD_TYPES = tcomb.struct({
@@ -47,7 +50,10 @@ const FIELD_OPTIONS = {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: palette.surface
+    backgroundColor: palette.surface,
+    alignItems: 'center',
+    justifyContent: 'space-around',
+    paddingTop: 100
   },
   cmsImage: {
     marginBottom: 14
@@ -80,7 +86,7 @@ const styles = StyleSheet.create({
   }
 });
 
-export default class EmailSignUp extends Component<ScreenProps, EmailSignUpState> {
+export default class EmailSignUp extends Component<EmailSignUpProps, EmailSignUpState> {
   static navigatorStyle: NavigatorStyle = navBarDefault;
   static leftButtons: NavButton[] = [backButton];
   form?: Form;
@@ -170,6 +176,7 @@ export default class EmailSignUp extends Component<ScreenProps, EmailSignUpState
         onClose={this.closeModal}
         visible={this.state.modalVisible}
         renderRightItem={this.renderModalRightItem}
+        verticalPosition={VerticalPosition.Top}
       >
         <View style={styles.modalBody}>
           <Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12862,6 +12862,11 @@ react-native-sensitive-info@^5.1.0:
   resolved "https://registry.yarnpkg.com/react-native-sensitive-info/-/react-native-sensitive-info-5.3.0.tgz#dab9f346a6f7cc6d4c520c4973e60854b7a82ef8"
   integrity sha512-bAY05Tye8QDr1Bytv950P7ToxQjan6ZzVdF34Y/RWz7O5b2wvfRLJIafmuY/XN5DboQF+ShIUPxIuBf09vVBAg==
 
+react-native-status-bar-height@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.3.1.tgz#b92ce9112c2367290847ac11284d9d84a6330169"
+  integrity sha512-m9nGKYfFn6ljF1abafzF5cFaD9JCzXwj7kNE9CuF+g0TgtItH70eY2uHaCV9moENTftqd5XIS3Cx0mf4WfistA==
+
 react-native-svg@^8.0.0:
   version "8.0.10"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-8.0.10.tgz#b07e2342d1486220f5fda1a584e316e7d2d1f392"


### PR DESCRIPTION
sets up `verticalPosition` props with 'top', 'middle', and 'bottom' as default. Testable in **Development > PSHalfModal** (EmailSignUp, with `verticalPosition={'middle'}`).  

Handles https://github.com/brandingbrand/flagship/issues/309