### PR TITLE
fix(fsapp): Put dev menu as first screen

### DIFF
--- a/packages/fsapp/src/fsapp/FSApp.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.tsx
@@ -35,7 +35,7 @@ export class FSApp extends FSAppBase {
     });
 
     if (this.shouldShowDevMenu()) {
-      enhancedScreens.push({
+      enhancedScreens.unshift({
         key: 'devMenu',
         screen: screenWrapper(DevMenu, this.appConfig, this.api)
       });

--- a/packages/fsapp/src/fsapp/FSApp.web.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.web.tsx
@@ -14,7 +14,10 @@ export class FSApp extends FSAppBase {
 
   registerScreens(): void {
     if (this.shouldShowDevMenu()) {
-      this.appConfig.screens.devMenu = DevMenu as any;
+      this.appConfig.screens = {
+        devMenu: DevMenu as any,
+        ...this.appConfig.screens
+      };
       if (this.appConfig.devMenuPath) {
         this.appConfig.screens.devMenu.path = this.appConfig.devMenuPath;
       }


### PR DESCRIPTION
When there is a collision between the path matching for other screens and the dev menu, this will make the dev menu take priority.

Cherry-pick of https://github.com/brandingbrand/flagship/pull/733

