### PR TITLE
fix: appcenter upload groups for android

### DIFF
--- a/packages/flagship/android/fastlane/Fastfile
+++ b/packages/flagship/android/fastlane/Fastfile
@@ -30,7 +30,6 @@ lane :appcenter_app_bundle do
 
   appcenter_upload(
     #PROJECT_MODIFY_FLAG_appcenter_api_token
-    destination_type: "store",
     owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
     app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
   )


### PR DESCRIPTION
This removes the destination_type line from the Android fastfile which prevents distribution to groups which is our most common use case. This will default to "group" but can be customized with the APPCENTER_DISTRIBUTE_DESTINATION_TYPE environment variable.