### PR TITLE
Revert "feat(fsapp): Track whether the drawer is visible"

### DIFF
--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -19,7 +19,6 @@
     "path-to-regexp": "^2.2.1",
     "qs": "^6.7.0",
     "react": "16.6.3",
-    "react-dom": "^16.3.2",
     "react-native": "0.57.8",
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^0.29.1",

--- a/packages/fsapp/src/components/Drawer.web.tsx
+++ b/packages/fsapp/src/components/Drawer.web.tsx
@@ -4,7 +4,6 @@ import {
   StyleSheet,
   View
 } from 'react-native';
-import ReactDOM from 'react-dom';
 
 export interface PropType {
   component: typeof React.Component;
@@ -13,10 +12,6 @@ export interface PropType {
   width: string;
   duration: string;
   backgroundColor?: string;
-}
-
-export interface DrawerState {
-  drawerVisible: boolean;
 }
 
 const DEFAULT_BACKGROUND_COLOR = 'white';
@@ -45,46 +40,7 @@ const S = StyleSheetCreate({
   }
 });
 
-export default class Drawer extends Component<PropType, DrawerState> {
-  drawView?: any;
-
-  constructor(props: PropType) {
-    super(props);
-    this.state = {
-      drawerVisible: props.isOpen
-    };
-  }
-
-  componentDidUpdate = (prevProps: PropType, prevState: DrawerState): void => {
-    if (this.props.isOpen && !this.state.drawerVisible) {
-      this.setState({
-        drawerVisible: true
-      });
-    }
-  }
-
-  componentWillUnmount = (): void => {
-    if (this.drawView) {
-      this.drawView.removeEventListener('transitionend', this.animationListener);
-    }
-  }
-
-  animationListener = (e: any): void => {
-    if (!this.props.isOpen) {
-      this.setState({
-        drawerVisible: false
-      });
-    }
-  }
-
-  animationRef = (ref: any): void => {
-    if (this.drawView) {
-      this.drawView.removeEventListener('transitionend', this.animationListener);
-    }
-    this.drawView = ReactDOM.findDOMNode(ref);
-    this.drawView.addEventListener('transitionend', this.animationListener);
-  }
-
+export default class Drawer extends Component<PropType> {
   render(): JSX.Element {
     const width = this.props.width;
     const DrawerComponent = this.props.component;
@@ -109,14 +65,8 @@ export default class Drawer extends Component<PropType, DrawerState> {
     }
 
     return (
-      <View
-        style={[S.container, propCss, orientationStyle, !this.props.isOpen && closedCss]}
-        ref={this.animationRef}
-      >
-        <DrawerComponent
-          drawerVisible={this.state.drawerVisible}
-          {...this.props}
-        />
+      <View style={[S.container, propCss, orientationStyle, !this.props.isOpen && closedCss]}>
+        <DrawerComponent {...this.props} />
       </View>
     );
   }


### PR DESCRIPTION
Reverts brandingbrand/flagship#658

@Cauldrath  - I'm not sure why I didn't catch this during testing but this is throwing errors for me consistently now when doing `yarn run ship:compile-web`:

```
index.ts:3 Uncaught TypeError: Cannot read property 'addEventListener' of null
    at Drawer._this.animationRef (index.ts:3)
    at HTMLUnknownElement.callCallback (index.ts:3)
    at Object.invokeGuardedCallbackDev (index.ts:3)
    at invokeGuardedCallback (index.ts:3)
    at safelyDetachRef (index.ts:3)
    at commitUnmount (index.ts:3)
    at commitNestedUnmounts (index.ts:3)
    at unmountHostComponents (index.ts:3)
    at commitDeletion (index.ts:3)
    at commitAllHostEffects (index.ts:3)
```