### PR TITLE
fix(fscomponents): Fix crash for empty carousel

### DIFF
--- a/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
+++ b/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
@@ -45,7 +45,7 @@ export class Carousel extends Component<CarouselProps> {
             } : {}}
             {...webOptions}
           >
-            {_children && _children.map((child: any, i: number) => {
+            {React.Children.map(_children, (child, i) => {
               return (
                 <View key={i} style={{ height }}>
                   {child}

--- a/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
+++ b/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
@@ -45,7 +45,7 @@ export class Carousel extends Component<CarouselProps> {
             } : {}}
             {...webOptions}
           >
-            {_children.map((child: any, i: number) => {
+            {_children && _children.map((child: any, i: number) => {
               return (
                 <View key={i} style={{ height }}>
                   {child}

--- a/packages/fscomponents/src/components/__stories__/Carousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/Carousel.story.tsx
@@ -66,4 +66,9 @@ storiesOf('Carousel', module)
       {textSlide}
       {textSlide}
     </Carousel>
+  ))
+  .add('empty', () => (
+    <Carousel
+      height={190}
+    />
   ));


### PR DESCRIPTION
If the carousel was empty, it would crash. This gives you a way to test it in the storybook and fixes the crash.