### PR TITLE
chore: tell dependabot to ignore react-native-cli

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -25,3 +25,7 @@ update_configs:
           dependency_name: "react"
       - match:
           dependency_name: "react-dom"
+      - match:
+          dependency_name: "@react-native-community/cli-platform-ios"
+      - match:
+          dependency_name: "@react-native-community/cli-platform-android"


### PR DESCRIPTION
These versions are dependent on the current version of React Native and therefore shouldn't be upgraded automatically.