### PR TITLE
fix: exclude kotlin intermediate build files

### DIFF
--- a/packages/flagship/android/app/build.gradle
+++ b/packages/flagship/android/app/build.gradle
@@ -154,6 +154,7 @@ android {
 
     // for jsc-android: https://github.com/react-native-community/jsc-android-buildscripts
     packagingOptions {
+        exclude 'META-INF/*.kotlin_module'
         pickFirst '**/libjsc.so'
         pickFirst '**/libc++_shared.so'
     }


### PR DESCRIPTION
3rd party libraries begin using Kotlin and intermediate`*.kotlin_module` files are causing build errors. Added this rule to exclude those files