### PR TITLE
feat: implement react-native-permissions v2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@types/react-dom": "^16.9.3",
     "@types/react-native": "^0.60.22",
     "@types/react-native-i18n": "^2.0.0",
-    "@types/react-native-permissions": "^1.1.1",
     "@types/react-native-touch-id": "^4.0.0",
     "@types/react-redux": "^7.0.0",
     "@types/react-router-dom": "^5.1.2",

--- a/packages/flagship/android/app/src/main/AndroidManifest.xml
+++ b/packages/flagship/android/app/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
             package="CONFIG_BUNDLE_ID">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.CAMERA" />
 
     <!-- __ADDITIONAL_PERMISSIONS__ -->
 

--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -4,6 +4,7 @@ import * as helpers from '../helpers';
 import * as path from './path';
 import * as versionLib from './version';
 import * as nativeConstants from './native-constants';
+import * as usageDescriptions from './usage-descriptions';
 
 /**
  * Updates app bundle id.
@@ -250,53 +251,7 @@ export function usageDescription(configuration: Config): void {
     `updating iOS usage description: [${configuration.usageDescriptionIOS.map(u => u.key)}]`
   );
 
-  const infoPlist = path.ios.infoPlistPath(configuration);
-
-  configuration.usageDescriptionIOS.forEach(usage => {
-    if (fs.doesKeywordExist(infoPlist, usage.key)) {
-      // Replace the existing usage description for this key
-      if (usage.array) {
-        const stringArray = usage.array.map(res => {
-          return `<string>${res}</string>`;
-        });
-        fs.update(
-          infoPlist,
-          new RegExp(
-            `<key>${usage.key}<\\/key>\\s+<array>\\s+(<string>[^<]+<\\/string>\\s+){0,}<\\/array>`
-          ),
-          `<key>${usage.key}</key><array>${stringArray}</array>`
-        );
-      } else {
-        fs.update(
-          infoPlist,
-          new RegExp(`<key>${usage.key}<\\/key>\\s+<string>[^<]+<\\/string>`),
-          `<key>${usage.key}</key><string>${usage.string}</string>`
-        );
-      }
-    } else {
-      // This key doesn't exist so add it to the file
-      if (usage.array) {
-        const stringArray = usage.array.map(res => {
-          return `<string>${res}</string>`;
-        });
-        fs.update(
-          infoPlist,
-          '<key>UIRequiredDeviceCapabilities</key>',
-          `<key>${usage.key}</key>`
-          + `<array>${stringArray.join('')}</array>`
-          + `<key>UIRequiredDeviceCapabilities</key>`
-        );
-      } else {
-        fs.update(
-          infoPlist,
-          '<key>UIRequiredDeviceCapabilities</key>',
-          `<key>${usage.key}</key><string>${
-          usage.string
-          }</string><key>UIRequiredDeviceCapabilities</key>`
-        );
-      }
-    }
-  });
+  usageDescriptions.add(configuration, configuration.usageDescriptionIOS);
 }
 
 /**

--- a/packages/flagship/src/lib/modules/android/react-native-permissions.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-permissions.ts
@@ -1,0 +1,32 @@
+// tslint:disable ter-max-len max-line-length
+
+import { logInfo } from '../../../helpers';
+import { Config } from '../../../types';
+import * as path from '../../path';
+import * as fs from '../../fs';
+
+export function postLink(configuration: Config): void {
+  logInfo('patching Android for react-native-permissions');
+
+  if (!configuration?.permissions?.android) {
+    logInfo('react-native-permissions not configured for Android');
+  }
+
+  let manifestPermissions = '';
+
+  configuration?.permissions?.android?.forEach(permission => {
+    if (permission === 'ADD_VOICEMAIL') {
+      manifestPermissions += `\n    <uses-permission android:name="com.android.voicemail.permission.ADD_VOICEMAIL" />`;
+    } else {
+      manifestPermissions += `\n    <uses-permission android:name="android.permission.${permission}" />`;
+    }
+  });
+
+  if (manifestPermissions) {
+    fs.update(
+      path.android.manifestPath(),
+      '<!-- __ADDITIONAL_PERMISSIONS__ -->',
+      `${manifestPermissions}\n    <!-- __ADDITIONAL_PERMISSIONS__ -->`
+    );
+  }
+}

--- a/packages/flagship/src/lib/modules/ios/react-native-permissions.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-permissions.ts
@@ -1,0 +1,113 @@
+// tslint:disable ter-max-len max-line-length
+
+import { Config, IOSPermissionKeys, UsageDescriptionIOS } from '../../../types';
+import { logInfo } from '../../../helpers';
+import * as pods from '../../cocoapods';
+import * as usageDescriptionsHelper from '../../usage-descriptions';
+
+interface IOSPermissionMeta {
+  pod: string;
+  usageDescriptionKey?: string;
+}
+
+// Object specifying the pod definition and iOS usage description key for each possible
+// type of permission available in react-native-permissions
+const permissionPods: {[k in IOSPermissionKeys]: IOSPermissionMeta} = {
+  APP_TRACKING_TRANSPARENCY: {
+    pod: 'pod \'Permission-AppTrackingTransparency\', :path => "../node_modules/react-native-permissions/ios/AppTrackingTransparency.podspec"',
+    usageDescriptionKey: 'NSAppleMusicUsageDescription'
+  },
+  BLUETOOTH_PERIPHERAL: {
+    pod: 'pod \'Permission-BluetoothPeripheral\', :path => "../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec"',
+    usageDescriptionKey: 'NSBluetoothPeripheralUsageDescription'
+  },
+  CALENDARS: {
+    pod: 'pod \'Permission-Calendars\', :path => "../node_modules/react-native-permissions/ios/Calendars.podspec"',
+    usageDescriptionKey: 'NSCalendarsUsageDescription'
+  },
+  CAMERA: {
+    pod: 'pod \'Permission-Camera\', :path => "../node_modules/react-native-permissions/ios/Camera.podspec"',
+    usageDescriptionKey: 'NSCameraUsageDescription'
+  },
+  CONTACTS: {
+    pod: 'pod \'Permission-Contacts\', :path => "../node_modules/react-native-permissions/ios/Contacts.podspec"',
+    usageDescriptionKey: 'NSContactsUsageDescription'
+  },
+  FACE_ID: {
+    pod: 'pod \'Permission-FaceID\', :path => "../node_modules/react-native-permissions/ios/FaceID.podspec"',
+    usageDescriptionKey: 'NSFaceIDUsageDescription'
+  },
+  LOCATION_ALWAYS: {
+    pod: 'pod \'Permission-LocationAlways\', :path => "../node_modules/react-native-permissions/ios/LocationAlways.podspec"',
+    usageDescriptionKey: 'NSLocationAlwaysAndWhenInUseUsageDescription'
+  },
+  LOCATION_WHEN_IN_USE: {
+    pod: 'pod \'Permission-LocationWhenInUse\', :path => "../node_modules/react-native-permissions/ios/LocationWhenInUse.podspec"',
+    usageDescriptionKey: 'NSLocationWhenInUseUsageDescription'
+  },
+  MEDIA_LIBRARY: {
+    pod: 'pod \'Permission-MediaLibrary\', :path => "../node_modules/react-native-permissions/ios/MediaLibrary.podspec"',
+    usageDescriptionKey: 'NSAppleMusicUsageDescription'
+  },
+  MICROPHONE: {
+    pod: 'pod \'Permission-Microphone\', :path => "../node_modules/react-native-permissions/ios/Microphone.podspec"',
+    usageDescriptionKey: 'NSMicrophoneUsageDescription'
+  },
+  MOTION: {
+    pod: 'pod \'Permission-Motion\', :path => "../node_modules/react-native-permissions/ios/Motion.podspec"',
+    usageDescriptionKey: 'NSMotionUsageDescription'
+  },
+  NOTIFICATIONS: {
+    pod: 'pod \'Permission-Notifications\', :path => "../node_modules/react-native-permissions/ios/Notifications.podspec"'
+  },
+  PHOTO_LIBRARY: {
+    pod: 'pod \'Permission-PhotoLibrary\', :path => "../node_modules/react-native-permissions/ios/PhotoLibrary.podspec"',
+    usageDescriptionKey: 'NSPhotoLibraryUsageDescription'
+  },
+  REMINDERS: {
+    pod: 'pod \'Permission-Reminders\', :path => "../node_modules/react-native-permissions/ios/Reminders.podspec"',
+    usageDescriptionKey: 'NSRemindersUsageDescription'
+  },
+  SIRI: {
+    pod: 'pod \'Permission-Siri\', :path => "../node_modules/react-native-permissions/ios/Siri.podspec"',
+    usageDescriptionKey: 'NSSiriUsageDescription'
+  },
+  SPEECH_RECOGNITION: {
+    pod: 'pod \'Permission-SpeechRecognition\', :path => "../node_modules/react-native-permissions/ios/SpeechRecognition.podspec"',
+    usageDescriptionKey: 'NSSpeechRecognitionUsageDescription'
+  },
+  STOREKIT: {
+    pod: 'pod \'Permission-StoreKit\', :path => "../node_modules/react-native-permissions/ios/StoreKit.podspec"'
+  }
+};
+
+export function preLink(config: Config): void {
+  logInfo('patching iOS for react-native-permissions');
+
+  if (!config?.permissions?.ios) {
+    logInfo('react-native-permissions not configured for iOS');
+
+    return;
+  }
+
+  const usageDescriptions: UsageDescriptionIOS[] = [];
+
+  (Object.keys(config.permissions.ios) as IOSPermissionKeys[]).forEach(key => {
+    const permission = permissionPods[key];
+
+    if (permission) {
+      pods.add([permission.pod]);
+
+      if (permission.usageDescriptionKey) {
+        usageDescriptions.push({
+          key: permission.usageDescriptionKey,
+          string: (config?.permissions?.ios && config.permissions.ios[key]) || ''
+        });
+      }
+    }
+  });
+
+  if (usageDescriptions.length > 0) {
+    usageDescriptionsHelper.add(config, usageDescriptions);
+  }
+}

--- a/packages/flagship/src/lib/usage-descriptions.ts
+++ b/packages/flagship/src/lib/usage-descriptions.ts
@@ -1,0 +1,53 @@
+import { Config, UsageDescriptionIOS } from '../types';
+import * as path from './path';
+import * as fs from './fs';
+
+export function add(config: Config, usageDescriptions: UsageDescriptionIOS[]): void {
+  const infoPlist = path.ios.infoPlistPath(config);
+
+  usageDescriptions.forEach(usage => {
+    if (fs.doesKeywordExist(infoPlist, usage.key)) {
+      // Replace the existing usage description for this key
+      if (usage.array) {
+        const stringArray = usage.array.map(res => {
+          return `<string>${res}</string>`;
+        });
+        fs.update(
+          infoPlist,
+          new RegExp(
+            `<key>${usage.key}<\\/key>\\s+<array>\\s+(<string>[^<]+<\\/string>\\s+){0,}<\\/array>`
+          ),
+          `<key>${usage.key}</key><array>${stringArray}</array>`
+        );
+      } else {
+        fs.update(
+          infoPlist,
+          new RegExp(`<key>${usage.key}<\\/key>\\s+<string>[^<]+<\\/string>`),
+          `<key>${usage.key}</key><string>${usage.string}</string>`
+        );
+      }
+    } else {
+      // This key doesn't exist so add it to the file
+      if (usage.array) {
+        const stringArray = usage.array.map(res => {
+          return `<string>${res}</string>`;
+        });
+        fs.update(
+          infoPlist,
+          '<key>UIRequiredDeviceCapabilities</key>',
+          `<key>${usage.key}</key>`
+          + `<array>${stringArray.join('')}</array>`
+          + `<key>UIRequiredDeviceCapabilities</key>`
+        );
+      } else {
+        fs.update(
+          infoPlist,
+          '<key>UIRequiredDeviceCapabilities</key>',
+          `<key>${usage.key}</key><string>${
+          usage.string
+          }</string><key>UIRequiredDeviceCapabilities</key>`
+        );
+      }
+    }
+  });
+}

--- a/packages/flagship/src/types.ts
+++ b/packages/flagship/src/types.ts
@@ -9,6 +9,62 @@ export enum TargetedDevices {
   Universal = 'Universal'
 }
 
+export type IOSPermissionKeys =
+  'APP_TRACKING_TRANSPARENCY'
+  | 'BLUETOOTH_PERIPHERAL'
+  | 'CALENDARS'
+  | 'CAMERA'
+  | 'CONTACTS'
+  | 'FACE_ID'
+  | 'LOCATION_ALWAYS'
+  | 'LOCATION_WHEN_IN_USE'
+  | 'MEDIA_LIBRARY'
+  | 'MICROPHONE'
+  | 'MOTION'
+  | 'NOTIFICATIONS'
+  | 'PHOTO_LIBRARY'
+  | 'REMINDERS'
+  | 'SIRI'
+  | 'SPEECH_RECOGNITION'
+  | 'STOREKIT';
+
+export type AndroidPermissionKeys =
+ 'ACCEPT_HANDOVER'
+ | 'ACCESS_BACKGROUND_LOCATION'
+ | 'ACCESS_COARSE_LOCATION'
+ | 'ACCESS_FINE_LOCATION'
+ | 'ACTIVITY_RECOGNITION'
+ | 'ADD_VOICEMAIL'
+ | 'ANSWER_PHONE_CALLS'
+ | 'BODY_SENSORS'
+ | 'CALL_PHONE'
+ | 'CAMERA'
+ | 'GET_ACCOUNTS'
+ | 'PROCESS_OUTGOING_CALLS'
+ | 'READ_CALENDAR'
+ | 'READ_CALL_LOG'
+ | 'READ_CONTACTS'
+ | 'READ_EXTERNAL_STORAGE'
+ | 'READ_PHONE_NUMBERS'
+ | 'READ_PHONE_STATE'
+ | 'READ_SMS'
+ | 'RECEIVE_MMS'
+ | 'RECEIVE_SMS'
+ | 'RECEIVE_WAP_PUSH'
+ | 'RECORD_AUDIO'
+ | 'SEND_SMS'
+ | 'USE_SIP'
+ | 'WRITE_CALENDAR'
+ | 'WRITE_CALL_LOG'
+ | 'WRITE_CONTACTS'
+ | 'WRITE_EXTERNAL_STORAGE';
+
+export interface UsageDescriptionIOS {
+  key: string;
+  string?: string;
+  array?: string[];
+}
+
 export interface Config {
   name: string;
   displayName: string;
@@ -76,11 +132,12 @@ export interface Config {
 
   enabledCapabilitiesIOS?: string[];
   entitlementsFileIOS?: string;
-  usageDescriptionIOS?: {
-    key: string;
-    string?: string;
-    array?: string[];
-  }[];
+  usageDescriptionIOS?: UsageDescriptionIOS[];
+
+  permissions?: {
+    ios?: {[k in IOSPermissionKeys]: string};
+    android?: AndroidPermissionKeys[];
+  };
 
   UIBackgroundModes?: {
     string: string;

--- a/packages/fsengage/package.json
+++ b/packages/fsengage/package.json
@@ -19,7 +19,7 @@
     "decimal.js": "^10.0.0",
     "react": "^16.11.0",
     "react-native": "^0.61.0",
-    "react-native-permissions": "~1.1.1",
+    "react-native-permissions": "^2.2.0",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
+++ b/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
@@ -1,15 +1,14 @@
-import Permissions from 'react-native-permissions';
+import {check, Permission, PERMISSIONS, request, RESULTS} from 'react-native-permissions';
+import { Platform } from 'react-native';
 
-const kLocationPermissionStatuses: any = {
-  Authorized: 'authorized',
-  Denied: 'denied',
-  Restricted: 'restricted',
-  Undetermined: 'undetermined'
-};
+function getPermissionToCheck(): Permission {
+  return Platform.OS === 'ios' ?
+    PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+}
 
 export async function isGeolocationAllowed(): Promise<boolean> {
-  return Permissions.check('location')
-    .then(status => status === kLocationPermissionStatuses.Authorized)
+  return check(getPermissionToCheck())
+    .then(status => status === RESULTS.GRANTED)
     .catch(error => {
       if (__DEV__) {
         console.log(
@@ -25,6 +24,6 @@ export async function isGeolocationAllowed(): Promise<boolean> {
 }
 
 export async function requestGeolocationPermission(): Promise<boolean> {
-  return Permissions.request('location')
-    .then(status => status === kLocationPermissionStatuses.Authorized);
+  return request(getPermissionToCheck())
+    .then(status => status === RESULTS.GRANTED);
 }

--- a/packages/fslocator/package.json
+++ b/packages/fslocator/package.json
@@ -25,7 +25,7 @@
     "react-native-geocoder": "^0.5.0",
     "react-native-maps": "^0.26.0",
     "react-native-open-settings": "^1.0.1",
-    "react-native-permissions": "~1.1.1"
+    "react-native-permissions": "^2.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fslocator/src/lib/getLocationPermission.ts
+++ b/packages/fslocator/src/lib/getLocationPermission.ts
@@ -1,15 +1,22 @@
-import { Alert } from 'react-native';
+import { Alert, Platform } from 'react-native';
+import {check, PERMISSIONS, request, RESULTS} from 'react-native-permissions';
 
 // @ts-ignore TODO: Add typing support for react-native-open-settings
 import OpenSettings from 'react-native-open-settings';
-import Permissions from 'react-native-permissions';
 
 export default async function getLocationPermission(): Promise<boolean> {
-  const permStatus = await Permissions.check('location');
-  if (permStatus === 'undetermined') {
-    const requestedPerm = await Permissions.request('location');
-    return requestedPerm === 'authorized';
-  } else if (permStatus === 'denied') {
+  const permissionToCheck = Platform.OS === 'ios' ?
+    PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+
+  const permStatus = await check(permissionToCheck);
+
+  if (permStatus === RESULTS.DENIED) {
+    // DENIED means that the user doesn't have the permission enabled but is requestable
+    const requestedPerm = await request(permissionToCheck);
+
+    return requestedPerm === RESULTS.GRANTED;
+  } else if (permStatus === RESULTS.BLOCKED) {
+    // BLOCKED means that we cannot request for the permission; the user has to enable it manually
     Alert.alert(
       'Turn on Location Services To Allow Us to Determine Your Location',
       '',

--- a/packages/pirateship/env/common.js
+++ b/packages/pirateship/env/common.js
@@ -45,48 +45,14 @@ module.exports = {
     android: 'com.brandingbrand.reactnative.and.pirateship',
     ios: 'com.brandingbrand.reactnative.pirateship',
   },
-  usageDescriptionIOS: [
-    {
-      key: 'NSAppleMusicUsageDescription',
-      string: ''
+  permissions: {
+    ios: {
+      LOCATION_WHEN_IN_USE: 'Test Description'
     },
-    {
-      key: 'NSBluetoothPeripheralUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSCalendarsUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSCameraUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSLocationWhenInUseUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSMotionUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSPhotoLibraryAddUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSPhotoLibraryUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSSpeechRecognitionUsageDescription',
-      string: ''
-    },
-    {
-      key: 'NSFaceIDUsageDescription',
-      string: ''
-    }
-  ],
+    android: [
+      'ACCESS_FINE_LOCATION'
+    ]
+  },
   associatedDomains: [],
   targetedDevices: 'Universal'
 };

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -53,6 +53,7 @@
     "react-native-htmlview": "^0.15.0",
     "react-native-localize": "^1.3.0",
     "react-native-navigation": "^6.0.0",
+    "react-native-permissions": "^2.2.0",
     "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "^5.5.0",
     "react-native-svg": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3666,11 +3666,6 @@
   dependencies:
     "@types/i18n-js" "*"
 
-"@types/react-native-permissions@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/react-native-permissions/-/react-native-permissions-1.1.1.tgz#297f39ed19234045e1dc1cd0abd85b86bdf9c606"
-  integrity sha512-+xLVH6kefg9hpJKxQhRcaYHckhbQCxDrU6HEaTzf3gMbn4I4aunjxkqeSMAofrHFNOnOS/phnsTbifoDATjk3w==
-
 "@types/react-native-snap-carousel@^3.7.3":
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/@types/react-native-snap-carousel/-/react-native-snap-carousel-3.7.4.tgz#1e1ad5b5314715d538f6785b4f3a6590a036a6bd"
@@ -13741,10 +13736,10 @@ react-native-open-settings@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-open-settings/-/react-native-open-settings-1.0.1.tgz#1c0ae3d25fd3fd6de94b6d538333d47245cc5a0c"
   integrity sha1-HArj0l/T/W3pS21TgzPUckXMWgw=
 
-react-native-permissions@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-1.1.1.tgz#4876004681ff8556454613d85249b01baff9b35b"
-  integrity sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ==
+react-native-permissions@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.2.0.tgz#7980caccf98814c6a4677816d21e90ba456362d3"
+  integrity sha512-y5GvcYdEe9PEWVM12UgdkNI/BVvjEU6SZGN7zBpoalTczSlWGQ4SeD2dBz9KfCu1jg5l1752sKDAggTjaq3QKQ==
 
 "react-native-restart@git+https://github.com/brandingbrand/react-native-restart#0.0.13-hotfix":
   version "0.0.13"


### PR DESCRIPTION
BREAKING CHANGE: This upgrades react-native-permissions from v1 to v2 and adds config support for adding the appropriate pods and permissions to the ios and android projects. Permissions v2 has a new API that will require changes for existing implementations.

Usage of the library is described in their repo: https://github.com/react-native-community/react-native-permissions#methods

In v1 of permissions, support for every permission is included out of the box. In v2, you opt into individual permissions as needed. This PR adds a new key to the config, `permissions`, which allows you to specify what to support. Here's an example:

```
  permissions: {
    ios: {
      LOCATION_WHEN_IN_USE: 'Test Description'
    }
    android: [
      'ACCESS_FINE_LOCATION'
    ]
  }
````

For iOS, you provide an object keyed by the permission with the value being the usage description. The list of possible keys can be found here: https://github.com/brandingbrand/flagship/compare/feature/flagship-10...bweissbart:rnPermissions?expand=1#diff-90a9460d837cd74e4bee72e514f76767R12-R29

For Android, you provide an array of permissions: https://github.com/brandingbrand/flagship/compare/feature/flagship-10...bweissbart:rnPermissions?expand=1#diff-90a9460d837cd74e4bee72e514f76767R31-R60

The library will then add the appropriate pods, usage descriptions, and Android Manifest permissions.

Edit: my writeup in the Flagship 10 wiki article is here: https://github.com/brandingbrand/flagship/wiki/Flagship-10#react-native-permissions-v2