### PR TITLE
chore: tell greenkeeper to ignore react and react native types

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -37,6 +37,8 @@
     "react",
     "metro-react-native-babel-preset",
     "@babel/core",
-    "@babel/runtime"
+    "@babel/runtime",
+    "@types/react",
+    "@types/react-native"
   ]
 }


### PR DESCRIPTION
These types should be updated in sync with Flagship updates to the React and React Native libraries.