### PR TITLE
fix(fsproductindex): Update commerce data even if no products

### DIFF
--- a/packages/fsproductindex/src/components/ProductIndexProvider.tsx
+++ b/packages/fsproductindex/src/components/ProductIndexProvider.tsx
@@ -180,6 +180,9 @@ function withProductIndexData<
           !Array.isArray(commerceData.products) ||
           commerceData.products.length === 0
         ) {
+          this.setState({
+            commerceData
+          });
           return;
         }
 


### PR DESCRIPTION
Currently, the ProductIndexProvider component keeps a separate state variable for commerceData, which only gets updated if there are products to request reviews for. If there is an update where there were products before, but there no longer are, then the update does not make it through the provider.