### PR TITLE
chore: Update CMSBanner to allow state generic type

### DIFF
--- a/packages/fscomponents/src/components/CMSBanner.tsx
+++ b/packages/fscomponents/src/components/CMSBanner.tsx
@@ -31,7 +31,7 @@ export interface CMSBannerState {
   containerWidth: number;
 }
 
-export abstract class CMSBanner<P extends CMSBannerProps>
+export abstract class CMSBanner<P extends CMSBannerProps, S = {}>
   extends Component<P, CMSBannerState> {
 
   state: CMSBannerState = {


### PR DESCRIPTION
### Description:
https://github.com/brandingbrand/flagship/issues/244

https://github.com/brandingbrand/flagship/blob/master/packages/fscomponents/src/components/CMSBanner.tsx

Currently this component only defines a generic for props, meaning that components that extend CMSBanner cannot have their own state. We should update the type definition to add a state generic type.

### Changes:
Added type state for CMSBanner. Now we can use own state in component which are extends from CMSBanner.