### PR TITLE
fix(fscomponents): revert buggy button refactor

### DIFF
--- a/packages/fscomponents/src/components/Button.tsx
+++ b/packages/fscomponents/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import {
   Image,
   ImageSourcePropType,
@@ -22,22 +22,6 @@ import {
 import { Loading } from './Loading';
 
 const DEFAULT_TINT_PERC = 15;
-
-export interface Palette {
-  primary: string;
-  secondary: string;
-  accent: string;
-  error: string;
-  background: string;
-  surface: string;
-  onPrimary: string;
-  onSecondary: string;
-  onAccent: string;
-  onBackground: string;
-  onSurface: string;
-  onError: string;
-  [key: string]: string;
-}
 
 export interface ButtonProps extends Pick<TouchableHighlightProperties, 'hitSlop'> {
   title: string;
@@ -68,24 +52,65 @@ export interface ButtonProps extends Pick<TouchableHighlightProperties, 'hitSlop
   full?: boolean;
 }
 
-export const Button = (props: ButtonProps) => {
-  const {
-    title,
-    style = {},
-    onPress,
-    onLongPress,
-    underlayColor,
-    full,
-    accessibilityLabel,
-    hitSlop,
-    size = 'medium',
-    color = 'primary',
-    light,
-    link,
-    disabled
-  } = props;
+export interface ButtonState {
+  palette: any;
+}
 
-  const renderButtonInner = () => {
+export class Button extends PureComponent<ButtonProps, ButtonState> {
+  state: ButtonState = {
+    palette: this.props.palette || palette
+  };
+
+  render(): any {
+    const {
+      title,
+      style = {},
+      onPress,
+      onLongPress,
+      underlayColor,
+      full,
+      accessibilityLabel,
+      hitSlop,
+      size = 'medium',
+      color = 'primary',
+      light,
+      link,
+      disabled
+    } = this.props;
+
+    const { palette } = this.state;
+
+    return (
+      <TouchableHighlight
+        accessibilityLabel={accessibilityLabel || title}
+        accessibilityRole='button'
+        onPress={onPress}
+        onLongPress={onLongPress}
+        underlayColor={
+          underlayColor || darken(palette[color], DEFAULT_TINT_PERC)
+        }
+        disabled={disabled}
+        hitSlop={hitSlop}
+        style={[
+          S.container,
+          {
+            backgroundColor: light || link ? 'transparent' : palette[color],
+            borderColor: light ? palette[color] : undefined,
+            borderWidth: light ? border.width : 0
+          },
+          stylesSize[size],
+          full && S.full,
+          style
+        ]}
+      >
+        <View style={S.buttonInner}>
+          {this.renderButtonInner()}
+        </View>
+      </TouchableHighlight>
+    );
+  }
+
+  private renderButtonInner = () => {
     const {
       loading,
       icon,
@@ -96,16 +121,11 @@ export const Button = (props: ButtonProps) => {
       size = 'medium',
       color = 'primary',
       light,
-      link,
-      palette
-    } = props;
+      link
+    } = this.props;
 
-    // color prop is passed as a string representing the key on palette, ie. "primary" or
-    // "onAcccent". Defaults to "primary", and applied to button background color
+    const { palette } = this.state;
     const onColor = 'on' + color.charAt(0).toUpperCase() + color.slice(1);
-    const newPalette: Palette | undefined = props.palette ? props.palette : palette;
-    const newColor = newPalette &&
-      { color: light || link ? newPalette[color] : newPalette[onColor] };
 
     if (loading) {
       return <Loading />;
@@ -116,7 +136,7 @@ export const Button = (props: ButtonProps) => {
           <Text
             style={[
               S.text,
-              newColor,
+              { color: light || link ? palette[color] : palette[onColor] },
               stylesTextSize[size],
               titleStyle
             ]}
@@ -126,35 +146,5 @@ export const Button = (props: ButtonProps) => {
         </View>
       );
     }
-  };
-
-  return (
-    <TouchableHighlight
-      accessibilityLabel={accessibilityLabel || title}
-      accessibilityRole='button'
-      onPress={onPress}
-      onLongPress={onLongPress}
-      underlayColor={
-        underlayColor || darken(palette[color], DEFAULT_TINT_PERC)
-      }
-      disabled={disabled}
-      hitSlop={hitSlop}
-      style={[
-        S.container,
-        {
-          backgroundColor: light || link ? 'transparent' : palette[color],
-          borderColor: light ? palette[color] : undefined,
-          borderWidth: light ? border.width : 0
-        },
-        stylesSize[size],
-        full && S.full,
-        style
-      ]}
-    >
-      <View style={S.buttonInner}>
-        {renderButtonInner()}
-      </View>
-    </TouchableHighlight>
-  );
-};
-
+  }
+}


### PR DESCRIPTION
This reverts the SFC refactor from #415 as it introduced regressions such as not being to provide a palette as a prop to override the default styling. It does re-implement the accessibility update added in #587.