### PR TITLE
fix(fsweb): tag type of css bundle

### DIFF
--- a/packages/fsweb/dev-server/index.html
+++ b/packages/fsweb/dev-server/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
   <meta name="theme-color" content="#000000">
   <title>Flagship Dev</title>
-  <meta rel="stylesheet" href="/static/css/bundle.css">
+  <link rel="stylesheet" href="/static/css/bundle.css">
 </head>
 
 <body>


### PR DESCRIPTION
running default template wasn't loading css correctly unless you created index.html in your project 