### PR TITLE
fix(fsweb): Lock webpack version to 4.39.3

### DIFF
--- a/packages/fsweb/package.json
+++ b/packages/fsweb/package.json
@@ -32,7 +32,7 @@
     "sw-precache-webpack-plugin": "^0.11.5",
     "ts-loader": "^4.3.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
-    "webpack": "^4.16.5",
+    "webpack": "4.39.3",
     "webpack-bundle-size-analyzer": "^2.7.0",
     "webpack-cli": "^3.0.8",
     "webpack-hot-client": "^4.0.4",


### PR DESCRIPTION
Version 4.40.0 introduces a bug that prevents web from compiling:
https://github.com/webpack/webpack/issues/9693