### PR TITLE
chore: Update react-native-touch-id dependency

### DIFF
--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -53,7 +53,7 @@
     "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "~5.4.0",
     "react-native-svg": "^9.3.6",
-    "react-native-touch-id": "~4.3.0",
+    "react-native-touch-id": "~4.4.0",
     "react-redux": "^5.0.7",
     "tcomb-form-native": "^0.6.12"
   },

--- a/packages/pirateship/src/components/PSSignInForm.tsx
+++ b/packages/pirateship/src/components/PSSignInForm.tsx
@@ -3,7 +3,7 @@ import { Form } from '@brandingbrand/fscomponents';
 // @ts-ignore TODO: Add types for tcomb-form-native
 import * as t from 'tcomb-form-native';
 import { merge } from 'lodash-es';
-import TouchId from 'react-native-touch-id';
+import TouchId, { AuthenticationError, IsSupportedError } from 'react-native-touch-id';
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
 import { EMAIL_REGEX } from '../lib/constants';
 import { textboxWithRightIcon } from '../lib/formTemplate';
@@ -390,7 +390,9 @@ export default class PSSignInForm extends Component<
     });
   }
 
-  getBiometricIcon = async (authType: string | boolean | TouchId.TouchIDError) => {
+  getBiometricIcon = async (
+      authType: string | boolean | AuthenticationError | IsSupportedError
+  ) => {
     return this.props.getCredentials()
       .then(({ email, password }) => {
         if (!email || !password) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13078,10 +13078,10 @@ react-native-swiper@^1.5.13:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-touch-id@~4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.3.0.tgz#c25abd1d03d1ce5075f73ca87b18b47e7d60fa71"
-  integrity sha512-c9VB8Q5+d1H/bXz3gKmlPeWgEIcIeSiLK6jIhx0gUHPD9Geaquhq7NwOFGVt3WkGyvyqfKQTjZTWmuWY1g7hLg==
+react-native-touch-id@~4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz#8b1bb2d04c30bac36bb9696d2d723e719c4a8b08"
+  integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
 
 react-native-video@^4.0.0:
   version "4.4.4"


### PR DESCRIPTION
#396 
The dependency react-native-touch-id was updated from 4.3.0 to 4.4.0