### PR TITLE
feat: add serializable props to ApplePayButton component

### DIFF
--- a/packages/fscomponents/src/components/ApplePayButton/ApplePayButtonProps.ts
+++ b/packages/fscomponents/src/components/ApplePayButton/ApplePayButtonProps.ts
@@ -1,7 +1,16 @@
 import { InjectedProps } from '../DigitalWalletProvider';
 import { StyleProp, ViewStyle } from 'react-native';
 
-export interface ApplePayButtonProps extends InjectedProps {
+export interface SerializableApplePayButtonProps extends InjectedProps {
+  buttonStyle?: 'black' | 'white' | 'white-with-line';
+  style?: ViewStyle;
+}
+
+export interface ApplePayButtonProps extends InjectedProps, Omit<
+  SerializableApplePayButtonProps,
+  'style' |
+  'buttonStyle'
+  > {
   applePayOnPress: () => void;
   buttonStyle?: 'black' | 'white' | 'white-with-line';
   style?: StyleProp<ViewStyle>;


### PR DESCRIPTION
add serializable props to ApplePayButton component