### PR TITLE
fix(fscomponents): fix serializable accordion props

### DIFF
--- a/packages/fscomponents/src/components/Accordion.tsx
+++ b/packages/fscomponents/src/components/Accordion.tsx
@@ -88,7 +88,7 @@ export interface SerializableAccordionProps {
   /**
    * Content of the accordion title
    */
-  title: string | JSX.Element;
+  title: string;
   /**
    *  Styles for the accordion title container
    */
@@ -121,6 +121,7 @@ export interface AccordionProps extends Omit<
   'openTitleStyle' |
   'plusMinusStyle' |
   'style' |
+  'title' |
   'titleContainerStyle' |
   'titleStyle' |
   'titleTouchStyle'
@@ -166,6 +167,10 @@ export interface AccordionProps extends Omit<
    * Styles for the accordion container
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Content of the accordion title
+   */
+  title: string | JSX.Element;
   /**
    *  Styles for the accordion title container
    */


### PR DESCRIPTION
`JSX.Element` is not a serializable property