### PR TITLE
chore: remove xcode build from push ci step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,21 +65,6 @@ jobs:
     - pod repo update
     - yarn ship:init
     - yarn ship:compile-ios || travis_terminate 1
-  - language: objective-c
-    if: type = push AND branch = master
-    os: osx
-    osx_image: xcode10.1
-    env:
-    - KEY_CHAIN=ios-build.keychain
-    before_install:
-    - nvm install 10
-    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.7.0
-    - export PATH=$HOME/.yarn/bin:$PATH
-    - node --version
-    - yarn --version
-    script:
-    - yarn prepare
-    - yarn ship:build-ios || travis_terminate 1
   - stage: deploy
     if: branch = master AND head_branch IS blank
     git:


### PR DESCRIPTION
This removes the Xcode build phase of CI when code is pushed to master. This has been erroring due to issues with the PirateShip provisioning profile. After consideration, I decided that this was unnecessary as we already perform an iOS compile on pull requests so this shouldn't be needed as long as we follow proper protocol in requiring CI to pass before merging pull requests.