### PR TITLE
feat(flagship): update podfile to use cocoapods cdn

### DIFF
--- a/packages/flagship/__tests__/mock_project/ios/Podfile
+++ b/packages/flagship/__tests__/mock_project/ios/Podfile
@@ -1,5 +1,6 @@
 # You Podfile should look similar to this file. React Native currently does not support use_frameworks!
-source 'https://github.com/CocoaPods/Specs.git'
+# This requires CocoaPods 1.7.2+
+source 'https://cdn.cocoapods.org/'
 # add more sources using environment key ios.pods.sources
 # ADDITIONAL_POD_SOURCES
 

--- a/packages/flagship/ios/Podfile
+++ b/packages/flagship/ios/Podfile
@@ -1,5 +1,7 @@
 # You Podfile should look similar to this file. React Native currently does not support use_frameworks!
-source 'https://github.com/CocoaPods/Specs.git'
+
+# This requires CocoaPods 1.7.2+
+source 'https://cdn.cocoapods.org/'
 # add more sources using environment key ios.pods.sources
 # ADDITIONAL_POD_SOURCES
 


### PR DESCRIPTION
BREAKING CHANGE: This requires updating CocoaPods (including in CI) to v1.7.2+ in order for pod install to work with the CDN. This allows CocoaPods to pull from their own CDN which avoids rate limiting when pulling sources from GitHub instead.