### PR TITLE
fix(fscomponents): Remove redundant code in SearchModal

### DIFF
--- a/packages/fscomponents/src/components/SearchModal.tsx
+++ b/packages/fscomponents/src/components/SearchModal.tsx
@@ -1,326 +1,41 @@
 import React, { Component } from 'react';
-import {
-  ScrollView,
-  StyleProp,
-  Text,
-  TextStyle,
-  TouchableHighlight,
-  TouchableOpacity,
-  View,
-  ViewStyle
-} from 'react-native';
-import AsyncStorage from '@react-native-community/async-storage';
 import { Modal } from './Modal';
-import { HighlightResult, HighlightResultAccumulator } from './SearchScreen';
-import { style as S } from '../styles/SearchScreen';
-import { SearchBar, SearchBarProps } from './SearchBar';
-import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
+import { SearchScreen, SearchScreenProps, SerializableSearchScreenProps } from './SearchScreen';
 
-const searchIcon = require('../../assets/images/search.png');
-
-const SEARCH_MODAL_HISTORY_KEY = 'SEARCH_MODAL_HISTORY_KEY';
-const MAX_HISTORY_ITEM_NUM = 5;
-
-export interface SearchModalResult {
-  title: string;
-  query: string;
-  [key: string]: any;
-}
-
-export interface SerializableSearchModalProps {
+interface SharedSearchModalProps {
   visible: boolean;
-  itemStyle?: ViewStyle;
-  itemTextStyle?: TextStyle;
 }
 
-export interface SearchModalProps extends Omit<
-  SerializableSearchModalProps,
-  'itemStyle' |
-  'itemTextStyle'
-  > {
-  onClose: () => void;
-  onResultPress?: (result: SearchModalResult) => void;
-  onInputChange?: (value: string) => void;
-  onInputSubmit?: (value: string) => void;
-  renderResultItem?: (
-    result: SearchModalResult,
-    index: number,
-    inputValue: string
-  ) => React.ReactNode;
-  searchBarProps?: SearchBarProps;
-  results?: SearchModalResult[];
-  itemStyle?: StyleProp<ViewStyle>;
-  itemTextStyle?: StyleProp<TextStyle>;
+export interface SerializableSearchModalProps extends
+  SerializableSearchScreenProps, SharedSearchModalProps {
 }
 
-export interface SearchModalState {
-  history: SearchModalResult[];
-  inputValue: string;
+export interface SearchModalProps extends SearchScreenProps, SharedSearchModalProps {
 }
 
-export class SearchModal extends Component<SearchModalProps, SearchModalState> {
+export class SearchModal extends Component<SearchModalProps> {
   searchBar: any;
-
-  constructor(props: SearchModalProps) {
-    super(props);
-
-    this.state = {
-      history: [],
-      inputValue: ''
-    };
-  }
-
-  componentDidMount(): void {
-    this.loadHistoryToState();
-  }
 
   componentDidUpdate(prevProps: SearchModalProps): void {
     if (!prevProps.visible && this.props.visible) {
       setTimeout(() => {
         this.searchBar.focusInput();
       }, 100);
-
-      this.loadHistoryToState();
     }
-  }
-
-  loadHistoryToState = () => {
-    this.getHistory()
-      .then(history => {
-        this.setState({ history, inputValue: '' });
-      })
-      .catch(e => console.warn(e));
-  }
-
-  getSearchBarRef = (ref: any) => {
-    this.searchBar = ref;
-  }
-
-  getHistory = async (): Promise<SearchModalResult[]> => {
-    const historyData = await AsyncStorage.getItem(SEARCH_MODAL_HISTORY_KEY) || '[]';
-    try {
-      const history = JSON.parse(historyData);
-      return history.slice(0, MAX_HISTORY_ITEM_NUM);
-    } catch (e) {
-      await AsyncStorage.setItem(SEARCH_MODAL_HISTORY_KEY, '[]');
-      return [];
-    }
-  }
-
-  addToHistory = async (item: SearchModalResult) => {
-    let history = await this.getHistory();
-    const existIndex = history.findIndex(result => result.title === item.title);
-
-    if (existIndex > -1) {
-      history = history
-        .slice(0, existIndex)
-        .concat(history.slice(existIndex + 1));
-      history.unshift(item);
-    } else {
-      history.unshift(item);
-      history = history.slice(0, MAX_HISTORY_ITEM_NUM);
-    }
-
-    await AsyncStorage.setItem(
-      SEARCH_MODAL_HISTORY_KEY,
-      JSON.stringify(history)
-    );
-    return history;
-  }
-
-  handleResultPress = (result: SearchModalResult) => () => {
-    this.addToHistory(result).catch(e => console.warn(e));
-    if (this.props.onResultPress) {
-      return this.props.onResultPress(result);
-    }
-  }
-
-  handleSubmit = (value: string) => {
-    this.addToHistory({
-      title: value,
-      query: value
-    }).catch(e => console.warn(e));
-
-    if (this.props.onInputSubmit) {
-      return this.props.onInputSubmit(value);
-    }
-  }
-
-  clearHistory = async () => {
-    await AsyncStorage.setItem(SEARCH_MODAL_HISTORY_KEY, '[]');
-    this.setState({ history: [] });
-  }
-
-  renderHistory = () => {
-    if (!this.state.history || !this.state.history.length) {
-      return null;
-    }
-
-    return (
-      <ScrollView
-        style={S.resultsContainer}
-        keyboardShouldPersistTaps='always'
-        keyboardDismissMode='on-drag'
-      >
-        <View style={S.recentSearchContainer}>
-          <Text style={S.recentSearch}>
-            {FSI18n.string(translationKeys.flagship.search.recentSearches)}:
-          </Text>
-
-          <TouchableOpacity
-            onPress={this.clearHistory}
-            accessibilityLabel={
-              FSI18n.string(translationKeys.flagship.search.actions.clear.accessibility)
-            }
-          >
-            <Text style={S.recentSearchClearText}>
-              {FSI18n.string(translationKeys.flagship.search.actions.clear.actionBtn)}
-            </Text>
-          </TouchableOpacity>
-        </View>
-        {this.state.history.map(this.renderItem)}
-      </ScrollView>
-    );
-  }
-
-  renderResult = () => {
-    if (!this.props.results || !this.props.results.length) {
-      if (this.props.results === null) {
-        return this.renderHistory();
-      } else {
-        return null;
-      }
-    }
-
-    return (
-      <ScrollView
-        style={S.resultsContainer}
-        keyboardShouldPersistTaps='always'
-        keyboardDismissMode='on-drag'
-      >
-        {this.props.results.map(this.renderItem)}
-      </ScrollView>
-    );
-  }
-
-  renderItem = (item: SearchModalResult, i: number) => {
-    if (this.props.renderResultItem) {
-      return this.props.renderResultItem(item, i, this.state.inputValue);
-    }
-
-    return (
-      <TouchableHighlight
-        key={i}
-        underlayColor='#f8f8f8'
-        style={[S.resultItem, this.props.itemStyle]}
-        onPress={this.handleResultPress(item)}
-        accessibilityLabel={`Search ${item.title}`}
-      >
-        {this.renderTextWithHighLighs(item.title, this.state.inputValue)}
-      </TouchableHighlight>
-    );
-  }
-
-  renderTextWithHighLighs = (name: string = '', query: string) => {
-    const strArr = highlightStr(name, query);
-
-    return (
-      <Text style={[S.suggestionTitle, this.props.itemTextStyle]}>
-        {strArr.map((str: HighlightResult, i: number) => {
-          return (
-            <Text key={i} style={str.isHighlight && S.suggestionHighlight}>
-              {str.str}
-            </Text>
-          );
-        })}
-      </Text>
-    );
-  }
-
-  handleChange = (value: string) => {
-    this.setState({ inputValue: value });
-    if (this.props.onInputChange) {
-      return this.props.onInputChange(value);
-    }
-  }
-
-  renderSearchBar = () => {
-    return (
-      <View style={S.searchBarContainer}>
-        <SearchBar
-          ref={this.getSearchBarRef}
-          onCancel={this.props.onClose}
-          onSubmit={this.handleSubmit}
-          onChange={this.handleChange}
-          showSearchIcon={true}
-          searchIcon={searchIcon}
-          cancelButtonAlwaysVisible={true}
-          {...this.props.searchBarProps}
-        />
-      </View>
-    );
   }
 
   render(): JSX.Element {
+    const { visible, ...searchProps } = this.props;
     return (
       <Modal
         visible={this.props.visible}
         animationType='fade'
         onRequestClose={this.props.onClose}
       >
-        <View style={S.modalContainer}>
-          {this.renderSearchBar()}
-          {this.renderResult()}
-        </View>
+        <SearchScreen
+          {...searchProps}
+        />
       </Modal>
     );
   }
-}
-
-function highlightStr(name: string, query: string): HighlightResult[] {
-  let queryRegx;
-
-  try {
-    queryRegx = new RegExp(query, 'ig');
-  } catch (e) {
-    return [
-      {
-        str: name,
-        isHighlight: false
-      }
-    ];
-  }
-
-  const matches = name.match(queryRegx);
-  if (!matches || !query) {
-    return [
-      {
-        str: name,
-        isHighlight: false
-      }
-    ];
-  }
-
-  const textSplits = name.split(queryRegx).reduce(
-    (acc: HighlightResultAccumulator, item, index) => {
-      if (item) {
-        acc.result.push({
-          str: item,
-          isHighlight: false
-        });
-      }
-
-      if (matches[index]) {
-        acc.result.push({
-          str: matches[index],
-          isHighlight: true
-        });
-      }
-
-      return acc;
-    },
-    { result: [] }
-  );
-
-  return textSplits.result;
 }

--- a/packages/fscomponents/src/components/SearchScreen.tsx
+++ b/packages/fscomponents/src/components/SearchScreen.tsx
@@ -201,7 +201,7 @@ export class SearchScreen extends PureComponent<SearchScreenProps, SearchScreenS
 
   renderResult = () => {
     if (!this.props.results || !this.props.results.length) {
-      if (this.props.results === null) {
+      if (this.props.results === undefined) {
         return this.renderHistory();
       } else {
         return null;

--- a/packages/fscomponents/src/components/SearchScreen.tsx
+++ b/packages/fscomponents/src/components/SearchScreen.tsx
@@ -30,7 +30,6 @@ export interface HighlightResultAccumulator {
 
 export interface SearchScreenResult {
   title: string;
-  query: string;
   [key: string]: any;
 }
 
@@ -78,11 +77,12 @@ export interface SearchScreenState {
 }
 
 export class SearchScreen extends PureComponent<SearchScreenProps, SearchScreenState> {
-  searchBar: any;
+  searchBar: SearchBar | null;
 
   constructor(props: SearchScreenProps) {
     super(props);
 
+    this.searchBar = null;
     this.state = {
       history: [],
       inputValue: ''
@@ -101,14 +101,14 @@ export class SearchScreen extends PureComponent<SearchScreenProps, SearchScreenS
     const { searchBarShouldFocus } = this.props;
 
     // Focus on the search bar by default
-    if (searchBarShouldFocus === undefined || searchBarShouldFocus) {
+    if (searchBarShouldFocus !== false && this.searchBar) {
       this.searchBar.focusInput();
     }
 
     this.loadHistoryToState();
   }
 
-  getSearchBarRef = (ref: any) => {
+  getSearchBarRef = (ref: SearchBar | null) => {
     this.searchBar = ref;
   }
 
@@ -236,17 +236,17 @@ export class SearchScreen extends PureComponent<SearchScreenProps, SearchScreenS
         onPress={this.handleResultPress(item)}
         accessibilityLabel={`Search ${item.title}`}
       >
-        {this.renderTextWithHighLighs(item.title, this.state.inputValue)}
+        {this.renderTextWithHighLights(item.title, this.state.inputValue)}
       </TouchableHighlight>
     );
   }
 
-  renderTextWithHighLighs = (name: string = '', query: string) => {
+  renderTextWithHighLights = (name: string = '', query: string) => {
     const strArr = highlightStr(name, query);
 
     return (
       <Text style={[S.suggestionTitle, this.props.itemTextStyle]}>
-        {strArr.map((str: any, i: number) => {
+        {strArr.map((str: HighlightResult, i: number) => {
           return (
             <Text key={i} style={str.isHighlight && S.suggestionHighlight}>
               {str.str}

--- a/packages/fscomponents/src/components/SearchScreen.tsx
+++ b/packages/fscomponents/src/components/SearchScreen.tsx
@@ -200,12 +200,10 @@ export class SearchScreen extends PureComponent<SearchScreenProps, SearchScreenS
   }
 
   renderResult = () => {
-    if (!this.props.results || !this.props.results.length) {
-      if (this.props.results === undefined) {
-        return this.renderHistory();
-      } else {
-        return null;
-      }
+    if (!this.props.results) {
+      return this.renderHistory();
+    } else if (!this.props.results.length) {
+      return null;
     }
 
     return (

--- a/packages/pirateship/src/screens/Search.tsx
+++ b/packages/pirateship/src/screens/Search.tsx
@@ -88,7 +88,7 @@ const NoSearchResultsStyle = StyleSheet.create({
 });
 
 export interface SearchState {
-  suggestions: any;
+  suggestions: (CommerceTypes.BrandSuggestion | CommerceTypes.CategorySuggestion)[] | null;
   showResult: boolean;
   keyword: string;
 }
@@ -129,7 +129,7 @@ class Search extends Component<SearchProps, SearchState> {
         needInSafeArea={true}
       >
         <SearchSuggestionScreen
-          results={result}
+          results={result || undefined}
           onClose={this.handleCancel}
           onResultPress={this.handleSearchResultPress}
           onInputChange={this.handleInputChange}
@@ -304,7 +304,7 @@ class Search extends Component<SearchProps, SearchState> {
     (value: string) => {
       dataSource
         .searchSuggestion(value)
-        .then((data: any) => {
+        .then((data: CommerceTypes.SearchSuggestion) => {
           this.setState({
             suggestions: this.getAllSuggestions(data)
           });
@@ -370,15 +370,10 @@ class Search extends Component<SearchProps, SearchState> {
     }
   }
 
-  getAllSuggestions = (data: any) => {
-    const groups = [
-      { name: 'brandSuggestions', dataKey: 'brands' },
-      { name: 'categorySuggestions', dataKey: 'categories' },
-      { name: 'brandPartSuggestions', dataKey: 'brandPartTypes' }
-    ];
-
-    const suggestions = groups
-      .map((key: any) => data[key.name] && data[key.name][key.dataKey])
+  getAllSuggestions = (data: CommerceTypes.SearchSuggestion) => {
+    const suggestions: (CommerceTypes.BrandSuggestion | CommerceTypes.CategorySuggestion)[] =
+      (data.brandSuggestions?.brands || [])
+      .concat(data.categorySuggestions?.categories || [])
       .filter(Boolean);
 
     return flatten(suggestions);


### PR DESCRIPTION
Almost all the code in SearchModal is identical to the code in SearchScreen, just with the Modal wrapper added and a few less options. This makes the SearchModal wrap a SearchScreen in a Modal, which allows those same options to work with SearchModal and removes repeated code. The result should be no changes to how the SearchModal works, except for the addition of some options in SearchScreen that weren't there before.

Also fixed some typing in SearchScreen and PirateShip's Search screen. brandPartSuggestions was referring to some old code that isn't part of fscommerce anymore, so that was removed as it is no longer part of the applicible types.