### PR TITLE
fix: get default env from initial script

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -253,6 +253,14 @@ function initWeb(
     path.project.resolve('web')
   );
 
+  // create config for web version
+  fs.writeFileSync(
+    path.project.resolve('web', 'config.web.json'),
+    JSON.stringify({
+      defaultEnvName: environmentIdentifier
+    })
+  );
+
   web.homepage(configuration.webPath || '/');
   web.title(configuration.webTitle);
   web.headerScripts(configuration.webScriptInjectHeader);

--- a/packages/fsweb/webpack.config.js
+++ b/packages/fsweb/webpack.config.js
@@ -11,6 +11,14 @@ const history = require('connect-history-api-fallback');
 const convert = require('koa-connect');
 const escapedSep = '\\' + path.sep;
 
+let webConfig;
+
+try {
+  webConfig = require('./config.web.json')
+} catch (exception) {
+  console.warn('Cannot find web config');
+}
+
 const globalConfig = {
   optimization: {
     concatenateModules: false
@@ -168,6 +176,12 @@ const globalConfig = {
 };
 
 module.exports = function(env, options) {
+  const defaultEnv = JSON.stringify(
+    (env && env.defaultEnvName) ||
+    (webConfig && webConfig.defaultEnvName) ||
+    'prod'
+  );
+
   // add our environment specific config to the webpack config based on mode
   if (options && options.mode === 'production') {
     !options.json && console.log('Webpacking for Production');
@@ -179,7 +193,7 @@ module.exports = function(env, options) {
       }),
       new webpack.DefinePlugin({
         __DEV__: env.enableDev ? true : false,
-        __DEFAULT_ENV__: JSON.stringify((env && env.defaultEnvName) || 'prod')
+        __DEFAULT_ENV__: defaultEnv
       }),
       new UglifyJsPlugin({
         test: /.m?[jt]sx?/,
@@ -246,7 +260,7 @@ module.exports = function(env, options) {
       }),
       new webpack.DefinePlugin({
         __DEV__: true,
-        __DEFAULT_ENV__: JSON.stringify((env && env.defaultEnvName) || 'prod')
+        __DEFAULT_ENV__: defaultEnv
       })
     ]);
   }


### PR DESCRIPTION
Resolve for issue #403

### Behavior:
Now, the default env for webpack getting from generated config (config.web.json). Config generates by fsweb package and puts into web build directory. Then webpack get this generated config and set into web app.