### PR TITLE
Apple Pay | Wrap Logic for Buttons

### DIFF
--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -16,6 +16,7 @@
     "@brandingbrand/fsfoundation": "^9.0.1",
     "@brandingbrand/fsi18n": "^9.0.1",
     "@brandingbrand/fsnetwork": "^9.0.1",
+    "@brandingbrand/react-native-payments": "^0.10.1",
     "@react-native-community/async-storage": "^1.6.1",
     "@types/yup": "^0.26.27",
     "credit-card": "^3.0.1",

--- a/packages/fscomponents/src/components/ApplePayButtonFK/index.tsx
+++ b/packages/fscomponents/src/components/ApplePayButtonFK/index.tsx
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import { NativeModules } from 'react-native';
+import { ApplePayButton, ApplePayButtonProps } from '../ApplePayButton';
+import {
+  PaymentDetailsInit,
+  PaymentRequest
+} from '@brandingbrand/react-native-payments';
+
+const { ReactNativePayments } = NativeModules;
+
+export interface ApplePayButtonFKProps extends ApplePayButtonProps {
+  iosMerchantIdentifier: string;
+  supportedNetworks: string[];
+  countryCode: string;
+  currencyCode: string;
+  paymentDetails: PaymentDetailsInit;
+  applePayReady?: boolean;
+  paymentOptions?: PaymentOptions;
+  insteadOfPayButton?: JSX.Element;
+  onApplePayReady: (canMakePayments: boolean) => void;
+}
+
+export interface ApplePayButtonFKState {
+  applePayReady: boolean;
+}
+
+export class ApplePayButtonFK extends Component<ApplePayButtonFKProps, ApplePayButtonFKState> {
+
+  constructor(props: ApplePayButtonFKProps) {
+    super(props);
+
+    this.state = {
+      applePayReady: props.applePayReady || false
+    };
+  }
+
+  onPayButtonReady = () => {
+    if (this.props.onApplePayReady && typeof this.props.onApplePayReady === 'function') {
+      this.props.onApplePayReady(this.state.applePayReady);
+    }
+  }
+
+  async componentDidMount(): Promise<void> {
+    try {
+      const paymentRequest = new PaymentRequest(
+        [{
+          supportedMethods: ['apple-pay'],
+          data: {
+            merchantIdentifier: this.props.iosMerchantIdentifier,
+            supportedNetworks: this.props.supportedNetworks,
+            countryCode: this.props.countryCode,
+            currencyCode: this.props.currencyCode
+          }
+        }],
+        this.props.paymentDetails,
+        this.props.paymentOptions
+      );
+
+      const canMakePayments = await paymentRequest.canMakePayment();
+
+      this.setState({ applePayReady: canMakePayments }, this.onPayButtonReady);
+    } catch (exception) {
+      this.setState({ applePayReady: false }, this.onPayButtonReady);
+    }
+  }
+
+  render(): React.ReactNode {
+    const { applePayReady } = this.state;
+
+    return ReactNativePayments.canMakePayments && applePayReady ? (
+      <ApplePayButton
+        buttonStyle={this.props.buttonStyle}
+        style={this.props.style}
+        applePayOnPress={this.props.applePayOnPress}
+      />
+    ) : (this.props.insteadOfPayButton || null);
+  }
+
+}

--- a/packages/fscomponents/src/components/index.ts
+++ b/packages/fscomponents/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './AddToCart';
 export * from './AddressForm';
 export * from './Alert';
 export * from './ApplePayButton';
+export * from './ApplePayButtonFK';
 export * from './Breadcrumbs';
 export * from './Button';
 export * from './CMSBanner';

--- a/packages/fscomponents/src/typings.d.ts
+++ b/packages/fscomponents/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module '@brandingbrand/react-native-payments';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,7 +1229,7 @@
   dependencies:
     "@brandingbrand/fsfoundation" "^0.1.0"
 
-"@brandingbrand/react-native-payments@^0.10.0":
+"@brandingbrand/react-native-payments@^0.10.0", "@brandingbrand/react-native-payments@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@brandingbrand/react-native-payments/-/react-native-payments-0.10.1.tgz#73ddd11b8231e6fb320f1deefb166bb3b0abfb96"
   integrity sha512-T6ULhmEYN6RyMHWV9stYA0YFAjD/dplE1X9SRo5nt6U+zDxFBRZH+I4AfjDgDeseaPxSi9cPpJpFZ//9famV1Q==


### PR DESCRIPTION
### Description:
New component | Ensure existing Apple Pay components are backwards-compatible

Create Wrapper for the ApplyPayButton | Provided by react-native payments, by doing this we can be sure that our UI is always synced to what apple is expecting.

This wrapper should contain all the logic to determine if the user is able to to make payments and if to show the apple pay button. 

Standardized Logic | All of the implementations currently rely on a variety of implemented logic.

BJ’s Wholesale | Utilizes the ApplePayButton component from react-native-payments ApplePayButton.md. 

This implementation allows us to maintain the apple required UI to the button simply by passing down the ‘type’ prop to the imported component. 

The FS ApplePayButton may not be needed as  react-native-payments provides ‘out of the box’ functionality. 

Arcadia | Implements a wrapper component called ApplePayBtn which imports the ApplePayButton from react-native-payments. 

Levis | Simply uses a .png for the applePay label. 

### Solution
Created wrapper for existing ApplePayButton using @brandingbrand/react-native-payments module for check opportunity to pay with ApplePayButton.