### PR TITLE
feat(fscomponents): Add knobs to zoom carousel story

### DIFF
--- a/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // tslint:disable-line:no-implicit-dependencies
 import { ZoomCarousel } from '../ZoomCarousel/ZoomCarousel';
+// tslint:disable-next-line:no-implicit-dependencies
+import { boolean, number, object } from '@storybook/addon-knobs';
 
-const images = [
+const defaultImages = [
   {
     src: require('./assets/images/wide.png'),
     zoomSrc: require('./assets/images/wide@2x.png')
@@ -24,11 +26,13 @@ const images = [
 storiesOf('ZoomCarousel', module)
   .add('basic usage', () => (
     <ZoomCarousel
-      peekSize={20}
-      gapSize={10}
-      centerMode={true}
-      showThumbnails={true}
-      images={images}
-      showArrow={true}
+      images={object('Images', defaultImages)}
+      peekSize={number('Peek Size', 20)}
+      gapSize={number('Gap Size', 10)}
+      centerMode={boolean('Center Mode', true)}
+      showThumbnails={boolean('Show Thumbnails', true)}
+      showArrow={boolean('Show Arrow', true)}
+      hideZoomButton={boolean('Hide Zoom Button', false)}
+      fillContainer={boolean('Fill Container', false)}
     />
   ));


### PR DESCRIPTION
[ Story #1078](https://github.com/brandingbrand/flagship/issues/1078)

**Description**
Added knobs to the zoom carousel story in storybook for the following props:
- images
- gapSize
- centerMode
- hideZoomButton
- fillContainer
- peekSize
- showArrow
- showThumbnails

**Testing**
- Pull down and run `yarn run dev:storybook`
- Open the Zoom Carousel story
- You can replace the current URLs with remote image URLs and interact with all of the props listed above