### PR TITLE
feat(flagship): deprecate appcenter.apiconfig configuration option

### DIFF
--- a/packages/flagship/android/fastlane/Fastfile
+++ b/packages/flagship/android/fastlane/Fastfile
@@ -17,7 +17,7 @@ lane :appcenter do
   gradle(task: "assembleRelease")
 
   appcenter_upload(
-    api_token: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_api_token
+    #PROJECT_MODIFY_FLAG_appcenter_api_token
     owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
     app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
   )

--- a/packages/flagship/ios/fastlane/Fastfile
+++ b/packages/flagship/ios/fastlane/Fastfile
@@ -39,7 +39,7 @@ lane :appcenter do
   )
 
   appcenter_upload(
-    api_token: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_api_token
+    #PROJECT_MODIFY_FLAG_appcenter_api_token
     owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
     app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_ios
   )

--- a/packages/flagship/src/lib/fastlane.ts
+++ b/packages/flagship/src/lib/fastlane.ts
@@ -1,6 +1,6 @@
 import { Config } from '../types';
 import * as fs from './fs';
-import { logInfo } from '../helpers';
+import { logInfo, logWarn } from '../helpers';
 
 /**
  * Configures the project Fastfile from the project configuration.
@@ -67,11 +67,18 @@ export function configure(path: string, configuration: Config): void {
   if (configuration && configuration.appCenter) {
     const { apiToken, organization, distribute } = configuration.appCenter;
 
-    fs.update(
-      path,
-      /.+#PROJECT_MODIFY_FLAG_appcenter_api_token/g,
-      `api_token: "${apiToken}", #PROJECT_MODIFY_FLAG_appcenter_api_token`
-    );
+    if (apiToken) {
+      logWarn(
+        'appCenter.apiToken is deprecated and will be removed in a future release;'
+        + ' use APPCENTER_API_TOKEN environment variable instead'
+      );
+
+      fs.update(
+        path,
+        /.+#PROJECT_MODIFY_FLAG_appcenter_api_token/g,
+        `api_token: "${apiToken}", #PROJECT_MODIFY_FLAG_appcenter_api_token`
+      );
+    }
 
     fs.update(
       path,

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -24,7 +24,7 @@ export interface Config {
   };
 
   appCenter?: {
-    apiToken: string;
+    apiToken?: string; // deprecated; will be removed in a future release
     organization: string;
     distribute?: {
       appNameIOS?: string;


### PR DESCRIPTION
This deprecates the appcenter.apiConfig configuration option in favor of using the APPCENTER_API_TOKEN environment variable. This makes the key optional in the typedef and updates the Fastfiles for iOS and Android such that not including this option will not break the builds.