### PR TITLE
fix(flagship): add init script to patch rn images for ios 14

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -215,6 +215,8 @@ function initIOS(
   ios.backgroundModes(configuration); // Add background modes
   ios.sentryProperties(configuration);
   ios.setEnvSwitcherInitialEnv(configuration, environmentIdentifier);
+  ios.patchRCTUIImageViewAnimated();
+
   if (configuration.ios) {
     if (configuration.ios.pods) {
       if (configuration.ios.pods.sources) {


### PR DESCRIPTION
This adds a script to iOS init that patches RCTUIImageViewAnimated.m to display images in iOS 14.

See issue here: https://github.com/facebook/react-native/issues/29268

# Test

1. Download Xcode 12 Beta
2. Select the Xcode 12 build environment (`sudo xcode-select -s /Applications/Xcode12-Beta.app/Contents/Developer/`)
3. `yarn && yarn ship:init`
4. Open PirateShip in Xcode 12 Beta
5. Select an iOS 14 simulator
6. Run the app in Xcode (you may have to run the packager from the command line manually first)
7. Verify that images appear as expected in the app