### PR TITLE
feat(fsengagement): add more event emitters and position data

### DIFF
--- a/packages/fsengagement/src/EngagementComp.tsx
+++ b/packages/fsengagement/src/EngagementComp.tsx
@@ -190,6 +190,7 @@ export interface EngagementScreenProps extends ScreenProps, EmitterProps {
   animate?: boolean;
   onBack?: () => void;
   language?: string;
+  cardPosition?: number;
 }
 export interface EngagementState {
   scrollY: Animated.Value;
@@ -210,7 +211,8 @@ export default function(
     static childContextTypes: any = {
       handleAction: PropTypes.func,
       story: PropTypes.object,
-      language: PropTypes.string
+      language: PropTypes.string,
+      cardPosition: PropTypes.number
     };
 
     state: any = {};
@@ -270,7 +272,8 @@ export default function(
     getChildContext = () => ({
       handleAction: this.handleAction,
       story: this.props.backButton ? this.props.json : null,
-      language: this.props.language
+      language: this.props.language,
+      cardPosition: this.props.cardPosition || 0
     })
 
     // tslint:disable-next-line:cyclomatic-complexity
@@ -282,7 +285,8 @@ export default function(
         title: actions.name,
         id: actions.id,
         type: actions.type,
-        value: actions.value
+        value: actions.value,
+        position: actions.position
       });
       switch (actions.type) {
         case 'blog-url':
@@ -422,6 +426,7 @@ export default function(
       }
       if (this.props.renderType && this.props.renderType === 'carousel') {
         item.fullScreenCard = true;
+        item.position = index + 1;
       }
       return this.renderBlock(item);
     }
@@ -559,9 +564,19 @@ export default function(
     }
     onSnapToItem = (index: number): void => {
       const pageNum = index + 1;
+      if (this.props.json && this.props.json.private_blocks &&
+          this.props.json.private_blocks.length && this.props.json.private_blocks[index]) {
+        DeviceEventEmitter.emit('swipeCard', {
+          title: this.props.json.private_blocks[index].name,
+          id: this.props.json.private_blocks[index].id,
+          position: pageNum
+        });
+      }
       this.setState({
         pageNum
       });
+
+
     }
 
     renderFlatlistFooterPadding = (): JSX.Element => {

--- a/packages/fsengagement/src/inboxblocks/CTABlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/CTABlock.tsx
@@ -67,15 +67,17 @@ export default class CTABlock extends Component<CTABlockProps> {
     handleStoryAction: PropTypes.func,
     name: PropTypes.string,
     id: PropTypes.string,
-    language: PropTypes.string
+    language: PropTypes.string,
+    cardPosition: PropTypes.number
   };
 
   handleActionWithStory = (action: string, actions: Action, story: JSON) => {
-    const { handleAction, handleStoryAction } = this.context;
+    const { handleAction, handleStoryAction, cardPosition } = this.context;
     if (story.html) {
       return handleAction({
         type: 'blog-url',
-        value: story.html.link
+        value: story.html.link,
+        position: cardPosition
       });
     } else if (action === 'story' || (story && actions &&
       (actions.type === null || actions.type === 'story'))) {
@@ -88,7 +90,7 @@ export default class CTABlock extends Component<CTABlockProps> {
   }
 
   handleActionNoStory = (actions: Action) => {
-    const { handleAction, cardActions } = this.context;
+    const { handleAction, cardActions, cardPosition } = this.context;
     if (actions && !actions.value) {
       return;
     }
@@ -96,14 +98,16 @@ export default class CTABlock extends Component<CTABlockProps> {
       return handleAction({
         ...actions,
         name: this.props.name,
-        id: this.props.id
+        id: this.props.id,
+        position: cardPosition
       });
     }
     // tappable card with no story - CTAs use actions of container card
     return handleAction({
       ...cardActions,
       name: this.props.name,
-      id: this.props.id
+      id: this.props.id,
+      position: cardPosition
     });
   }
 

--- a/packages/fsengagement/src/inboxblocks/FullScreenImageCard.tsx
+++ b/packages/fsengagement/src/inboxblocks/FullScreenImageCard.tsx
@@ -58,6 +58,7 @@ export interface FullScreenCardProps extends CardProps {
   isNew?: boolean;
   AnimatedPageCounter?: any;
   AnimatedNavTitle?: any;
+  position?: number;
   setScrollEnabled: (enabled: boolean) => void;
 }
 
@@ -115,7 +116,8 @@ export default class FullScreenImageCard extends Component<FullScreenCardProps> 
   handleStoryAction = (json: JSON) => {
     DeviceEventEmitter.emit('viewStory', {
       title: this.props.name,
-      id: this.props.id
+      id: this.props.id,
+      position: this.props.position
     });
     Navigation.showModal({
       stack: {
@@ -142,7 +144,8 @@ export default class FullScreenImageCard extends Component<FullScreenCardProps> 
               name: this.props.name,
               id: this.props.id,
               animate: true,
-              onBack: this.onBack
+              onBack: this.onBack,
+              cardPosition: this.props.position
             }
           }
         }]

--- a/packages/fsengagement/src/types.ts
+++ b/packages/fsengagement/src/types.ts
@@ -19,6 +19,7 @@ export interface Action {
   body?: string;
   name?: string;
   id?: string;
+  position?: number;
 }
 
 export interface EmitterProps {
@@ -80,6 +81,7 @@ export interface JSON {
   pageCounterStyle?: StyleProp<ViewStyle>;
   id?: string;
   key?: string;
+  name?: string;
   storyType?: string;
   tabbedItems?: any[];
   AnimatedPageCounter?: any;
@@ -97,6 +99,7 @@ export interface BlockItem extends ScreenProps, JSON {
   forceBackground?: boolean;
   fullScreenCard?: boolean;
   animateIndex?: number;
+  position?: number;
 }
 
 export interface InjectedProps {


### PR DESCRIPTION
- Adds the event emitter `swipeCard` when using a FullScreenImageCarousel card, emits an event when swiping to each new card.
- If available, send the position of the card with the events `viewLink` and `viewStory`