### PR TITLE
fix: address android bundle restart crashes

### DIFF
--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -24,7 +24,7 @@
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^5.0.0",
     "react-native-navigation": "^4.0.0",
-    "react-native-restart": "^0.0.13",
+    "react-native-restart": "git+https://github.com/brandingbrand/react-native-restart#0.0.13-hotfix",
     "react-native-sensitive-info": "^5.5.0",
     "react-native-web-modal": "^1.0.1",
     "react-redux": "^7.0.0",

--- a/packages/pirateship/src/index.ts
+++ b/packages/pirateship/src/index.ts
@@ -33,7 +33,7 @@ const appConfig: FSAppTypes.AppConfigType = {
           icon: require('../assets/images/shop-inbox-icn.png')
         }
       }
-    },     {
+    }, {
       id: 'SHOP_TAB',
       name: 'Shop',
       options: {

--- a/packages/pirateship/src/lib/shortcuts.ts
+++ b/packages/pirateship/src/lib/shortcuts.ts
@@ -27,35 +27,8 @@ export const handleAccountRequestError = (
 ): void => {
   if (error.response && error.response.status && error.response.status === 401) {
     signOutFn()
-      .then(() => {
-        navigator.setStackRoot({
-          component: {
-            name: 'Account',
-            options: {
-              topBar: {
-                title: {
-                  text: 'Account'
-                }
-              }
-            }
-          }
-        }).catch(e => console.warn('Account SETSTACKROOT error: ', e));
-      })
       .catch(e => {
         console.warn('Error signing user out', e);
-
-        navigator.setStackRoot({
-          component: {
-            name: 'Account',
-            options: {
-              topBar: {
-                title: {
-                  text: 'Account'
-                }
-              }
-            }
-          }
-        }).catch(e => console.warn('Account SETSTACKROOT error: ', e));
       });
   } else {
     console.warn(error, error.response);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13469,10 +13469,9 @@ react-native-permissions@~1.1.1:
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-1.1.1.tgz#4876004681ff8556454613d85249b01baff9b35b"
   integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
 
-react-native-restart@^0.0.13:
+"react-native-restart@git+https://github.com/brandingbrand/react-native-restart#0.0.13-hotfix":
   version "0.0.13"
-  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.13.tgz#88003fd6b1cce9de5bafa2570ba4ef8ff1ea2937"
-  integrity sha512-p4rBiTliPiJEejA0IhExHuM7Ge6TuLpUAm98TbtkmiISWDRK2a/DeZ4Wno7bawcMr1Yb6O5eeTHPO0rUltRD/A==
+  resolved "git+https://github.com/brandingbrand/react-native-restart#57c34c52e3bc573554b92f22ef4ce0500f41973e"
 
 react-native-safe-area@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
This PR includes a series of fixes that attempt to alleviate crashing when restarting the bundle on Android.

- Use BB fork of react-native-restart package which contains a fix to the Android code
- Wrap Navigation.setRoot() in fsapp inside runAfterInteractions which appears to help alleviate Navigation being clobbered on startup (inspired by https://github.com/wix/react-native-navigation/issues/3767#issuecomment-438029517)
- Refactor tab logic in fsapp so that tabs are generated before setting them in the Navigator
- Update tab schema to follow recommended format (https://github.com/wix/react-native-navigation/issues/5096#issuecomment-492032466)
- Removed non-printable character from PirateShip initialization config
- Removed setStackRoot() calls in PirateShip that were being used when authentication failed on app startup. These appeared to be clobbering Navigation when it was trying to initialize the app.

## TEST
- Run PirateShip for iOS & Android
- Click FS Dev Menu > Reload JS button
- Repeat several times in succession
- Verify that app doesn't crash (may crash after several attempts due to resource exhaustion but previously Android was crashing after the first or second try)