### PR TITLE
feat: add serializable props to PayPalCheckoutButton component

### DIFF
--- a/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
+++ b/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
@@ -9,10 +9,17 @@ type LimitedButtonProps = Omit<ButtonProps, 'color' | 'light' | 'link' | 'palett
 export type ButtonShape = 'pill' | 'rect';
 export type ButtonTheme = 'gold' | 'blue' | 'silver' | 'black';
 
-export interface PayPalCheckoutButtonProps extends LimitedButtonProps {
+export interface SerializablePayPalCheckoutButtonProps extends LimitedButtonProps {
   shape: ButtonShape;
   theme: ButtonTheme;
   tagLine?: string;
+  tagLineStyle?: TextStyle;
+}
+
+export interface PayPalCheckoutButtonProps extends LimitedButtonProps, Omit<
+  SerializablePayPalCheckoutButtonProps,
+  'tagLineStyle'
+  > {
   tagLineStyle?: StyleProp<TextStyle>;
 }
 type DefaultProps = Pick<PayPalCheckoutButtonProps, 'shape' | 'theme' | 'title' | 'tagLine'>;


### PR DESCRIPTION
Create serializable props interface for PayPalCheckoutButton component