### PR TITLE
fix(flagship): Downgrade typedoc to 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "swiper": "^5.0.0",
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.0.0",
-    "typedoc": "^0.16.0",
+    "typedoc": "^0.15.0",
     "typescript": "^3.7.2",
     "webpack": "^4.41.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8223,7 +8223,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.4.0, handlebars@^4.5.3, handlebars@^4.7.2:
+handlebars@^4.4.0, handlebars@^4.5.3, handlebars@^4.7.0:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.2.tgz#01127b3840156a0927058779482031afe0e730d7"
   integrity sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
@@ -15797,31 +15797,31 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.7.1.tgz#1b92999162dc816b52b8094f503f254c87f07c28"
-  integrity sha512-s3jeUHc4EY8snIta6lNkUu9+36WMDUnkKm0UQ59w5iPo/4Y2d4+M9CDIKoenYKT5hkg/UnTc3oX48VZZytv8Xw==
+typedoc-default-themes@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz#c214ce5bbcc6045558448a8fd422b90e3e9b6782"
+  integrity sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==
   dependencies:
     backbone "^1.4.0"
     jquery "^3.4.1"
     lunr "^2.3.8"
     underscore "^1.9.1"
 
-typedoc@^0.16.0:
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.16.5.tgz#11cd23988a18839f4e52b3d5f3e016d8a3075d3e"
-  integrity sha512-P6doxqlz5xwD8kocRTn7G9DSfR5jRM6GA94DPuJtundnhIKp/X26kESUuzit1hJUuLADS14WsNCBCKpI4OzGIA==
+typedoc@^0.15.0:
+  version "0.15.8"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.8.tgz#d83195445a718d173e0d5c73b5581052cb47d4d9"
+  integrity sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==
   dependencies:
     "@types/minimatch" "3.0.3"
     fs-extra "^8.1.0"
-    handlebars "^4.7.2"
+    handlebars "^4.7.0"
     highlight.js "^9.17.1"
     lodash "^4.17.15"
     marked "^0.8.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
     shelljs "^0.8.3"
-    typedoc-default-themes "^0.7.1"
+    typedoc-default-themes "^0.6.3"
     typescript "3.7.x"
 
 typescript@3.7.x, typescript@^3.7.2:


### PR DESCRIPTION
typedoc 16 isn't compatible with the latest version of typedoc-plugin-monorepo (0.2.1 or 0.2.2), because it gets rid of OptionsReadMode. This change will allow build:docs to work again.

For reference, this is the line that blows up:
https://github.com/unstubbable/typedoc-plugin-monorepo/blob/7dc0fc86a8aae24b2c9e60a1a39a36c97de24083/external-module-map-plugin.ts#L68