### PR TITLE
chore: add unit test for android exception domains

### DIFF
--- a/packages/flagship/__tests__/mock_project/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/flagship/__tests__/mock_project/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <debug-overrides>
+    <trust-anchors>
+      <certificates src="user" />
+    </trust-anchors>
+  </debug-overrides>
+</network-security-config>

--- a/packages/flagship/src/lib/__tests__/android.test.ts
+++ b/packages/flagship/src/lib/__tests__/android.test.ts
@@ -33,6 +33,14 @@ function getManifest(): string {
     .toString();
 }
 
+function getNetworkSecurityConfig(): string {
+  return fs
+    .readFileSync(
+      nodePath.join(tempRootDir, 'android/app/src/main/res/xml/network_security_config.xml')
+    )
+    .toString();
+}
+
 function getGradleProperties(): string {
   return fs.readFileSync(nodePath.join(tempRootDir, `android/gradle.properties`)).toString();
 }
@@ -166,5 +174,21 @@ test(`set env switcher initial env`, () => {
 
   expect(EnvSwitcherFile).toMatch(
     `String initialEnvName = "stage2stage"; // [EnvSwitcher initialEnvName]`
+  );
+});
+
+test('android exception domains', () => {
+  android.exceptionDomains({
+    name: appName,
+    bundleIds: {
+      android: `test.bundle.id`
+    },
+    exceptionDomains: ['brandingbrand.com']
+  });
+
+  expect(getNetworkSecurityConfig()).toMatch('<domain includeSubdomains="true">localhost</domain>');
+  expect(getNetworkSecurityConfig()).toMatch('<domain includeSubdomains="true">10.0.2.2</domain>');
+  expect(getNetworkSecurityConfig()).toMatch(
+    '<domain includeSubdomains="true">brandingbrand.com</domain>'
   );
 });


### PR DESCRIPTION
This test ensures that localhost, 10.0.2.2 (the Android emulator internal localhost IP), and any configured exception domains are added to the network security file in the Android project.