### PR TITLE
fix(pirateship): Update tab index for cart count

### DIFF
--- a/packages/pirateship/src/screens/Cart.tsx
+++ b/packages/pirateship/src/screens/Cart.tsx
@@ -237,7 +237,7 @@ class Cart extends Component<CartScreenProps> {
       );
     } else if (cartData && cartData.items) {
       this.props.navigator.setTabBadge({
-        tabIndex: 1,
+        tabIndex: 2,
         badge: this.props.cart.cartCount || null,
         badgeColor: palette.primary
       });
@@ -303,7 +303,7 @@ class Cart extends Component<CartScreenProps> {
     });
 
     this.props.navigator.setTabBadge({
-      tabIndex: 1,
+      tabIndex: 2,
       badge:
         (cartData.items &&
           cartData.items.reduce((total, item) => total + item.quantity, 0)) ||


### PR DESCRIPTION
The tabs got shifted over one when the "Home" tab was added, but the cart count was being applied to the same index. This makes the cart count show up on the cart icon.