### PR TITLE
feat(flagship): Add option to only include the default env

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -97,6 +97,7 @@ export function handler(argv: HandlerArgs): void {
  *
  * @param {string} environmentIdentifier The environment identifier for which to initialize.
  * @param {object} packageJSON The project's package.json.
+ * @param {boolean} onlyDefault Set if you want only the default environment added to the project
  * @returns {object} The project configuration.
  */
 function initEnvironment(

--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -29,6 +29,7 @@ export interface BuilderArgs {
 export interface HandlerArgs {
   platform: string;
   env: string;
+  onlyDefault: boolean;
 }
 
 const TEMPLATE_ANDROID_PACKAGE = 'com.brandingbrand.reactnative.and.flagship';
@@ -59,7 +60,7 @@ export function handler(argv: HandlerArgs): void {
   helpers.logInfo(`Flagship ${platform} init`);
 
   const projectPackageJSON = require(path.project.resolve('package.json'));
-  const configuration = initEnvironment(argv.env, projectPackageJSON);
+  const configuration = initEnvironment(argv.env, projectPackageJSON, argv.onlyDefault);
 
   if (doAndroid) {
     initAndroid(projectPackageJSON, configuration, projectPackageJSON.version, argv.env);
@@ -100,12 +101,13 @@ export function handler(argv: HandlerArgs): void {
  */
 function initEnvironment(
   environmentIdentifier: string,
-  packageJSON: NPMPackageConfig
+  packageJSON: NPMPackageConfig,
+  onlyDefault?: boolean
 ): Config {
   const configuration = env.configuration(environmentIdentifier, packageJSON);
 
   env.write(configuration); // Replace env.js with the current environment
-  env.createEnvIndex();
+  env.createEnvIndex(onlyDefault ? environmentIdentifier : undefined);
 
   return configuration;
 }

--- a/packages/flagship/src/lib/env.ts
+++ b/packages/flagship/src/lib/env.ts
@@ -111,13 +111,21 @@ export function configuration(env: string, projectPackageJson: NPMPackageConfig)
 
 /**
  * Create a index file for project envs
+ *
+ * @param {string} singleEnv Set if you want only a single environment added to the file
  */
-export function createEnvIndex(): void {
-  helpers.logInfo('Creating index file for project envs');
+export function createEnvIndex(singleEnv?: string): void {
+  let envMatch = /env.[\w]+.js/;
+  if (singleEnv) {
+    envMatch = new RegExp('env\.' + singleEnv + '\.js');
+    helpers.logInfo('Creating index file for default env');
+  } else {
+    helpers.logInfo('Creating index file for project envs');
+  }
 
   const envs = fs
     .readdirSync(project.resolve('env'))
-    .filter((f: string) => f.match(/env.[\w]+.js/));
+    .filter((f: string) => f.match(envMatch));
 
   const envIndexFile = `module.exports = {\n${envs
     .map((env: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6179,6 +6179,16 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
+
 css-selector-tokenizer@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz#a177271a8bca5019172f4f891fc6eed9cbf68d5d"
@@ -6204,10 +6214,23 @@ css-tree@1.0.0-alpha.33:
     mdn-data "2.0.4"
     source-map "^0.5.3"
 
+css-tree@^1.0.0-alpha.37:
+  version "1.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.37.tgz#98bebd62c4c1d9f960ec340cf9f7522e30709a22"
+  integrity sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==
+  dependencies:
+    mdn-data "2.0.4"
+    source-map "^0.6.1"
+
 css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css-what@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.2.1.tgz#f4a8f12421064621b456755e34a03a2c22df5da1"
+  integrity sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -12986,10 +13009,10 @@ react-native-geocoder@^0.5.0:
   resolved "https://registry.yarnpkg.com/react-native-geocoder/-/react-native-geocoder-0.5.0.tgz#ff4b9c55d5768a4784eefccb411761c82e067579"
   integrity sha1-/0ucVdV2ikeE7vzLQRdhyC4GdXk=
 
-react-native-htmlview@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-htmlview/-/react-native-htmlview-0.13.0.tgz#2c34646c35bbe94386db9aaebbb3930ec58c8bcf"
-  integrity sha512-gVEggLcAi5Gfi88LX9uaACiAGIcEuzg9i/gs8ymIQuV/xQ0IpeKpVMpBZwiAOSHBrJJhGUCoCihV2bgz5TruVw==
+react-native-htmlview@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-native-htmlview/-/react-native-htmlview-0.14.0.tgz#be1be4d1608369e2d9d367731dd3aef70f018d89"
+  integrity sha512-y51QJtz/nDRX/6P6eikizyma5eHWN/BTGLyzI2JpUUM+8JSg7VN4MMb54wQHGVotAwnb5FJjDQcZ9qd3T0PMKw==
   dependencies:
     entities "^1.1.1"
     htmlparser2-without-node-native "^3.9.2"
@@ -13065,6 +13088,14 @@ react-native-snap-carousel@^3.8.0:
   dependencies:
     prop-types "^15.6.1"
     react-addons-shallow-compare "15.6.2"
+
+react-native-svg@^9.13.3:
+  version "9.13.3"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.13.3.tgz#6414b337d55af169ac2487ab70f3108404434446"
+  integrity sha512-H50b2m4jvrQ7KxKs8uYSuWecr6e5XC7BDfS7DaA96+0Owjh0C9DksI5l8SRyHnmE+emiYMPu6Qqfr9dCyKkaJQ==
+  dependencies:
+    css-select "^2.0.2"
+    css-tree "^1.0.0-alpha.37"
 
 react-native-svg@^9.3.6:
   version "9.5.3"


### PR DESCRIPTION
Usage: `yarn run init --env prod --onlyDefault`

Will only include the default env, which should reduce the size of production bundles by excluding the environments that aren't needed.