### PR TITLE
chore: react native 0.59 bug fixes

### DIFF
--- a/packages/flagship/android/app/src/debug/AndroidManifest.xml
+++ b/packages/flagship/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+</manifest>

--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -43,7 +43,7 @@ ext {
     compileSdkVersion = 28
     targetSdkVersion = 28
     supportLibVersion = "28.0.0"
-    googlePlayServicesVersion = "16.1.0" // Needed for react-native-camera & react-native-maps
+    googlePlayServicesVersion = "16.+" // Needed for react-native-camera & react-native-maps
 }
 
 // Force subprojects to use the same SDK and build tools

--- a/packages/flagship/src/lib/modules/android/react-native-camera.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-camera.ts
@@ -31,15 +31,5 @@ export function postLink(configuration: Config): void {
   fs.writeFileSync(path.android.gradlePropertiesPath(), gradleProps);
   logInfo('disabled aapt2 in gradle.properties');
 
-  // Add dependencies to /android/build.gradle and update gradle version to 3.1.3
-  let gradleBuild = fs.readFileSync(path.resolve('android', 'build.gradle'), { encoding: 'utf8' });
-  gradleBuild = gradleBuild.replace(
-    /(com\.android\.tools\.build:gradle:)[\d\.]+/,
-    '$13.1.3'
-  );
-
-  fs.writeFileSync(path.resolve('android', 'build.gradle'), gradleBuild);
-  logInfo('updated ./android/build.gradle');
-
   logInfo('finished updating Android for react-native-camera');
 }

--- a/packages/flagship/src/lib/modules/android/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-firebase.ts
@@ -70,11 +70,6 @@ export function postLink(configuration: Config): void {
     `$1\n        google()`
   );
 
-  gradleBuild = gradleBuild.replace(
-    /(com\.android\.tools\.build:gradle:)[\d\.]+/,
-    '$13.1.3'
-  );
-
   fs.writeFileSync(path.resolve('android', 'build.gradle'), gradleBuild);
   logInfo('updated ./android/build.gradle');
 


### PR DESCRIPTION
- Adds missing debug AndroidManifest file
- Changes playServicesVersion to 16.+
- Removes module scripts that change the gradle version