### PR TITLE
feat: update podfile to use cocoapods cdn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
     # android emulator setup based on https://github.com/brianegan/flutter_architecture_samples
     # from comment in https://github.com/googlemaps/android-maps-utils/issues/371#issuecomment-498921876
     before_install:
+    - nvm install 10
     - ANDROID_SDK_TOOLS=4333796 # android-28
     - ANDROID_PLATFORM_SDK=28
     - ANDROID_BUILD_TOOLS=28.0.3

--- a/packages/flagship/__tests__/mock_project/ios/Podfile
+++ b/packages/flagship/__tests__/mock_project/ios/Podfile
@@ -1,5 +1,6 @@
 # You Podfile should look similar to this file. React Native currently does not support use_frameworks!
-source 'https://github.com/CocoaPods/Specs.git'
+# This requires CocoaPods 1.7.2+
+source 'https://cdn.cocoapods.org/'
 # add more sources using environment key ios.pods.sources
 # ADDITIONAL_POD_SOURCES
 

--- a/packages/flagship/ios/Podfile
+++ b/packages/flagship/ios/Podfile
@@ -1,5 +1,6 @@
 # You Podfile should look similar to this file. React Native currently does not support use_frameworks!
-source 'https://github.com/CocoaPods/Specs.git'
+# This requires CocoaPods 1.7.2+
+source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.3'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'


### PR DESCRIPTION
BREAKING CHANGE: This requires updating CocoaPods (including in CI) to v1.7.2+ in order for pod install to work with the CDN. This allows CocoaPods to pull from their own CDN which avoids rate limiting when pulling sources from GitHub instead.