### PR TITLE
feat: FS-1314 - upgrade typescript to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.0.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.7.2",
+    "typescript": "^4.0.2",
     "webpack": "^4.41.2"
   },
   "greenkeeper": {

--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -16,7 +16,6 @@
     "@brandingbrand/fsfoundation": "^10.0.0-alpha.2",
     "@brandingbrand/fsnetwork": "^10.0.0-alpha.2",
     "@react-native-community/async-storage": "^1.6.1",
-    "lodash-es": "^4.17.10",
     "path-to-regexp": "^1.7.0",
     "qs": "^6.7.0",
     "react": "^16.11.0",

--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -16,6 +16,7 @@
     "@brandingbrand/fsfoundation": "^10.0.0-alpha.2",
     "@brandingbrand/fsnetwork": "^10.0.0-alpha.2",
     "@react-native-community/async-storage": "^1.6.1",
+    "lodash-es": "^4.17.10",
     "path-to-regexp": "^1.7.0",
     "qs": "^6.7.0",
     "react": "^16.11.0",

--- a/packages/fsapp/src/components/screenWrapper.web.tsx
+++ b/packages/fsapp/src/components/screenWrapper.web.tsx
@@ -72,8 +72,11 @@ export default function wrapScreen(
         navModals: []
       };
       this.navigator = new Navigator({
+        ...props,
         toggleDrawerFn,
-        ...props
+        appConfig,
+        updateModals: this.updateModals,
+        modals: props.modals || []
       });
     }
     updateModals = (navModals: NavModal[]): void => {
@@ -125,9 +128,11 @@ export default function wrapScreen(
           {this.renderPage()}
           {this.renderVersion()}
           <NavRender
-            navigator={this.navigator}
-            onDismiss={this.onDismiss}
             {...this.props}
+            modals={this.state.navModals}
+            appConfig={appConfig}
+            onDismiss={this.onDismiss}
+            navigator={this.navigator}
           />
         </View>
       );

--- a/packages/fsapp/src/components/screenWrapper.web.tsx
+++ b/packages/fsapp/src/components/screenWrapper.web.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import { setGlobalData } from '../actions/globalDataAction';
 import qs from 'qs';
-import { omit } from 'lodash-es';
 import NavRender from './Navigator.web';
 import Navigator, { GenericNavProp } from '../lib/nav-wrapper.web';
 import { AppConfigType, DrawerConfig, NavModal } from '../types';
@@ -73,11 +72,8 @@ export default function wrapScreen(
         navModals: []
       };
       this.navigator = new Navigator({
-        appConfig,
-        modals: [],
         toggleDrawerFn,
-        updateModals: this.updateModals,
-        ...omit(props, ['appConfig', 'modals', 'updateModals'])
+        ...props
       });
     }
     updateModals = (navModals: NavModal[]): void => {
@@ -129,11 +125,9 @@ export default function wrapScreen(
           {this.renderPage()}
           {this.renderVersion()}
           <NavRender
-            appConfig={appConfig}
-            modals={this.state.navModals}
             navigator={this.navigator}
             onDismiss={this.onDismiss}
-            {...omit(this.props, 'appConfig', 'modals')}
+            {...this.props}
           />
         </View>
       );

--- a/packages/fsapp/src/components/screenWrapper.web.tsx
+++ b/packages/fsapp/src/components/screenWrapper.web.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import { setGlobalData } from '../actions/globalDataAction';
 import qs from 'qs';
+import { omit } from 'lodash-es';
 import NavRender from './Navigator.web';
 import Navigator, { GenericNavProp } from '../lib/nav-wrapper.web';
 import { AppConfigType, DrawerConfig, NavModal } from '../types';
@@ -76,7 +77,7 @@ export default function wrapScreen(
         modals: [],
         toggleDrawerFn,
         updateModals: this.updateModals,
-        ...props
+        ...omit(props, ['appConfig', 'modals', 'updateModals'])
       });
     }
     updateModals = (navModals: NavModal[]): void => {
@@ -132,7 +133,7 @@ export default function wrapScreen(
             modals={this.state.navModals}
             navigator={this.navigator}
             onDismiss={this.onDismiss}
-            {...this.props}
+            {...omit(this.props, 'appConfig', 'modals')}
           />
         </View>
       );

--- a/packages/fscommerce/src/index.ts
+++ b/packages/fscommerce/src/index.ts
@@ -1,4 +1,4 @@
-export { default as CommerceTypes } from './Commerce/CommerceTypes';
+export * as CommerceTypes from './Commerce/CommerceTypes';
 export {
   default as withCommerceData,
   WithCommerceDataProps,
@@ -12,7 +12,7 @@ export {
   default as CommerceCookieSessionManager
 } from './Commerce/sessions/CommerceCookieSessionManager';
 
-export { default as ReviewTypes } from './Review/ReviewTypes';
+export * as ReviewTypes from './Review/ReviewTypes';
 export {
   ReviewDataSource,
   AbstractReviewDataSource,

--- a/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
+++ b/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, memo } from 'react';
 import { ImageSourcePropType, StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native';
 import { Button, ButtonProps } from './Button';
 import { Omit } from '@brandingbrand/fsfoundation';
+import { omit as lodashOmit } from 'lodash-es';
 import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
 const componentTranslationKeys = translationKeys.flagship.payPalButton;
 
@@ -118,7 +119,7 @@ memo((props): JSX.Element => {
         icon={selectedTheme.icon}
         iconStyle={styles.icon}
         underlayColor={selectedTheme.bgActive}
-        {...buttonProps}
+        {...lodashOmit(buttonProps, ['title'])}
       />
       {!!tagLineVal && (
         <Text style={[styles.tagLine, tagLineStyle]}>

--- a/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
+++ b/packages/fscomponents/src/components/PayPalCheckoutButton.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, memo } from 'react';
 import { ImageSourcePropType, StyleProp, StyleSheet, Text, TextStyle, View } from 'react-native';
 import { Button, ButtonProps } from './Button';
 import { Omit } from '@brandingbrand/fsfoundation';
-import { omit as lodashOmit } from 'lodash-es';
 import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
 const componentTranslationKeys = translationKeys.flagship.payPalButton;
 
@@ -115,11 +114,11 @@ memo((props): JSX.Element => {
   return (
     <View style={{ paddingVertical: 10 }}>
       <Button
+        {...buttonProps}
         title={titleVal}
         icon={selectedTheme.icon}
         iconStyle={styles.icon}
         underlayColor={selectedTheme.bgActive}
-        {...lodashOmit(buttonProps, ['title'])}
       />
       {!!tagLineVal && (
         <Text style={[styles.tagLine, tagLineStyle]}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16212,10 +16212,15 @@ typedoc@^0.15.0:
     typedoc-default-themes "^0.6.3"
     typescript "3.7.x"
 
-typescript@3.7.x, typescript@^3.7.2:
+typescript@3.7.x:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
   integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
BREAKING CHANGE: This upgrades Typescript from 3.x to 4.x which includes changes that are for edge cases but still breaking nonetheless. The full changelog can be found here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#breaking-changes

Fixed a couple instances where TypeScript recognized that we were always overriding variables by using the spread operator. Also addressed a couple places where we were importing `default` even though no such export existed.