### PR TITLE
feat(flagship): Custom Short Version string for iOS

### DIFF
--- a/packages/flagship/src/lib/__tests__/ios.test.ts
+++ b/packages/flagship/src/lib/__tests__/ios.test.ts
@@ -268,6 +268,26 @@ test('provide custom bundle version number', () => {
   expect(infoPlist).toMatch(`<key>CFBundleVersion</key>\n\t<string>1.3.3</string>`);
 });
 
+test('provide custom short version number', () => {
+  const version = '1.3.2';
+  ios.version(
+    {
+      name: appName,
+      ios: {
+        shortVersion: '1.3.3'
+      }
+    },
+    version
+  );
+
+  const infoPlist = fs
+    .readFileSync(nodePath.join(tempRootDir, `ios/${appName}/Info.plist`))
+    .toString();
+
+  expect(infoPlist).toMatch(`<key>CFBundleShortVersionString</key>\n\t<string>1.3.3</string>`);
+  expect(infoPlist).toMatch(`<key>CFBundleVersion</key>\n\t<string>01003002</string>`);
+});
+
 test(`set env switcher initial env`, () => {
   ios.setEnvSwitcherInitialEnv(
     {

--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -348,6 +348,9 @@ export function urlScheme(configuration: Config): void {
  * @param {string} newVersion The version number to set.
  */
 export function version(configuration: Config, newVersion: string): void {
+  const shortVersion = (configuration.ios && configuration.ios.shortVersion)
+  || newVersion;
+
   const bundleVersion = (configuration.ios && configuration.ios.buildVersion)
     || versionLib.normalize(newVersion);
 
@@ -357,7 +360,7 @@ export function version(configuration: Config, newVersion: string): void {
   fs.update(
     path.ios.infoPlistPath(configuration),
     /\<key\>CFBundleShortVersionString\<\/key\>[\n\r\s]+\<string\>[\d\.]+<\/string\>/,
-    `<key>CFBundleShortVersionString</key>\n\t<string>${newVersion}</string>`
+    `<key>CFBundleShortVersionString</key>\n\t<string>${shortVersion}</string>`
   );
 
   fs.update(

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -152,6 +152,7 @@ export interface AndroidConfig {
 export interface IOSConfig {
   pods?: PodsConfig;
   buildVersion?: string;
+  shortVersion?: string;
 }
 
 export interface PodsConfig {


### PR DESCRIPTION
Updated iOS config to support custom shortVersion build number
Added tests
This may require changes to iosExtension PR as well

This will allow builds for multi-tenant apps that are using different versions.
This is already possible with Android builds.