### PR TITLE
feat(fscomponents): Add image counter, new style options to ZoomCarousel

### DIFF
--- a/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
+++ b/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
@@ -11,6 +11,7 @@ import {
   Image,
   ScrollView,
   StyleSheet,
+  Text,
   TouchableOpacity,
   View
 } from 'react-native';
@@ -51,6 +52,10 @@ export interface ZoomCarouselStateType {
 }
 
 const S = StyleSheet.create({
+  carouselContainer: {
+    flex: 1,
+    flexBasis: 'auto'
+  },
   searchIcon: {
     width: 25,
     height: 25
@@ -107,9 +112,6 @@ const S = StyleSheet.create({
   fullHeight: {
     height: '100%'
   },
-  fullHeightWithThumbnails: {
-    height: '85%'
-  },
   thumbnailImg: {
     width: '100%',
     height: '100%'
@@ -125,6 +127,11 @@ const S = StyleSheet.create({
   thumbnailSelected: {
     borderWidth: 3,
     borderColor: 'red'
+  },
+  imageCounter: {
+    position: 'absolute',
+    right: 0,
+    top: 0
   }
 });
 
@@ -266,6 +273,19 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
     );
   }
 
+  renderImageCounter = () => {
+    const total: number = this.props.images && this.props.images.length || 0;
+    const currentIndex = this.state.currentIndex + 1;
+
+    return (
+      <View style={this.props.imageCounterStyle || S.imageCounter}>
+        <Text>
+          {`${currentIndex}/${total}`}
+        </Text>
+      </View>
+    );
+  }
+
   renderPhotoSwipe = () => (
     <PhotoSwipe
       isOpen={this.state.isZooming}
@@ -304,20 +324,46 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
     this.renderPhotoSwipe()
   )
 
+  renderThumbnails = () => (
+    <ScrollView
+      horizontal={true}
+      contentContainerStyle={[
+        S.thumbnailContainer,
+        this.props.thumbnailContainerStyle
+      ]}
+    >
+    {this.props.images.map((img, i) => (
+      <TouchableOpacity
+        key={i}
+        style={[
+          S.thumbnail,
+          this.props.thumbnailStyle,
+          this.state.currentIndex === i && S.thumbnailSelected
+        ]}
+        onPress={this.handleThumbPress(i)}
+        accessibilityRole={'button'}
+        accessibilityLabel={FSI18n.string(componentTranslationKeys.focus.actionBtn)}
+      >
+        <Image
+          resizeMode='cover'
+          source={img.src}
+          style={S.thumbnailImg}
+        />
+      </TouchableOpacity>
+    ))}
+    </ScrollView>
+  )
+
+  // tslint:disable-next-line:cyclomatic-complexity
   render(): JSX.Element {
     const { peekSize = 0, gapSize = 0 } = this.props;
-    const height = this.props.fillContainer ? this.props.fillContainerStyle ||
-      (this.props.showThumbnails ? S.fullHeightWithThumbnails : S.fullHeight)
-       : null;
-
-    // line 316 and 324 needs to be at 100% height
     return (
       <View
-        style={S.fullHeight}
+        style={this.props.contentContainerStyle || S.carouselContainer}
         onLayout={this.handleLayoutChange}
       >
         <View
-          style={height}
+          style={this.props.imageContainerStyle || S.carouselContainer}
         >
           <div
             id={`zoom-carousel-${this.id}`}
@@ -337,7 +383,7 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
               zoomButtonStyle={this.props.zoomButtonStyle}
               renderPageIndicator={this.props.renderPageIndicator}
               centerMode={this.props.centerMode}
-              style={height}
+              style={this.props.fillContainer ? S.fullHeight : null}
               nextArrowOnBlur={this.props.nextArrowOnBlur}
               hidePageIndicator={this.props.hidePageIndicator}
             />
@@ -365,34 +411,13 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
           (this.props.renderThumbnails ? (
             this.props.renderThumbnails(this.state.currentIndex, this.goTo)
           ) : (
-            <ScrollView
-              horizontal={true}
-              contentContainerStyle={[
-                S.thumbnailContainer,
-                this.props.thumbnailContainerStyle
-              ]}
-            >
-              {this.props.images.map((img, i) => (
-                <TouchableOpacity
-                  key={i}
-                  style={[
-                    S.thumbnail,
-                    this.props.thumbnailStyle,
-                    this.state.currentIndex === i && S.thumbnailSelected
-                  ]}
-                  onPress={this.handleThumbPress(i)}
-                  accessibilityRole={'button'}
-                  accessibilityLabel={FSI18n.string(componentTranslationKeys.focus.actionBtn)}
-                >
-                  <Image
-                    resizeMode='cover'
-                    source={img.src}
-                    style={S.thumbnailImg}
-                  />
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
+            this.renderThumbnails()
           ))}
+          {this.props.showImageCounter &&
+          (this.props.renderImageCounter ?
+            this.props.renderImageCounter(this.state.currentIndex) :
+            (this.renderImageCounter())
+          )}
       </View>
     );
   }

--- a/packages/fscomponents/src/components/ZoomCarousel/types.ts
+++ b/packages/fscomponents/src/components/ZoomCarousel/types.ts
@@ -53,9 +53,39 @@ export interface ZoomCarouselProps {
   hidePageIndicator?: boolean;
 
   /**
-   * The styling used if fill container is set to true (that makes all carousel elememts expand)
+   * The styling of the container that holds the image carousel and thumbnails
    *
-   * @example {{height: '50%'}}
+   * @example {{flex: 1}}
    */
-  fillContainerStyle?: StyleProp<ViewStyle>;
+  carouselContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * The styling of the container that holds just the image carousel
+   *
+   * @example {{minHeight: 400px}}
+   */
+  imageContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Dicates whether the default image counter displays
+   *
+   * @example true
+   */
+  showImageCounter?: boolean;
+
+  /**
+   * Custom styling for the imageCounter. Use absolute positioning to set the location
+   *
+   * @example {{position: 'absolute'}}
+   */
+  imageCounterStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * custom image counter rendering. This function is called last inside the carousel container
+   *
+   * @example const renderImageCounter = (currentIndex: number) => (<View>1/2</View>)
+   */
+  renderImageCounter?: (
+    currentIndex: number
+  ) => React.ReactNode;
 }

--- a/packages/fscomponents/src/components/ZoomCarousel/types.ts
+++ b/packages/fscomponents/src/components/ZoomCarousel/types.ts
@@ -43,6 +43,12 @@ export interface ZoomCarouselProps {
   showThumbnails?: boolean;
   thumbnailStyle?: any;
   thumbnailContainerStyle?: any;
+
+  /**
+   * The styling of the container that holds the image carousel and thumbnails
+   *
+   * @example {{flex: 1}}
+   */
   contentContainerStyle?: StyleProp<ViewStyle>;
 
   /**
@@ -51,13 +57,6 @@ export interface ZoomCarouselProps {
    * @example true
    */
   hidePageIndicator?: boolean;
-
-  /**
-   * The styling of the container that holds the image carousel and thumbnails
-   *
-   * @example {{flex: 1}}
-   */
-  carouselContainerStyle?: StyleProp<ViewStyle>;
 
   /**
    * The styling of the container that holds just the image carousel

--- a/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
@@ -23,15 +23,24 @@ const images = [
 
 storiesOf('ZoomCarousel', module)
   .add('basic usage', () => (
-    <ZoomCarousel
-      peekSize={20}
-      gapSize={10}
-      centerMode={true}
-      showThumbnails={true}
-      images={images}
-      showArrow={true}
-    />
-  )).add('fill container', () => (
+      <ZoomCarousel
+        peekSize={20}
+        gapSize={10}
+        centerMode={true}
+        images={images}
+        showArrow={true}
+      />
+  )).add('with thumbnails', () => (
+      <ZoomCarousel
+        peekSize={20}
+        gapSize={10}
+        centerMode={true}
+        showThumbnails={true}
+        images={images}
+        showArrow={true}
+        fillContainer={true}
+      />
+  )).add('with image counter', () => (
     <ZoomCarousel
       peekSize={20}
       gapSize={10}
@@ -40,16 +49,6 @@ storiesOf('ZoomCarousel', module)
       images={images}
       showArrow={true}
       fillContainer={true}
+      showImageCounter={true}
     />
-  )).add('custom fill container', () => (
-    <ZoomCarousel
-      peekSize={20}
-      gapSize={10}
-      centerMode={true}
-      showThumbnails={true}
-      images={images}
-      showArrow={true}
-      fillContainer={true}
-      fillContainerStyle={{height: '75%'}}
-    />
-  ));
+));


### PR DESCRIPTION
 - Added a new option that can be rendered: image counter
 --Absolutely placed component with custom rendering or custom styles as props
 - Added new prop options for the carousel and image containers
 - changed the default container styling to be flex friendly, fixing an issue where thumbnails would overflow beyond parent boundaries


Added some storybook options and also tested as a linked package inside of a test app.