### PR TITLE
chore: tell greenkeeper to ignore more dependencies

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -33,6 +33,10 @@
     }
   },
   "ignore": [
-    "react-native"
+    "react-native",
+    "react",
+    "metro-react-native-babel-preset",
+    "@babel/core",
+    "@babel/runtime"
   ]
 }


### PR DESCRIPTION
react, metro-react-babel-preset, and babel should only be updated as part of coordinated React Native upgrades.