### PR TITLE
fix(flagship): Fix overwriting launch screen file

### DIFF
--- a/packages/flagship/src/lib/__tests__/ios.test.ts
+++ b/packages/flagship/src/lib/__tests__/ios.test.ts
@@ -120,7 +120,7 @@ test(`update launch screen`, () => {
     .toString();
 
   const xib = fs
-    .readFileSync(nodePath.join(tempRootDir, `ios/${appName}/LaunchScreen.xib`))
+    .readFileSync(nodePath.join(tempRootDir, `ios/${appName}/LaunchScreen.storyboard`))
     .toString();
 
   expect(launchScreenImagesSource).toEqual(launchScreenImages);

--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -170,7 +170,7 @@ export function launchScreen(configuration: Config): void {
   const sourceLaunchScreen = configuration.launchScreen.ios.xib;
   const destinationLaunchScreen = path.resolve(
     path.ios.nativeProjectPath(configuration),
-    'LaunchScreen.xib'
+    'LaunchScreen.storyboard'
   );
 
   try {


### PR DESCRIPTION
The init script was not updated to replace the new storyboard launch screen rather than the old xib.
The config option probably should also be updated to reflect the new storyboard expectation (ie.
rename `launchScreen.ios.xib` to something like `launchScreen.ios.storyboard`)