### PR TITLE
fix(pirateship): Remove duplicate "name" in config

### DIFF
--- a/packages/pirateship/env/common.js
+++ b/packages/pirateship/env/common.js
@@ -29,7 +29,6 @@ module.exports = {
     }
   },
   apiHost: 'https://api.example.com',
-  name: 'PirateShip',
   publicVersionNumber: '1.0.0',
   require: [],
   appIds: {


### PR DESCRIPTION
The file had two different "name" members, so this removes the second one.