### PR TITLE
chore: tell greenkeeper to ignore react-native updates

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -31,5 +31,8 @@
         "packages/pirateship/package.json"
       ]
     }
-  }
+  },
+  "ignore": [
+    "react-native"
+  ]
 }


### PR DESCRIPTION
This updates the Greenkeeper configuration to always ignore react-native updates, as we should never be merging in react-native updates without developer oversight. Syntax per the Greenkeeper docs: https://greenkeeper.io/docs.html#monorepo