### PR TITLE
fix(fscomponents): Fix crashes with bad currency codes

### DIFF
--- a/packages/fscomponents/src/components/CartItem/CartItemDetails.tsx
+++ b/packages/fscomponents/src/components/CartItem/CartItemDetails.tsx
@@ -36,20 +36,38 @@ memo((props): JSX.Element => {
     totalPrice
   } = props;
 
+  let convertedPrice: string | undefined;
+  try {
+    if (price) {
+      convertedPrice = FSI18n.currency(price);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  let convertedTotalPrice: string | undefined;
+  try {
+    if (totalPrice) {
+      convertedTotalPrice = FSI18n.currency(totalPrice);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
   return (
     <View style={style}>
       {itemText && <Text style={[defaultStyles.detailText, detailTextStyle]}>{itemText}</Text>}
       {productId && <Text style={[defaultStyles.detailText, detailTextStyle]}>#{productId}</Text>}
-      {price && (
+      {convertedPrice && (
         <Text style={[defaultStyles.detailText, detailTextStyle]}>
           {FSI18n.string(componentTranslationKeys.unitPrice)}:
-          {FSI18n.currency(price)}
+          {FSI18n.currency(convertedPrice)}
         </Text>
       )}
-      {totalPrice && (
+      {convertedTotalPrice && (
         <Text style={detailTextStyle}>
           {FSI18n.string(componentTranslationKeys.totalPrice)}:
-          {FSI18n.currency(totalPrice)}
+          {FSI18n.currency(convertedTotalPrice)}
         </Text>
       )}
     </View>

--- a/packages/fscomponents/src/components/CartItem/CartItemDetails.tsx
+++ b/packages/fscomponents/src/components/CartItem/CartItemDetails.tsx
@@ -61,13 +61,13 @@ memo((props): JSX.Element => {
       {convertedPrice && (
         <Text style={[defaultStyles.detailText, detailTextStyle]}>
           {FSI18n.string(componentTranslationKeys.unitPrice)}:
-          {FSI18n.currency(convertedPrice)}
+          {convertedPrice}
         </Text>
       )}
       {convertedTotalPrice && (
         <Text style={detailTextStyle}>
           {FSI18n.string(componentTranslationKeys.totalPrice)}:
-          {FSI18n.currency(convertedTotalPrice)}
+          {convertedTotalPrice}
         </Text>
       )}
     </View>

--- a/packages/fscomponents/src/components/ProductItem/components/ProductItemPrice.tsx
+++ b/packages/fscomponents/src/components/ProductItem/components/ProductItemPrice.tsx
@@ -47,14 +47,28 @@ export class ProductItemPrice extends Component<ProductItemPriceProps> {
       return null;
     }
 
+    let convertedPrice: string | undefined;
+    try {
+      convertedPrice = FSI18n.currency(price);
+    } catch (e) {
+      console.error(e);
+    }
+
     if (originalPrice && !originalPrice.value.equals(price.value)) {
+      let convertedOriginalPrice: string | undefined;
+      try {
+        convertedOriginalPrice = FSI18n.currency(originalPrice);
+      } catch (e) {
+        console.error(e);
+      }
+
       return (
         <View style={[style.priceContainer]}>
           <Text style={[types.small, weights.regular, style.originalPrice, originalPriceStyle]}>
-            {FSI18n.currency(originalPrice)}
+            {convertedOriginalPrice}
           </Text>
           <Text style={[types.small, weights.medium, style.salePrice, salePriceStyle]}>
-            {FSI18n.currency(price)}
+            {convertedPrice}
           </Text>
         </View>
       );
@@ -62,7 +76,7 @@ export class ProductItemPrice extends Component<ProductItemPriceProps> {
       return (
         <View style={[style.priceContainer]}>
           <Text style={[types.small, weights.medium, priceStyle]}>
-            {FSI18n.currency(price)}
+            {convertedPrice}
           </Text>
         </View>
       );

--- a/packages/fscomponents/src/components/ProductMetadata.tsx
+++ b/packages/fscomponents/src/components/ProductMetadata.tsx
@@ -70,6 +70,7 @@ export const ProductMetadata: FunctionComponent<ProductMetadataProps> = memo((pr
       <Text style={[styles.title, props.titleStyle]}>{props.title}</Text>
     );
   };
+  // tslint:disable-next-line: cyclomatic-complexity
   const renderPrice = (): JSX.Element => {
     const {
       originalPriceStyle,
@@ -85,11 +86,30 @@ export const ProductMetadata: FunctionComponent<ProductMetadataProps> = memo((pr
       originalPrice && salePriceStyle || null
     ];
 
+    let convertedPrice: string | undefined;
+    try {
+      if (price) {
+        convertedPrice = FSI18n.currency(price);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
+    let convertedOriginalPrice: string | undefined;
+    try {
+      if (originalPrice) {
+        convertedOriginalPrice = FSI18n.currency(originalPrice);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+
+
     return (
       <View style={styles.priceContainer}>
-        {originalPrice && (
+        {convertedOriginalPrice && (
           <Text style={[styles.originalPrice, originalPriceStyle]}>
-            {FSI18n.currency(originalPrice)}
+            {convertedOriginalPrice}
           </Text>
         )}
         {price && (
@@ -97,7 +117,7 @@ export const ProductMetadata: FunctionComponent<ProductMetadataProps> = memo((pr
             <Text
               style={priceStyleGenerated}
             >
-              {FSI18n.currency(price)}
+              {convertedPrice}
             </Text>
           </View>
         )}

--- a/packages/fscomponents/src/components/Total.tsx
+++ b/packages/fscomponents/src/components/Total.tsx
@@ -61,8 +61,14 @@ const TotalInner = (props: TotalProps): JSX.Element => {
       );
     }
     if (isCurrency(data)) {
+      let convertedTotal: string | undefined;
+      try {
+        convertedTotal = FSI18n.currency(data);
+      } catch (e) {
+        console.error(e);
+      }
       return (
-        <Text style={style}>{FSI18n.currency(data)}</Text>
+        <Text style={style}>{convertedTotal}</Text>
       );
     }
     return data;


### PR DESCRIPTION
If your currency code was invalid, it would crash the app when it tried to render. This wraps those conversions in a try/catch, so it will put the error in the console and display as if the currency value was undefined instead of crashing.