### PR TITLE
chore: update @types/storybook dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/react-redux": "^6.0.0",
     "@types/react-router-dom": "^4.2.6",
     "@types/redux-logger": "^3.0.6",
-    "@types/storybook__addon-actions": "^3.0.3",
+    "@types/storybook__addon-actions": "^3.4.3",
     "@types/storybook__addon-knobs": "^3.3.1",
     "@types/storybook__react": "^3.0.7",
     "@types/url-parse": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,7 +3168,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/storybook__addon-actions@^3.0.3":
+"@types/storybook__addon-actions@^3.4.3":
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/@types/storybook__addon-actions/-/storybook__addon-actions-3.4.3.tgz#bb0c3fd066e1f495d3f2b724487e2b99194b3f1a"
   integrity sha512-RSFFfruUHL7La4CZpuiKZ0mZvr5orjenFA2jc31tfPwvA3fYNH4/9XSfA2MB08IpJbF3aErtYWT5Dtigkxnltg==


### PR DESCRIPTION
**Ticket:**
Update @types/storybook dependency

## Description
The devDependency @types/storybook__addon-actions was updated from 3.4.2 to 3.4.3

Issue: https://github.com/brandingbrand/flagship/issues/682

Updating dependencies require understanding / researching what is changing in the update and ensuring that current projects won't break. If the update breaks our exitsing projects, then we should not update

** Done**
@types/storybook__addon-actions was updated  to 3.4.3