### PR TITLE
fix: engagement flicker on scroll of items

### DIFF
--- a/packages/fsengagement/src/EngagementComp.tsx
+++ b/packages/fsengagement/src/EngagementComp.tsx
@@ -260,7 +260,7 @@ export default function(
           ...props,
           storyGradient: props.story ? json.storyGradient : null,
           api,
-          key: Math.floor(Math.random() * 1000000)
+          key: this.dataKeyExtractor(item)
         },
         private_blocks && private_blocks.map(this.renderBlock)
       );
@@ -379,6 +379,7 @@ export default function(
       return (
         <FlatList
           data={this.props.json.private_blocks || []}
+          keyExtractor={this.dataKeyExtractor}
           renderItem={this.renderBlockItem}
           ListEmptyComponent={(
             <Text style={[styles.emptyMessage, empty.textStyle]}>
@@ -417,6 +418,10 @@ export default function(
             </Text>}
         </View>
       );
+    }
+
+    dataKeyExtractor = (item: BlockItem): string => {
+      return item.id || item.key || Math.floor(Math.random() * 1000000).toString();
     }
   };
 }

--- a/packages/fsengagement/src/inboxblocks/CTABlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/CTABlock.tsx
@@ -105,6 +105,14 @@ export default class CTABlock extends Component<CTABlockProps> {
     this.takeAction(this.props.action, this.props.actions);
   }
 
+  shouldComponentUpdate(nextProps: CTABlockProps): boolean {
+    return nextProps.buttonStyle !== this.props.buttonStyle ||
+      nextProps.textStyle !== this.props.textStyle ||
+      nextProps.containerStyle !== this.props.containerStyle ||
+      nextProps.text !== this.props.text ||
+      nextProps.icon !== this.props.icon;
+  }
+
   render(): JSX.Element {
     const {
       buttonStyle,

--- a/packages/fsengagement/src/inboxblocks/EventBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/EventBlock.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import {
   StyleProp,
   StyleSheet,
@@ -64,7 +64,15 @@ const whenIcon = require('../../assets/images/whenIcon.png');
 const whereIcon = require('../../assets/images/whereIcon.png');
 const whyIcon = require('../../assets/images/whyIcon.png');
 
-export default class EventBlock extends PureComponent<EventBlockProps> {
+export default class EventBlock extends Component<EventBlockProps> {
+
+  shouldComponentUpdate(nextProps: EventBlockProps): boolean {
+    return nextProps.textStyle !== this.props.textStyle ||
+      nextProps.titleStyle !== this.props.titleStyle ||
+      nextProps.containerStyle !== this.props.containerStyle ||
+      nextProps.eventInfo !== this.props.eventInfo;
+  }
+
   render(): JSX.Element {
     const {
       textStyle,

--- a/packages/fsengagement/src/inboxblocks/ImageBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/ImageBlock.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import {
   Dimensions,
   Image,
@@ -24,12 +24,25 @@ export interface ImageBlockState {
   height?: number;
 }
 
-export default class ImageBlock extends PureComponent<ImageBlockProps, ImageBlockState> {
+export default class ImageBlock extends Component<ImageBlockProps, ImageBlockState> {
   readonly state: ImageBlockState = {};
 
   componentDidMount(): void {
     this.setState(this.findImageRatio());
   }
+
+  shouldComponentUpdate(nextProps: ImageBlockProps, nextState: ImageBlockState): boolean {
+    return this.props.containerStyle !== nextProps.containerStyle ||
+      this.props.imageStyle !== nextProps.imageStyle ||
+      this.props.ratio !== nextProps.ratio ||
+      this.props.resizeMethod !== nextProps.resizeMethod ||
+      this.props.resizeMode !== nextProps.resizeMode ||
+      this.props.source !== nextProps.source ||
+      this.props.useRatio !== nextProps.useRatio ||
+      this.state.height !== nextState.height ||
+      this.state.width !== nextState.width;
+  }
+
   _onLayout = (event: LayoutChangeEvent) => {
     const { ratio, useRatio } = this.props;
     if (useRatio && ratio) {

--- a/packages/fsengagement/src/inboxblocks/ShareBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/ShareBlock.tsx
@@ -63,6 +63,13 @@ export default class ShareBlock extends Component<ShareBlockProps> {
     });
   }
 
+  shouldComponentUpdate(nextProps: ShareBlockProps): boolean {
+    return nextProps.imageSrc !== this.props.imageSrc ||
+      nextProps.imageStyle !== this.props.imageStyle ||
+      nextProps.underlayColor !== this.props.underlayColor ||
+      nextProps.containerStyle !== this.props.containerStyle;
+  }
+
   render(): JSX.Element {
     const {
       imageSrc,

--- a/packages/fsengagement/src/inboxblocks/TextBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/TextBlock.tsx
@@ -18,6 +18,12 @@ export interface TextBlockProps {
   containerStyle?: StyleProp<TextStyle>;
 }
 export default class TextBlock extends Component<TextBlockProps> {
+
+  shouldComponentUpdate(nextProps: TextBlockProps): boolean {
+    return nextProps.textStyle !== this.props.textStyle ||
+      nextProps.containerStyle !== this.props.containerStyle ||
+      nextProps.text !== this.props.text;
+  }
   render(): JSX.Element {
     const {
       textStyle,

--- a/packages/fsengagement/src/types.ts
+++ b/packages/fsengagement/src/types.ts
@@ -78,6 +78,8 @@ export interface JSON {
   pageNumberStyle?: StyleProp<TextStyle>;
   navBarTitleStyle?: StyleProp<TextStyle>;
   pageCounterStyle?: StyleProp<ViewStyle>;
+  id?: string;
+  key?: string;
 }
 
 export interface BlockItem extends ScreenProps, JSON {


### PR DESCRIPTION
@deemaabdallah here is the fix for the flickering on the engagement list. There are two parts to the fix.

1.) Making some inbox block components PureComponents
I added shouldComponentUpdate functions to make sure extra re-renders don't occur. I had to use the function instead of PureComponent as each block gets all props so it would still re-render using PureComponent.

2.) adding key to flat list render item
As you scrolled since the keys didn't match it would re-create the element inside the flat list causing the flicker