### PR TITLE
feat: update bv components w/ syndicated indicator

### DIFF
--- a/packages/fsbazaarvoice/src/BazaarvoiceNormalizer.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceNormalizer.ts
@@ -10,6 +10,8 @@ export function review(bvReview: any): ReviewTypes.Review {
     rating: bvReview.Rating,
     user: user(bvReview),
     isRecommended: bvReview.IsRecommended,
+    isSyndicated: bvReview.IsSyndicated,
+    syndicationSource: bvReview.SyndicationSource,
     badges: bvReview.Badges,
     created: bvReview.SubmissionTime,
     context: Object.keys(bvReview.ContextDataValues).map(key => {

--- a/packages/fscommerce/src/Review/types/Review.ts
+++ b/packages/fscommerce/src/Review/types/Review.ts
@@ -8,6 +8,16 @@ import { ReviewDimension } from './ReviewDimension';
  */
 export interface Review extends ReviewMetadata {
   /**
+   * Is the review insentivised or syndicated
+   */
+  isSyndicated?: boolean;
+
+  /**
+   * If the review is syndicated there will be an object with details attached
+   */
+  syndicationSource?: SyndicationSource;
+
+  /**
    * Contexts for the review
    */
   context?: ReviewContext[];
@@ -79,4 +89,15 @@ export interface ReviewBadge {
    * Content type of the badge
    */
   contentType: string;
+}
+
+/**
+ * Object with details about syndication
+ * Keys are capitalized here to match the data coming back from bazaarvoice
+ */
+export interface SyndicationSource {
+  ClientId?: string;
+  ContentLink?: string;
+  LogoImageUrl?: string;
+  Name?: string;
 }

--- a/packages/fscomponents/src/styles/ReviewItem.ts
+++ b/packages/fscomponents/src/styles/ReviewItem.ts
@@ -31,6 +31,10 @@ export const style = StyleSheet.create({
     color: '#555',
     fontSize: 14
   },
+  syndicatedLabel: {
+    color: '#767676',
+    fontSize: 13
+  },
   recommended: {
     color: '#000',
     fontSize: 15

--- a/packages/fsi18n/src/translations/en.ts
+++ b/packages/fsi18n/src/translations/en.ts
@@ -114,7 +114,8 @@ export const keys: FSTranslationKeys = {
       },
       recommendCount: '{{recommendPercent}}% of respondents would recommend this to a friend',
       recommended: 'Yes, I recommend this product.',
-      notRecommended: 'No, I do not reccommend this product.'
+      notRecommended: 'No, I do not reccommend this product.',
+      syndicatedLabel: 'Comment originally posted at {{site}}'
     },
     search: {
       recentSearches: 'RECENT SEARCHES',

--- a/packages/fsi18n/src/types.ts
+++ b/packages/fsi18n/src/types.ts
@@ -154,6 +154,7 @@ export interface ReviewsTranslations<KeyType> {
   recommendCount: KeyType;
   recommended: KeyType;
   notRecommended: KeyType;
+  syndicatedLabel: KeyType;
 }
 
 export interface SearchTranslations<KeyType> {


### PR DESCRIPTION
**Description**
Some reviews are syndicated by the manufacturer. When this is the case, if the client wants to display the indicator, another row will appear on the bottom of the review indicating that it is syndicated.