### PR TITLE
fix(flagship): remove minSdkVersion from Android versionCode

### DIFF
--- a/packages/flagship/__tests__/mock_project/android/app/build.gradle
+++ b/packages/flagship/__tests__/mock_project/android/app/build.gradle
@@ -104,10 +104,9 @@ android {
     defaultConfig {
         multiDexEnabled true
         applicationId "com.brandingbrand.reactnative.and.flagship"
-        minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionName project.VERSION_NAME
-        versionCode "${rootProject.ext.minSdkVersion}${project.VERSION_CODE_SHORT}".toInteger()
+        versionCode "${project.VERSION_CODE_SHORT}".toInteger()
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/packages/flagship/android/app/build.gradle
+++ b/packages/flagship/android/app/build.gradle
@@ -104,10 +104,9 @@ android {
     defaultConfig {
         multiDexEnabled true
         applicationId "com.brandingbrand.reactnative.and.flagship"
-        minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionName project.VERSION_NAME
-        versionCode "${rootProject.ext.minSdkVersion}${project.VERSION_CODE_SHORT}".toInteger()
+        versionCode "${project.VERSION_CODE_SHORT}".toInteger()
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }


### PR DESCRIPTION
This fix allows Android apps to be built and submitted to the store if
the minimum SDK version is >=21. See:
https://github.com/brandingbrand/flagship/issues/266