### PR TITLE
feat(fsbazaarvoice): Add recommended ratio to normalized data

### DIFF
--- a/packages/fsbazaarvoice/src/BazaarvoiceNormalizer.ts
+++ b/packages/fsbazaarvoice/src/BazaarvoiceNormalizer.ts
@@ -48,10 +48,19 @@ export function reviewSummary(bvProductStatistics: any): ReviewTypes.ReviewSumma
 
 export function reviewStatistics(bvProduct: any): ReviewTypes.ReviewStatistics {
   const bvStats = bvProduct.ReviewStatistics;
+
+  const recommendedCount = bvStats.RecommendedCount;
+  const nonRecommendedCount = bvStats.NotRecommendedCount;
+  const recommendedTotal = recommendedCount + nonRecommendedCount;
+
+  const recommendedRatio = recommendedTotal !== 0 ?
+  (recommendedCount / (recommendedTotal)) : 0;
+
   return {
     id: bvProduct.Id,
     averageRating: bvStats.AverageOverallRating,
     reviewCount: bvStats.TotalReviewCount,
+    recommendedRatio,
     ratingDistribution: bvStats.RatingDistribution.map((distribution: any) => {
       return {
         value: distribution.RatingValue,


### PR DESCRIPTION
ReviewStats had a defined property for recommendedRatio, but it was never actually populated.


Tested inside of the CVS app to make sure it works as expected.