### PR TITLE
fix: Gridlines are misaligned between products in Product Index	#143

### DIFF
--- a/packages/pirateship/src/components/PSProductIndex.tsx
+++ b/packages/pirateship/src/components/PSProductIndex.tsx
@@ -37,6 +37,7 @@ const PIPStyle = StyleSheet.create({
     marginHorizontal: 15
   },
   productItem: {
+    flex: 1,
     paddingTop: 15,
     paddingBottom: Platform.OS === 'android' ? 15 : 0,
     borderBottomColor: border.color,


### PR DESCRIPTION
Description:
#143

Happens when the product item heights differ (eg. product name wrapping, only some products having reviews, etc).

Changes:
Now gridlines are equals between products in Product Index