### PR TITLE
feat(fsproductindex): Add functionality for loading previous pages

### DIFF
--- a/packages/fscommerce/src/Commerce/CommerceProvider.tsx
+++ b/packages/fscommerce/src/Commerce/CommerceProvider.tsx
@@ -224,6 +224,10 @@ function withCommerceData<P, Data extends {}, Source = CommerceDataSource>(
           const { commerceData } = this.state;
 
           if (data && commerceData) {
+            if ((commerceData as any).minPage === undefined) {
+              (commerceData as any).minPage = (commerceData as any).page;
+            }
+            (data as any).minPage = (commerceData as any).minPage;
             // TODO: Since the data isn't guarneteed to be Pagable we have to cast to any to check.
             // Figure out a way to not include this function for non-pagable Data types
             if ((data as any).page > (commerceData as any).page) {
@@ -231,7 +235,14 @@ function withCommerceData<P, Data extends {}, Source = CommerceDataSource>(
                 ...(commerceData as any).products,
                 ...(data as any).products
               ];
-
+              this.setData(data);
+            } else if ((data as any).page < (commerceData as any).minPage) {
+              (data as any).products = [
+                ...(data as any).products,
+                ...(commerceData as any).products
+              ];
+              (data as any).minPage = (data as any).page;
+              (data as any).page = (commerceData as any).page;
               this.setData(data);
             }
           }

--- a/packages/fscommerce/src/Commerce/types/Pageable.ts
+++ b/packages/fscommerce/src/Commerce/types/Pageable.ts
@@ -13,4 +13,12 @@ export default interface Pageable {
    * @example 10
    */
   limit: number;
+
+  /**
+   * The page number of the first page of products if the data represents a range of pages
+   *
+   * @example 3
+   */
+  minPage?: number;
+
 }

--- a/packages/fsproductindex/src/components/ProductIndex.tsx
+++ b/packages/fsproductindex/src/components/ProductIndex.tsx
@@ -54,6 +54,7 @@ export interface UnwrappedProductIndexProps {
     handleFilterReset: Function,
     commerceData: CommerceTypes.ProductIndex
   ) => JSX.Element;
+  renderLoadPrev?: (loadPrev: Function, hasAnotherPage: boolean) => JSX.Element;
   renderLoadMore?: (loadMore: Function, hasAnotherPage: boolean) => JSX.Element;
   renderLoading?: () => JSX.Element;
   renderNoResult?: (

--- a/packages/fsproductindex/src/components/ProductIndexGrid.tsx
+++ b/packages/fsproductindex/src/components/ProductIndexGrid.tsx
@@ -37,7 +37,6 @@ export interface StateType {
   filterModalVisble: boolean;
   isLoading: boolean;
   isMoreLoading: boolean;
-  hasAnotherPage: boolean;
   hasFetchError: boolean;
 }
 
@@ -45,38 +44,54 @@ export default class ProductIndexGrid extends Component<
   PropTyps & WithProductIndexProps,
   StateType
 > {
-  page: number = 1;
-
   constructor(props: PropTyps & WithProductIndexProps) {
     super(props);
 
     const { commerceData, onLoadComplete } = props;
-
-    const hasAnotherPage = this.hasAnotherPage(commerceData);
+    let maxPageLoaded = 1;
+    let maxCount = 1;
+    if (commerceData) {
+      maxCount = this.maxCount(commerceData);
+      if (commerceData.page) {
+        maxPageLoaded = commerceData.page;
+        if (commerceData.limit && commerceData.products) {
+          maxCount = (commerceData.limit * (commerceData.page - 1)) + commerceData.products.length;
+        }
+      }
+      if (onLoadComplete) {
+        onLoadComplete(this.loadMore, maxPageLoaded < this.maxPage(commerceData),
+          maxCount, maxCount);
+      }
+    }
 
     this.state = {
       sortModalVisble: false,
       filterModalVisble: false,
       isLoading: false,
       isMoreLoading: false,
-      hasFetchError: false,
-      hasAnotherPage
+      hasFetchError: false
     };
 
-    if (commerceData && onLoadComplete) {
-      const count = commerceData.products && commerceData.products.length;
+  }
 
-      onLoadComplete(this.loadMore, hasAnotherPage, count, count);
+  maxCount = (commerceData?: CommerceTypes.ProductIndex): number => {
+    if (commerceData && commerceData.limit && commerceData.total && commerceData.page) {
+      const maxPage = this.maxPage(commerceData);
+      if (commerceData.page < maxPage) {
+        return commerceData.page * commerceData.limit;
+      } else {
+        return commerceData.total;
+      }
+    } else {
+      return 0;
     }
   }
 
-  hasAnotherPage = (data?: CommerceTypes.ProductIndex) => {
-    if (!data || !data.page || !data.total) {
-      return false;
+  maxPage = (commerceData?: CommerceTypes.ProductIndex) => {
+    if (commerceData && commerceData.total && commerceData.limit) {
+      return Math.ceil(commerceData.total / commerceData.limit);
     }
-
-    // fall back to count instead of limit in instances where limit wasn't specified in query
-    return data.page * (data.limit || data.products.length) < data.total;
+    return 1;
   }
 
   renderItem = ({ item }: ListRenderItemInfo<CommerceTypes.Product>): JSX.Element => {
@@ -104,7 +119,7 @@ export default class ProductIndexGrid extends Component<
     );
   }
 
-  renderHeader = () => {
+  renderActionBar = () => {
     const {
       commerceData,
       hideActionBar,
@@ -133,6 +148,43 @@ export default class ProductIndexGrid extends Component<
         sortButtonStyle={mergeSortToFilter ? { display: 'none' } : null}
         {...refineActionBarProps}
       />
+    );
+  }
+
+  renderHeader = () => {
+    const { commerceData } = this.props;
+
+    if (!commerceData) {
+      return null;
+    }
+
+    let loadPrev: JSX.Element | null = null;
+    if (this.props.renderLoadPrev) {
+      if (this.state.isMoreLoading) {
+        loadPrev = this.props.renderLoading ? (
+          this.props.renderLoading()
+        ) : (
+          <Loading
+            style={[
+              S.loading,
+              S.loadingLoadMore,
+              this.props.loadMoreLoadingStyle
+            ]}
+          />
+        );
+      } else {
+        loadPrev = this.props.renderLoadPrev(
+          this.loadPrev,
+          (commerceData.minPage || commerceData.page || 1) > 1
+        );
+      }
+    }
+
+    return (
+      <View>
+        {loadPrev}
+        {this.renderActionBar()}
+      </View>
     );
   }
 
@@ -208,7 +260,12 @@ export default class ProductIndexGrid extends Component<
   reloadByQuery = (query: CommerceTypes.ProductQuery) => {
     this.setState({ isLoading: true, hasFetchError: false });
     this.fetchByExtraQuery(query)
-      .then(this.handleNewData)
+      .then((data: CommerceTypes.ProductIndex) => {
+        this.handleNewData(data);
+        this.setState({
+          isLoading: false
+        });
+      })
       .catch(() => {
         this.setState({
           isLoading: false,
@@ -240,6 +297,9 @@ export default class ProductIndexGrid extends Component<
           this.closeFilterModal();
         }
         this.handleNewData(data);
+        this.setState({
+          isLoading: false
+        });
       })
       .catch(() => {
         this.setState({
@@ -249,17 +309,16 @@ export default class ProductIndexGrid extends Component<
       });
   }
 
-  handleNewData = (data: any) => {
-    this.page = 1;
-    const hasAnotherPage = this.hasAnotherPage(data);
+  handleNewData = (data: CommerceTypes.ProductIndex) => {
+    const newState: any = {};
+    const maxPageLoaded = data.page || 1;
+    const maxCount = this.maxCount(data);
+
     if (this.props.onLoadComplete) {
-      const count = data.products && data.products.length;
-      this.props.onLoadComplete(this.loadMore, hasAnotherPage, count, count);
+      this.props.onLoadComplete(this.loadMore, maxPageLoaded < this.maxPage(data),
+        maxCount, maxCount);
     }
-    this.setState({
-      isLoading: false,
-      hasAnotherPage
-    });
+    this.setState(newState);
 
     if (this.props.commerceLoadData) {
       this.props.commerceLoadData(data);
@@ -597,13 +656,13 @@ export default class ProductIndexGrid extends Component<
     );
   }
 
-  loadMore = () => {
+  loadPage = (page: number) => {
     const {
       commerceData,
       commerceProviderLoadMore
     } = this.props;
 
-    if (!commerceData || !commerceData.page) {
+    if (!commerceData) {
       // Cannot load more
       return;
     }
@@ -612,29 +671,13 @@ export default class ProductIndexGrid extends Component<
       isMoreLoading: true
     });
 
-    const newQuery = this.newProductQuery({ page: commerceData.page + 1 });
+    const newQuery = this.newProductQuery({ page });
     if (commerceProviderLoadMore) {
       commerceProviderLoadMore(newQuery)
-        .then(data => {
-          const hasAnotherPage = this.hasAnotherPage(data);
-          let totalCount: number = 0;
-
-          // TODO: Pageable properties should not be optional on Product Index type
-          if (data.limit && data.page) {
-            totalCount = (data.limit * (data.page - 1)) + data.products.length;
-          }
-
-          if (this.props.onLoadComplete) {
-            this.props.onLoadComplete(
-              this.loadMore,
-              hasAnotherPage,
-              totalCount,
-              data.products.length
-            );
-          }
+        .then((data: CommerceTypes.ProductIndex) => {
+          this.handleNewData(data);
           this.setState({
-            isMoreLoading: false,
-            hasAnotherPage
+            isMoreLoading: false
           });
         })
         .catch(() => {
@@ -645,7 +688,24 @@ export default class ProductIndexGrid extends Component<
     }
   }
 
+  loadPrev = () => {
+    const { commerceData } = this.props;
+    if (commerceData) {
+      this.loadPage((commerceData.minPage || commerceData.page || 1) - 1);
+    }
+  }
+
+  loadMore = () => {
+    const { commerceData } = this.props;
+    if (commerceData) {
+      this.loadPage((commerceData.page || 1) + 1);
+    }
+  }
+
   renderFooter = () => {
+    const { commerceData } = this.props;
+    const hasAnotherPage: boolean = commerceData !== undefined && commerceData.page !== undefined &&
+      commerceData.page < this.maxPage(commerceData);
     if (this.state.isMoreLoading) {
       return this.props.renderLoading ? (
         this.props.renderLoading()
@@ -663,11 +723,11 @@ export default class ProductIndexGrid extends Component<
     if (this.props.renderLoadMore) {
       return this.props.renderLoadMore(
         this.loadMore,
-        this.state.hasAnotherPage
+        hasAnotherPage
       );
     }
 
-    if (!this.state.hasAnotherPage) {
+    if (!hasAnotherPage) {
       return null;
     }
 


### PR DESCRIPTION
Currently you can load more, but if you start on a later page, you can not load previous pages. This adds that as an additional option and also adds a minPage value to Pageables, so that it can track the range of pages loaded with load more or load previous. Functionality should be unchanged for pages without load previous turned on or that don't look at the minPage value.