### PR TITLE
fix(fsapp): Close dev menu before restart

### DIFF
--- a/packages/fsapp/src/components/DevMenu.tsx
+++ b/packages/fsapp/src/components/DevMenu.tsx
@@ -243,7 +243,12 @@ export default class DevMenu extends Component<DevMenuProp, DevMenuState> {
   }
 
   restart = () => {
-    RNRestart.Restart();
+    this.props.hideDevMenu();
+    this.props.navigator.dismissModal()
+      .then(() => {
+        RNRestart.Restart();
+      })
+      .catch(err => console.warn('DevMenu DISMISSMODAL error: ', err));
   }
 
   dismissModal = () => {


### PR DESCRIPTION
There is a bug in react-native-navigation where it can hang when it tries to close any open modals when restarting. (This line never calling the callback: https://github.com/wix/react-native-navigation/blob/a641b0976f18c54a0d649cf7905b6c83ab2ebf67/lib/ios/RNNModalManager.m#L70) This change closes the dev menu modal before trying to restart to avoid that issue. It could still occur if another modal is open, though, so this is an incomplete fix.

TEST
------------------
- run on iOS
- open the dev menu and either change the environment or click "Reload JS"
- should restart the application