### PR TITLE
feat: Add serializable props for CMSBanner component

### DIFF
--- a/packages/fscomponents/src/components/CMSBanner.tsx
+++ b/packages/fscomponents/src/components/CMSBanner.tsx
@@ -15,16 +15,25 @@ import {
 } from 'react-native';
 import { TouchableOpacityLink } from './TouchableOpacityLink';
 
-
-export interface CMSBannerProps {
-  imageContainerStyle?: StyleProp<ViewStyle>;
+export interface SerializableCMSBannerProps {
   imageHeight?: number;
   imageWidth?: number;
-  onPress?: (instance: any) => void;
-  style?: StyleProp<ViewStyle>;
   cmsData?: any;
   accessible?: boolean;
+  style?: ViewStyle;
+  imageContainerStyle?: ViewStyle;
+}
+
+
+export interface CMSBannerProps extends Omit<
+  SerializableCMSBannerProps,
+  'imageContainerStyle' |
+  'style'
+  > {
+  onPress?: (instance: any) => void;
   getAccessibilityLabel?: (instance: any) => string;
+  imageContainerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
 }
 
 export interface CMSBannerState {


### PR DESCRIPTION
This gives us a serializable version of the CMSBanner properties. This allows us to generate a schema of the properties that can be represented in JSON.