### PR TITLE
feat(fscomponents): add ada label and initial value prop to searh v8

### DIFF
--- a/packages/fscomponents/src/components/SearchBar.tsx
+++ b/packages/fscomponents/src/components/SearchBar.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-native';
 import { ClearButtonMode } from '../types/Store';
 import { style as S } from '../styles/SearchBar';
+import { tr, trKeys } from '../lib/translations';
 
 const kCancelButtonWidthDefault = 75; // In pts
 const kCancelButtonAnimationDuration = 200; // In ms
@@ -27,6 +28,7 @@ const isAndroid = Platform.OS === 'android';
 
 export interface SearchBarProps {
   placeholder?: string;
+  initialValue?: string;
   onSubmit?: (value: string) => void;
   onChange?: (value: string) => void;
   onFocus?: (input: any, container: any) => void;
@@ -36,6 +38,7 @@ export interface SearchBarProps {
 
   // accessibility
   accessibilityLabel?: string;
+  rightBtnAccessibilityLabel?: string;
 
   // visibility
   showSearchIcon?: boolean;
@@ -108,7 +111,7 @@ export class SearchBar extends PureComponent<SearchBarProps, SearchBarState> {
     }
 
     this.state = {
-      value: '',
+      value: props.initialValue || '',
       cancelButtonWidth,
       isFocused: false
     };
@@ -226,6 +229,10 @@ export class SearchBar extends PureComponent<SearchBarProps, SearchBarState> {
         style={rightBtnStyle}
         onPress={onRightBtnPress || this.handleSubmit}
         accessibilityRole='button'
+        accessibilityLabel={this.props.rightBtnAccessibilityLabel ||
+          tr.string(
+            trKeys.flagship.search.actions.search.accessibilityLabel, {value: this.state.value}
+          )}
       >
         {icon}
       </TouchableOpacity>

--- a/packages/fsi18n/src/translations/en.ts
+++ b/packages/fsi18n/src/translations/en.ts
@@ -159,6 +159,9 @@ export const keys: FSTranslationKeys = {
         clear: {
           actionBtn: 'Clear',
           accessibility: 'Clear Recent Search'
+        },
+        search: {
+          accessibilityLabel: 'Search and return results for {{value}}'
         }
       }
     },

--- a/packages/fsi18n/src/types.ts
+++ b/packages/fsi18n/src/types.ts
@@ -212,6 +212,9 @@ export interface SearchTranslations<KeyType> {
       actionBtn: KeyType;
       accessibility: KeyType;
     };
+    search: {
+      accessibilityLabel: KeyType;
+    };
   };
 }
 


### PR DESCRIPTION
 - add prop "initialValue" to allow the searchbar to be constructed with an initial value
 - add a default ada label to the search button, with a prop to use a custom string


version 8 version of the PR