### PR TITLE
chore: Update react-id-swiper

### DIFF
--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -25,7 +25,7 @@
     "qs": "^6.7.0",
     "react": "16.8.3",
     "react-dom": "^16.3.2",
-    "react-id-swiper": "^1.6.6",
+    "react-id-swiper": "^1.6.9",
     "react-native": "0.59.10",
     "react-native-masked-text": "^1.7.1",
     "react-native-svg": "^9.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12921,7 +12921,7 @@ react-fuzzy@^0.5.2:
     fuse.js "^3.0.1"
     prop-types "^15.5.9"
 
-react-id-swiper@^1.6.6:
+react-id-swiper@^1.6.9:
   version "1.6.9"
   resolved "https://registry.yarnpkg.com/react-id-swiper/-/react-id-swiper-1.6.9.tgz#463116cb2b2b0ecea23b5e62ebfa0640e545f6f1"
   integrity sha512-RxGIdhgNY/NBO5qVAKBl4DIG7dy+OzSs9oKtRWQJxOKOCLLQD4FZUHznfCVLT2hWts7OJX4V0HMsb4pcnQrKAQ==


### PR DESCRIPTION
issue: https://github.com/brandingbrand/flagship/issues/190

Update react-id-swiper from 1.6.6 to 1.6.9