### PR TITLE
fix: pin axios to 0.18.x

### DIFF
--- a/packages/fsnetwork/package.json
+++ b/packages/fsnetwork/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@brandingbrand/fsfoundation": "^3.5.0",
-    "axios": "^0.19.0"
+    "axios": "~0.18.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fsshopify/package.json
+++ b/packages/fsshopify/package.json
@@ -24,7 +24,7 @@
     "react-native-payments": "^0.7.0"
   },
   "devDependencies": {
-    "axios": "^0.19.0"
+    "axios": "~0.18.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3310,9 +3310,10 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+axios@~0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"


### PR DESCRIPTION
Axios 0.19 contains a bug in which custom request parameters are not actually applied to the request.