### PR TITLE
fix(fsweb): Prevent double transpiling of typeof

### DIFF
--- a/packages/fsweb/.babelrc
+++ b/packages/fsweb/.babelrc
@@ -2,7 +2,11 @@
   "presets": [
     "module:metro-react-native-babel-preset",
     ["@babel/preset-env", {
-        "modules": false
+      "exclude": ["transform-typeof-symbol"],
+      "modules": false,
+      "targets": {
+        "browsers": ["last 2 versions", "ie >= 11"]
+      }
     }]
   ],
   "plugins": [

--- a/packages/fsweb/babel.config.js
+++ b/packages/fsweb/babel.config.js
@@ -1,11 +1,12 @@
 module.exports = {
   "presets": [
     "module:metro-react-native-babel-preset",
-    ["@babel/env", {
+    ["@babel/preset-env", {
+      "exclude": ["transform-typeof-symbol"],
+      "modules": false,
       "targets": {
         "browsers": ["last 2 versions", "ie >= 11"]
-      },
-      "modules": false
+      }
     }]
   ],
   "plugins": [


### PR DESCRIPTION
Both metro-react-native-babel-preset and @babel/preset-env transpile "typeof", which causes it to include itself. This prevents the transpiling of typeof in @babel/preset-env. Also made the two babel configs work the same way