### PR TITLE
fix: Modify the podspec version to ve 2.6.2

### DIFF
--- a/packages/flagship/src/lib/modules/ios/react-native-leanplum.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-leanplum.ts
@@ -7,5 +7,5 @@ import { Config } from '../../../types';
  * @param {object} configuration The project configuration.
  */
 export function preLink(configuration: Config): void {
-  pods.add([`pod "Leanplum-iOS-SDK", '2.6.1'`]);
+  pods.add([`pod "Leanplum-iOS-SDK", '2.6.2'`]);
 }


### PR DESCRIPTION
There is a version mismatch between flagship and react-native-leanplum@4.0.0 here:
https://github.com/brandingbrand/flagship/blob/develop/packages/flagship/src/lib/modules/ios/react-native-leanplum.ts
https://github.com/brandingbrand/react-native-leanplum/blob/master/react-native-leanplum.podspec

Modify the podspec version to ve 2.6.2:

https://github.com/brandingbrand/flagship/blob/develop/packages/flagship/src/lib/modules/ios/react-native-leanplum.ts#L11