### PR TITLE
fix(fsweb): add webpack alias for async storage

### DIFF
--- a/packages/fsweb/webpack.config.js
+++ b/packages/fsweb/webpack.config.js
@@ -47,7 +47,8 @@ const globalConfig = {
     ],
     alias: {
       'react-native': 'react-native-web',
-      'react-native-svg': 'svgs'
+      'react-native-svg': 'svgs',
+      '@react-native-community/async-storage': 'react-native-web/dist/exports/AsyncStorage/index.js'
     },
     modules: [
       path.resolve('./node_modules'),


### PR DESCRIPTION
AsyncStorage was replaced with @react-native-community/async-storage in a previous Flagship PR because it's going to be removed from the RN core in 0.60. Because of this change the react-native-web override of AsyncStorage no longer worked. This adds a new Webpack alias from @react-native-community/async-storage to the react-native-web implementation to fix Webpack compilation errors.