### PR TITLE
feat: Add serializable props for ImageWithOverlay component

### DIFF
--- a/packages/fscomponents/src/components/ImageWithOverlay.tsx
+++ b/packages/fscomponents/src/components/ImageWithOverlay.tsx
@@ -6,16 +6,17 @@ import { get } from 'lodash-es';
 
 export interface SerializedImageWithOverlayProps {
   imageProps: FadeInImageProps;
-  overlay?: string | JSX.Element;
+  overlay?: string;
   style?: ViewStyle;
 }
 
 export interface ImageWithOverlayProps extends Omit<SerializedImageWithOverlayProps,
   'style' |
-  'overlayPosition'
+  'overlayPosition' |
+  'overlay'
   > {
   imageProps: FadeInImageProps;
-  overlay?: JSX.Element;
+  overlay?: string | JSX.Element;
   style?: StyleProp<ViewStyle>;
   overlayPosition?:
     | 'bottomLeft'

--- a/packages/fscomponents/src/components/ImageWithOverlay.tsx
+++ b/packages/fscomponents/src/components/ImageWithOverlay.tsx
@@ -4,7 +4,16 @@ import { style as S } from '../styles/ImageWithOverlay';
 import { FadeInImage, FadeInImageProps } from './FadeInImage';
 import { get } from 'lodash-es';
 
-export interface ImageWithOverlayProps {
+export interface SerializedImageWithOverlayProps {
+  imageProps: FadeInImageProps;
+  overlay?: string | JSX.Element;
+  style?: ViewStyle;
+}
+
+export interface ImageWithOverlayProps extends Omit<SerializedImageWithOverlayProps,
+  'style' |
+  'overlayPosition'
+  > {
   imageProps: FadeInImageProps;
   overlay?: JSX.Element;
   style?: StyleProp<ViewStyle>;


### PR DESCRIPTION
This gives us a serializable version of the ImageWithOverlay properties. This allows us to generate a schema of the properties that can be represented in JSON.