### PR TITLE
feat(fsapp): add ability to pass location into the web router

### DIFF
--- a/packages/fsapp/src/components/DrawerRouter.web.tsx
+++ b/packages/fsapp/src/components/DrawerRouter.web.tsx
@@ -249,7 +249,7 @@ export default class DrawerRouter extends Component<PropType, AppStateTypes> {
     return (
       <Provider store={store}>
         <Router {...routerProps}>
-          <Switch>
+          <Switch location={appConfig.location}>
             {this.screensRoutes}
           </Switch>
         </Router>

--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -68,6 +68,7 @@ export interface AppConfigType {
   popToRootOnTabPressAndroid?: boolean;
   serverSide?: boolean;
   devMenuPath?: string;
+  location?: Location; // Use to provide a server-side location to router in DrawerRouter.web.tsx
 }
 
 export interface NavButton {
@@ -82,4 +83,11 @@ export interface NavigatorButtons {
 export interface NavigatorEvent {
   id: string;
   type: string;
+}
+
+export interface Location<T = any> {
+  pathname: string;
+  search: string;
+  hash: string;
+  state: T;
 }


### PR DESCRIPTION
The router that we're using for web supports the ability to pass in a location object that overrides the default behavior of using window.location. This allows for the existing web routing system to work with server side rendering as well.