### PR TITLE
fix(fscomponents): ease in carousel when there is itemUpdated

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.tsx
@@ -1,6 +1,7 @@
 import React, { Component, RefObject } from 'react';
 import {
   Animated,
+  Easing,
   FlatList,
   ListRenderItemInfo,
   Platform,
@@ -88,6 +89,16 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
       itemWidth: 0,
       opacity: new Animated.Value(this.props.itemUpdated ? 0 : 1)
     };
+  }
+
+  componentDidMount(): void {
+    if (this.props.itemUpdated) {
+      Animated.timing(this.state.opacity, {
+        toValue: 1,
+        easing: Easing.in(Easing.cubic),
+        useNativeDriver: true
+      }).start();
+    }
   }
 
   componentDidUpdate(


### PR DESCRIPTION
### Issue:
The multi carousel is not showing when there's itemUpdated in the props

### Cause of the Issue:
The initial opacity is set to 0 when there's itemUpdated in the props, but nothing triggers opacity change when first render

### Resolve by:
Trigger opacity change when first mounted if there's itemUpdated.
