### PR TITLE
fix(flagship): put placeholders back for using exception domains

### DIFF
--- a/packages/flagship/ios/FLAGSHIP/Info.plist
+++ b/packages/flagship/ios/FLAGSHIP/Info.plist
@@ -39,11 +39,10 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
+			<!-- {NSExceptionDomains-localhost-start} -->
+			<key>localhost</key><dict><key>NSExceptionAllowsInsecureHTTPLoads</key><true/></dict>
+			<!-- {NSExceptionDomains-localhost-end} -->
+			<!-- {NSExceptionDomains} -->
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
The changes put placeholders back for ios [script](https://github.com/brandingbrand/flagship/blob/master/packages/flagship/src/lib/ios.ts#L192) to add exception domains