### PR TITLE
fix: android fastline syntax error due to a trailing comma

### DIFF
--- a/packages/flagship/android/fastlane/Fastfile
+++ b/packages/flagship/android/fastlane/Fastfile
@@ -30,9 +30,9 @@ lane :appcenter_app_bundle do
 
   appcenter_upload(
     #PROJECT_MODIFY_FLAG_appcenter_api_token
+    destination_type: "store",
     owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
-    app_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_app_name_android
-    destination_type: "store"
+    app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
   )
 end
 


### PR DESCRIPTION
the script is not smart enough to decide if a comma is required and causing build errors. For now, the easiest way to fix the errors is to rearrange these lines