### PR TITLE
feat(fscomponents): add onblur and translations to multi carousel arrows

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
@@ -8,6 +8,8 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
+import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
+
 import { MultiCarouselProps } from './MultiCarouselProps';
 import { PageIndicator } from '../PageIndicator';
 
@@ -332,7 +334,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
           !!this.props.showArrow && (
             <TouchableOpacity
               accessibilityRole='button'
-              accessibilityLabel={'Show previous'}
+              accessibilityLabel={FSI18n.string(translationKeys.flagship.multiCarousel.prevBtn)}
               style={[S.goToPrev, this.props.prevArrowContainerStyle]}
               onPress={this.goToPrev}
             >
@@ -344,7 +346,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
           !!this.props.showArrow && (
             <TouchableOpacity
               accessibilityRole='button'
-              accessibilityLabel={'Show next'}
+              accessibilityLabel={FSI18n.string(translationKeys.flagship.multiCarousel.nextBtn)}
               style={[S.goToNext, this.props.nextArrowContainerStyle]}
               onPress={this.goToNext}
             >

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -7,10 +7,11 @@ import {
   View
 } from 'react-native';
 import { findDOMNode } from 'react-dom';
+import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
+
 import { MultiCarouselProps } from './MultiCarouselProps';
 import { animatedScrollTo } from '../../lib/helpers';
 import { PageIndicator } from '../PageIndicator';
-
 
 const ScrollViewCopy: any = ScrollView;
 
@@ -326,26 +327,30 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
 
         {this.state.currentIndex !== 0 &&
           !!this.props.showArrow && (
-            <TouchableOpacity
-              accessibilityRole='button'
-              accessibilityLabel={'Show previous'}
-              style={[S.goToPrev, this.props.prevArrowContainerStyle]}
-              onPress={this.goToPrev}
-            >
-              <View style={[S.buttonPrevIcon, this.props.prevArrowStyle]} />
-            </TouchableOpacity>
+            <div onBlur={this.props.prevArrowOnBlur}>
+              <TouchableOpacity
+                accessibilityRole='button'
+                accessibilityLabel={FSI18n.string(translationKeys.flagship.multiCarousel.prevBtn)}
+                style={[S.goToPrev, this.props.prevArrowContainerStyle]}
+                onPress={this.goToPrev}
+              >
+                <View style={[S.buttonPrevIcon, this.props.prevArrowStyle]} />
+              </TouchableOpacity>
+            </div>
           )}
 
         {this.state.currentIndex !== pageNum - 1 &&
           !!this.props.showArrow && (
-            <TouchableOpacity
-              accessibilityRole='button'
-              accessibilityLabel={'Show next'}
-              style={[S.goToNext, this.props.nextArrowContainerStyle]}
-              onPress={this.goToNext}
-            >
-              <View style={[S.buttonNextIcon, this.props.nextArrowStyle]} />
-            </TouchableOpacity>
+            <div onBlur={this.props.nextArrowOnBlur}>
+              <TouchableOpacity
+                accessibilityRole='button'
+                accessibilityLabel={FSI18n.string(translationKeys.flagship.multiCarousel.nextBtn)}
+                style={[S.goToNext, this.props.nextArrowContainerStyle]}
+                onPress={this.goToNext}
+              >
+                <View style={[S.buttonNextIcon, this.props.nextArrowStyle]} />
+              </TouchableOpacity>
+            </div>
           )}
 
         <style>

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarouselProps.ts
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarouselProps.ts
@@ -20,10 +20,12 @@ export interface MultiCarouselProps<ItemT> {
   onSlideChange?: (data: SlideChangeEvent) => void;
   nextArrowContainerStyle?: any;
   nextArrowStyle?: any;
+  nextArrowOnBlur?: () => void;
   pageIndicatorStyle?: any;
   peekSize?: number;
   prevArrowContainerStyle?: any;
   prevArrowStyle?: any;
+  prevArrowOnBlur?: () => void;
   renderItem: (data: any, i: number) => ReactNode;
   renderPageIndicator?: (currentIndex: number, itemsCount: number) => ReactNode;
   showArrow?: boolean;

--- a/packages/fsi18n/src/translations/en.ts
+++ b/packages/fsi18n/src/translations/en.ts
@@ -236,6 +236,10 @@ export const keys: FSTranslationKeys = {
     },
     selector: {
       close: 'Close'
+    },
+    multiCarousel: {
+      prevBtn: 'Show previous',
+      nextBtn: 'Show next'
     }
   }
 };

--- a/packages/fsi18n/src/types.ts
+++ b/packages/fsi18n/src/types.ts
@@ -37,6 +37,7 @@ export interface FSTranslationKeys<KeyType = TranslationKey> extends Translation
     checkout: CheckoutTranslations<KeyType>;
     step: StepTranslations<KeyType>;
     selector: SelectorTranslations<KeyType>;
+    multiCarousel: MultiCarouselTranslations<KeyType>;
   };
 }
 
@@ -283,4 +284,9 @@ export interface StepTranslations<KeyType> {
 
 export interface SelectorTranslations<KeyType> {
   close: KeyType;
+}
+
+export interface MultiCarouselTranslations<KeyType> {
+  prevBtn: KeyType;
+  nextBtn: KeyType;
 }


### PR DESCRIPTION
This adds the following for prev/next arrows on MultiCarousel:
 - Added accessibility labels into FSI18N so they're not hardcoded strings
 - Adds optional onblur property for use on web