### PR TITLE
feat(fsbazaarvoice): Expand review data source

### DIFF
--- a/packages/fsbazaarvoice/package.json
+++ b/packages/fsbazaarvoice/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@brandingbrand/fscommerce": "^8.2.0",
-    "@brandingbrand/fsnetwork": "^8.2.0"
+    "@brandingbrand/fsnetwork": "^8.2.0",
+    "qs": "^6.9.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
@@ -7,6 +7,7 @@ import {
 import * as BazaarvoiceNormalizer from './BazaarvoiceNormalizer';
 import * as BazaarvoiceDenormalizer from './BazaarvoiceDenormalizer';
 import { BazaarvoiceReviewRequest } from './BazaarvoiceReviewRequest';
+import qs from 'qs';
 
 export interface BazaarvoiceConfig {
   endpoint: string;
@@ -31,18 +32,26 @@ export class BazaarvoiceDataSource extends AbstractReviewDataSource implements R
 
   async fetchReviewDetails(query: ReviewTypes.ReviewQuery): Promise<ReviewTypes.ReviewDetails[]> {
     const id = Array.isArray(query.ids) ? query.ids[0] : query.ids;
+    const filter = query.filter || `ProductId:${id}`;
+
     const params: BazaarvoiceReviewRequest = {
-      Filter: `ProductId:${id}`,
+      Filter: filter,
       Include: 'Products',
       Stats: 'Reviews',
-      Limit: query.limit || 10
+      Limit: query.limit || 10,
+      ...(query.sort ? {Sort: query.sort} : {})
     };
 
     if (query.page) {
       params.Offset = params.Limit * (query.page - 1);
     }
 
-    const { data } = await this.client.get('/data/reviews.json', { params });
+    const { data } = await this.client.get('/data/reviews.json', {
+      params,
+      paramsSerializer: (params: BazaarvoiceReviewRequest) => {
+        return qs.stringify(params, { indices: false });
+      }
+    });
 
     return [{
       id,

--- a/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceDataSource.ts
@@ -39,7 +39,7 @@ export class BazaarvoiceDataSource extends AbstractReviewDataSource implements R
       Include: 'Products',
       Stats: 'Reviews',
       Limit: query.limit || 10,
-      ...(query.sort ? {Sort: query.sort} : {})
+      Sort: query.sort
     };
 
     if (query.page) {

--- a/packages/fsbazaarvoice/src/BazaarvoiceReviewRequest.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceReviewRequest.ts
@@ -1,5 +1,6 @@
 export interface BazaarvoiceReviewRequest {
-  Filter: string;
+  Filter: string | string[];
+  Sort?: string;
   Include: 'Products';
   Stats: 'Reviews';
   Limit: number;

--- a/packages/fscommerce/src/Review/types/ReviewQuery.ts
+++ b/packages/fscommerce/src/Review/types/ReviewQuery.ts
@@ -1,5 +1,6 @@
 /**
  * Query to select a group of reviews
+ * https://developer.bazaarvoice.com/conversations-api/reference/v5.4/reviews/review-display
  */
 export interface ReviewQuery {
   /**
@@ -20,4 +21,18 @@ export interface ReviewQuery {
    * @example 10
    */
   limit?: number;
+
+  /**
+   * The Filter parameter for the Bazaarvoice query
+   *
+   * @example ['ProductId:50', 'Rating:eq:2']
+   */
+  filter?: string | string[];
+
+  /**
+   * The Sort parameter for the Bazaarvoice query
+   *
+   * @example 'Rating:asc,SubmissionTime:desc'
+   */
+  sort?: string;
 }


### PR DESCRIPTION
Added new optional params to the bazaarvoice review data source while leaving existing functionality in place.
Filter allows for multiple values following the "Filter=first&Filter=second&Filter=third" format.


Found no existing framework to create a test case in flagship. In the interest of time, I tested it directly within the CVS app.
