### PR TITLE
chore: disable shallow clone for publish stage of ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ jobs:
     - yarn ship:build-ios || travis_terminate 1
   - stage: deploy
     if: branch = master AND head_branch IS blank
+    git:
+      depth: false
     before_install: npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN} -q
     script:
     - yarn prepare


### PR DESCRIPTION
Lerna publish is failing on Travis with invalid tag names, and my suspicion based on some Github comments is that Lerna is unable to properly read the history because Travis defaults to shallow clones of repos.

This turns of shallow cloning for the deploy stage to attempt to resolve this issue. https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth