### PR TITLE
chore(fsnetwork): fix fsnetwork unit tests

### DIFF
--- a/packages/fsnetwork/src/__tests__/index.test.ts
+++ b/packages/fsnetwork/src/__tests__/index.test.ts
@@ -4,7 +4,7 @@ describe('FSNetwork', () => {
   test('get request', async () => {
     const network = new FSNetwork();
 
-    return network.get('https://github.com').then(response => {
+    return network.get('https://www.brandingbrand.com').then(response => {
       expect(response.status).toBe(200);
     });
   });


### PR DESCRIPTION
Requesting the GitHub homepage with fsnetwork appears to consistently return a 406 error. This points the test at brandingbrand.com which resolves the error.