### PR TITLE
fix(fsengagement): Header for discover start missing after deeplinking

### DIFF
--- a/packages/fsengagement/src/EngagementComp.tsx
+++ b/packages/fsengagement/src/EngagementComp.tsx
@@ -245,6 +245,16 @@ export default function(
     handlePageCounterRef = (ref: any) => this.AnimatedPageCounter = ref;
     handleNavTitleRef = (ref: any) => this.AnimatedNavTitle = ref;
 
+    componentWillUnmount(): void {
+      // Check if closing because of navigation change or ui
+      if (!this.state.isClosingAnimation) {
+        // If navigation change also try to return back out of the story
+        if (this.props.onBack) {
+          this.props.onBack();
+        }
+      }
+    }
+
     componentDidMount(): void {
       if (this.props.animate) {
         if (this.props.json && this.props.json.tabbedItems && this.props.json.tabbedItems.length) {


### PR DESCRIPTION
The header is missing when deeplinking out of an engagement story
This happens because dismissAllModals is being called when changing tabs

Added a cleanup function componentWillUnmount to handle this interaction