### PR TITLE
fix: Add itemCount to cart interface in fscommerce

### DIFF
--- a/packages/fscommerce/src/Commerce/types/Cart.ts
+++ b/packages/fscommerce/src/Commerce/types/Cart.ts
@@ -80,6 +80,13 @@ export interface Cart<T extends CartItem = CartItem> {
    * shipments, each having its own tracking information.
    */
   shipments?: Shipment[];
+
+  /**
+   * The total amount of cart items.
+   *
+   * @example. '3'
+   */
+  itemCount?: number;
 }
 
 /**


### PR DESCRIPTION
#169 

**Description**
It would be useful to have an itemCount that takes into account quantities of different items in count. could be implemented as a virtual using 'get' function:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get