### PR TITLE
fix(fsengagement): update react-native-video

### DIFF
--- a/packages/fsengagement/package.json
+++ b/packages/fsengagement/package.json
@@ -19,7 +19,7 @@
     "react-native-fcm": "16.0.0",
     "react-native-navigation": "https://github.com/brandingbrand/react-native-navigation#v1",
     "react-native-snap-carousel": "^3.8.0",
-    "react-native-video": "^3.2.1",
+    "react-native-video": "^4.0.0",
     "uuid-js": "0.7.5"
   }
 }


### PR DESCRIPTION
there are compile issues of 3.X react-native-video with Android when compiling with react-native 0.59. Version 4.x has better support with this react-native version for this library.

https://github.com/react-native-community/react-native-video#version-400-breaking-changes
