### PR TITLE
 fix(fscomponents): hide web carousel if item width is 0

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -254,6 +254,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
 
   _saveScrollViewRef = (ref: any) => this.scrollView = ref;
 
+  // tslint:disable-next-line:cyclomatic-complexity
   render(): React.ReactNode {
     const snapToInterval =
       this.state.itemWidth *
@@ -292,21 +293,23 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
           <View
             style={{ width: this.props.centerMode ? this.props.peekSize : 0 }}
           />
-          {this.props.items.map((item, i) => {
-            return (
-              <View
-                key={i}
-                style={[
-                  {
-                    width: this.state.itemWidth
-                  },
-                  this.props.itemStyle
-                ]}
-              >
-                {this.props.renderItem(item, i)}
-              </View>
-            );
-          })}
+          {(this.state.itemWidth || (this.props.itemStyle && this.props.itemStyle.width))
+            && this.props.items.map((item, i) => {
+              return (
+                <View
+                  key={i}
+                  style={[
+                    {
+                      width: this.state.itemWidth
+                    },
+                    this.props.itemStyle
+                  ]}
+                >
+                  {this.props.renderItem(item, i)}
+                </View>
+              );
+            })
+          }
         </ScrollViewCopy>
 
         {this.props.renderPageIndicator ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11439,9 +11439,9 @@ number-is-nan@^1.0.0:
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 nwsapi@^2.0.7:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.3.tgz#25f3a5cec26c654f7376df6659cdf84b99df9558"
-  integrity sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
+  integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
 oauth-sign@~0.9.0:
   version "0.9.0"


### PR DESCRIPTION
requires:
- [x] https://github.com/brandingbrand/flagship/pull/596

This updates the web MultiCarousel component to not render items if the item width is 0. This will prevent the items from displaying in a squashed state before the component has initialized and determined the proper item width.