### PR TITLE
fix(MultiCarousel) update state.itemWidth when props.itemsPerPage changes

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
@@ -100,6 +100,11 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
         useNativeDriver: true
       }).start();
     };
+    if (this.props.itemsPerPage !== prevProps.itemsPerPage) {
+      this.setState({
+        itemWidth: this.getItemWidth(this.state.containerWidth)
+      });
+    }
     if (this.props.items.length <= this.state.currentIndex) {
       if (this.props.items.length) {
         this.setState({

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -97,6 +97,11 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
         toValue: 1
       }).start();
     };
+    if (this.props.itemsPerPage !== prevProps.itemsPerPage) {
+      this.setState({
+        itemWidth: this.getItemWidth(this.state.containerWidth)
+      });
+    }
     if (this.props.items.length <= this.state.currentIndex) {
       if (this.props.items.length) {
         this.setState({


### PR DESCRIPTION
In my use case, I am passing state into the `itemsPerPage`. This was causing an issue where `onLayout` was being called before the component received the new `itemsPerPage` prop and wasn't updating `this.state.itemWidth` appropriate, since the only place where that is set is in the `onLayout` function. Setting the new `itemWidth` will allow the user to dynamically update `itemsPerPage` and see their changes propagated without firing `onLayout`.