### PR TITLE
fix: add initialTabIndex prop to tabStyle

### DIFF
--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -26,6 +26,7 @@ export interface TabStyle {
   tabBarSelectedLabelColor?: string;
   forceTitlesDisplay?: boolean;
   tabBarHideShadow?: boolean;
+  initialTabIndex?: number;
 }
 
 export interface AppStyle extends TabStyle {


### PR DESCRIPTION
This PR adds the `initialTabIndex` property to `tabStyle`.