### PR TITLE
feat(fscomponents): Custom modal content in Zoom Carousel

### DIFF
--- a/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
+++ b/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
@@ -17,6 +17,7 @@ import {
 import { ImageData, ZoomCarouselProps } from './types';
 import { MultiCarousel } from '../MultiCarousel';
 import { PhotoSwipe } from './PhotoSwipe.web';
+import { Modal } from '../Modal';
 
 const searchIcon = require('../../../assets/images/search.png');
 
@@ -259,6 +260,44 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
     );
   }
 
+  renderPhotoSwipe = () => (
+    <PhotoSwipe
+      isOpen={this.state.isZooming}
+      items={this.props.images
+        .map(img => img.zoomSrc || img.src)
+        .map((img, i) => ({
+          src: img.uri || img,
+          w: this.state.screenWidth,
+          h: this.state.imageSizes[i]
+            ? this.state.screenWidth *
+              this.state.imageSizes[i].height /
+              this.state.imageSizes[i].width
+            : this.state.imageHeight
+        }))}
+      options={{
+        loop: false,
+        fullscreenEl: false,
+        shareEl: false,
+        captionEl: false,
+        history: false,
+        closeOnScroll: false,
+        index: this.state.currentIndex
+      }}
+      afterChange={this.handleZoomCarouselChange}
+      onClose={this.closeZoom}
+    />
+  )
+
+  renderCustomModal = () => (
+    this.props.renderModalContent ?
+      (
+        <Modal visible={this.state.isZooming} transparent={true}>
+          {this.props.renderModalContent(this.closeZoom)}
+        </Modal>
+      ) :
+    this.renderPhotoSwipe()
+  )
+
   render(): JSX.Element {
     const { peekSize = 0, gapSize = 0 } = this.props;
 
@@ -302,32 +341,7 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
                   </TouchableOpacity>
                 )}
               </View>}
-
-            <PhotoSwipe
-              isOpen={this.state.isZooming}
-              items={this.props.images
-                .map(img => img.zoomSrc || img.src)
-                .map((img, i) => ({
-                  src: img.uri || img,
-                  w: this.state.screenWidth,
-                  h: this.state.imageSizes[i]
-                    ? this.state.screenWidth *
-                      this.state.imageSizes[i].height /
-                      this.state.imageSizes[i].width
-                    : this.state.imageHeight
-                }))}
-              options={{
-                loop: false,
-                fullscreenEl: false,
-                shareEl: false,
-                captionEl: false,
-                history: false,
-                closeOnScroll: false,
-                index: this.state.currentIndex
-              }}
-              afterChange={this.handleZoomCarouselChange}
-              onClose={this.closeZoom}
-            />
+              {this.renderCustomModal()}
           </div>
         </View>
 

--- a/packages/pirateship/src/components/PSProductDetail.tsx
+++ b/packages/pirateship/src/components/PSProductDetail.tsx
@@ -586,6 +586,7 @@ class PSProductDetailComponent extends Component<
             dotActiveStyle={styles.zoomCarouselDotActiveStyle}
             renderZoomButton={this._renderZoomButton}
             zoomButtonStyle={styles.zoomCarouselZoomButtonStyle}
+            renderModalContent={this.props.id === '25752986' ? this.renderCustomModal : undefined}
           />
         </View>
         <View style={styles.edgePadding}>

--- a/packages/pirateship/src/components/PSProductDetail.tsx
+++ b/packages/pirateship/src/components/PSProductDetail.tsx
@@ -218,6 +218,11 @@ const styles = StyleSheet.create({
   },
   quantityView: {
     marginTop: 15
+  },
+  modalContainer: {
+    width: '50%',
+    margin: 'auto',
+    backgroundColor: 'white'
   }
 });
 
@@ -484,6 +489,19 @@ class PSProductDetailComponent extends Component<
         }
       }
     });
+  }
+
+  renderCustomModal = (closeModal: () => void): React.ReactNode => {
+    const testText = 'Hello World';
+    const closeText = 'Close';
+    return (
+      <View style={styles.modalContainer}>
+        <Text>{testText}</Text>
+        <TouchableOpacity onPress={closeModal}>
+          <Text>{closeText}</Text>
+        </TouchableOpacity>
+      </View>
+    );
   }
 
   renderShareButton = (): React.ReactNode => {


### PR DESCRIPTION
A reimplementation of the functionality that existed here

https://github.com/brandingbrand/flagship/commit/2391b829c6539080557f6c2631e33ae648754f4e

Allows us to pass in a custom content to be rendered upon zoom. This is necessary functionality to support client requirements.

Steps:
1. Run pirateship
2. set env to mock
3. navigate to ```/ProductDetail?productId=25752986``` (make sure productId is 25752989)
4. Click on the zoom button

Expected Result:
A simple Hello World, Close modal appears. Press Close to get rid of the modal. (to mock custom content that would be passed in)

Only productId 25752989 has a custom modal. Every other product uses the default ZoomCarousel content.