### PR TITLE
fix: resolve android build tools in subprojects

### DIFF
--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -22,6 +22,25 @@ buildscript {
     }
 }
 
+subprojects {
+    project.configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'com.android.support'
+                    && !details.requested.name.contains('multidex') ) {
+                details.useVersion "28.0.0"
+            }
+        }
+    }
+    afterEvaluate {
+        project -> if (project.hasProperty("android")) {
+            android {
+                compileSdkVersion 28
+                buildToolsVersion "28.0.3"
+            }
+        }
+    }
+}
+
 allprojects {
     repositories {
         mavenLocal()

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -12,7 +12,7 @@
     "compile-ios": "react-native run-ios --no-packager --simulator=\"iPhone X\"",
     "compile-web": "(test -d 'web' || flagship init web) && cd ./web/ && yarn start",
     "build-ios": "./scripts/buildiOS.sh",
-    "init": "node scripts/fixRNLink.js && flagship clean && flagship init native",
+    "init": "node scripts/fixRNLink.js && flagship clean && flagship init native && yarn init:android-jetify",
     "init:web": "node scripts/fixRNLink.js && flagship clean && flagship init web",
     "init:android-jetify": "jetify",
     "init:android-jetify-reverse": "jetify -r",


### PR DESCRIPTION
This adds a block to build.gradle to set the Android build tools version for subprojects (from external dependencies). This addresses a build error in release mode in which libraries are attempting to reference Material UI. This appears to be the community-supported resolution to this problem: https://stackoverflow.com/a/53371395

This also runs Jetify whenever init runs because this is a required step for builds to work.