### PR TITLE
feat(fsengagement): store engagement profileId

### DIFF
--- a/packages/fsengagement/src/EngagementService.ts
+++ b/packages/fsengagement/src/EngagementService.ts
@@ -141,6 +141,7 @@ export class EngagementService {
 
     const savedProfileId = await AsyncStorage.getItem('ENGAGEMENT_PROFILE_ID');
     if (savedProfileId && typeof savedProfileId === 'string' && !forceProfileSync) {
+      this.profileId = savedProfileId;
       return Promise.resolve(savedProfileId);
     }
 

--- a/packages/fsengagement/src/inboxblocks/VideoBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/VideoBlock.tsx
@@ -21,6 +21,8 @@ export interface VideoBlockProps {
   repeat?: boolean;
   resizeMode?: string;
   style?: any;
+  muted?: boolean;
+  fullscreen?: boolean;
   containerStyle?: StyleProp<TextStyle>;
 }
 
@@ -95,7 +97,9 @@ export default class VideoBlock extends Component<VideoBlockProps, StateType> {
     const {
       resizeMode = 'cover',
       autoPlay = false,
-      repeat = false
+      repeat = false,
+      muted = false,
+      fullscreen = false
     } = this.props;
 
     return (
@@ -103,6 +107,8 @@ export default class VideoBlock extends Component<VideoBlockProps, StateType> {
         <VideoPlayer
           resizeMode={resizeMode}
           repeat={repeat}
+          muted={muted}
+          fullscreen={fullscreen}
           onLoad={this.checkAutoPlay(autoPlay)}
           source={{ uri: src }}
           paused={this.state.videoPaused}


### PR DESCRIPTION
@bweissbart 

- by default save profileId in AsyncStorage (can for `getProfile` request by setting `forceProfileSync` to true)
- for Video component, handle optional props `fullscreen` and `muted`