### PR TITLE
fix(flagship): Fix renaming edge case for android

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -140,7 +140,6 @@ function initAndroid(
   rename.source('FLAGSHIP', configuration.name, 'android');
   rename.source('CONFIG_BUNDLE_ID', pkgId, 'android');
   rename.pkgDirectory(TEMPLATE_ANDROID_PACKAGE, pkgId, path.android.mainPath(), 'java');
-  rename.files('FLAGSHIP', configuration.name, 'android');
 
   fastlane.configure(path.android.fastfilePath(), configuration); // Update Fastfile
 


### PR DESCRIPTION
The only file/directory with "flagship" in the name was the package directory, which is already being renamed when fixing the package directory structure.

Resolves https://github.com/brandingbrand/flagship/issues/895