### PR TITLE
feat(fscomponents): ShareButton web support

### DIFF
--- a/packages/fscomponents/src/components/ShareButton/ShareButton.tsx
+++ b/packages/fscomponents/src/components/ShareButton/ShareButton.tsx
@@ -2,8 +2,8 @@ import React, { FunctionComponent, memo } from 'react';
 import { Clipboard, Image, Share, TouchableOpacity } from 'react-native';
 import { Alert } from '../Alert';
 import { ShareButtonProps } from './ShareButtonProps';
-import { translationKeys } from '@brandingbrand/fsi18n';
-const componentTranslation = translationKeys.flagship.shareButton.text;
+import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
+const componentTranslationKeys = translationKeys.flagship.shareButton;
 
 const shareImage = require('../../../assets/images/share.png');
 
@@ -20,12 +20,12 @@ export const ShareButton: FunctionComponent<ShareButtonProps> = memo(props => {
           const { url } = props.content;
           // @ts-ignore Web returns false on failure, native returns void
           if (Clipboard.setString(url) !== false) {
-            Alert.alert('URL copied to clipboard: ' + url);
+            Alert.alert(FSI18n.string(componentTranslationKeys.copied) + ': ' + url);
           } else {
-            Alert.alert('Unable to copy the URL to the clipboard');
+            Alert.alert(FSI18n.string(componentTranslationKeys.notCopied));
           }
         } else {
-          Alert.alert('Message sharing is not supported by your browser.');
+          Alert.alert(FSI18n.string(componentTranslationKeys.notSupported));
         }
       }
     });
@@ -52,7 +52,7 @@ export const ShareButton: FunctionComponent<ShareButtonProps> = memo(props => {
     <TouchableOpacity
       onPress={onSharePress}
       accessibilityRole={'button'}
-      accessibilityLabel={componentTranslation}
+      accessibilityLabel={FSI18n.string(componentTranslationKeys.text)}
     >
       {renderShareIcon()}
     </TouchableOpacity>

--- a/packages/fscomponents/src/components/ShareButton/ShareButton.web.tsx
+++ b/packages/fscomponents/src/components/ShareButton/ShareButton.web.tsx
@@ -1,8 +1,0 @@
-import React, { Component } from 'react';
-import { ShareButtonProps } from './ShareButtonProps';
-
-export class ShareButton extends Component<ShareButtonProps> {
-  render(): React.ReactNode {
-    return null;
-  }
-}

--- a/packages/fscomponents/src/components/__stories__/ShareButton.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ShareButton.story.tsx
@@ -7,11 +7,18 @@ import { storiesOf } from '@storybook/react'; // tslint:disable-line:no-implicit
 import { ShareButton } from '../ShareButton/ShareButton';
 
 storiesOf('ShareButton', module)
-  .add('basic usage', () => (
+  .add('share url', () => (
     <ShareButton
       content={{
         title: text('Share Text', 'Test Share Text'),
         url: text('Share URL', 'https://brandingbrand.github.io/flagship/storybook')
+      }}
+    />
+  )).add('share message', () => (
+    <ShareButton
+      content={{
+        title: text('Share Text', 'Test Share Text'),
+        message: text('Share Message', 'Test Share Message')
       }}
     />
   ));

--- a/packages/fscomponents/src/components/__stories__/ShareButton.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ShareButton.story.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {
+  text
+// tslint:disable-next-line no-submodule-imports no-implicit-dependencies
+} from '@storybook/addon-knobs/react';
+import { storiesOf } from '@storybook/react'; // tslint:disable-line:no-implicit-dependencies
+import { ShareButton } from '../ShareButton/ShareButton';
+
+storiesOf('ShareButton', module)
+  .add('basic usage', () => (
+    <ShareButton
+      content={{
+        title: text('Share Text', 'Test Share Text'),
+        url: text('Share URL', 'https://brandingbrand.github.io/flagship/storybook')
+      }}
+    />
+  ));

--- a/packages/fsi18n/src/translations/en.ts
+++ b/packages/fsi18n/src/translations/en.ts
@@ -310,7 +310,10 @@ export const keys: FSTranslationKeys = {
       nextBtn: 'Show next'
     },
     shareButton: {
-      text: 'Click To Share'
+      text: 'Click To Share',
+      copied: 'URL copied to clipboard',
+      notCopied: 'Unable to copy the URL to the clipboard',
+      notSupported: 'Message sharing is not supported by your browser.'
     },
     loginForm: {
       email: 'Email',

--- a/packages/fsi18n/src/types.ts
+++ b/packages/fsi18n/src/types.ts
@@ -377,6 +377,9 @@ export interface MultiCarouselTranslations<KeyType> {
 
 export interface ShareButtonTranslations<KeyType> {
   text: KeyType;
+  copied: KeyType;
+  notCopied: KeyType;
+  notSupported: KeyType;
 }
 export interface LoginFormTranslations<KeyType> {
   email: KeyType;


### PR DESCRIPTION
react-native-web has support for the same Share api that react-native uses, but it isn't supported by all browsers (mostly just mobile ones):
https://caniuse.com/#feat=web-share

This will attempt to use that same api and, if it isn't available, attempt to copy the url to the clipboard.