### PR TITLE
chore: reorder ci test commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ jobs:
     node_js: '12'
     script:
       - yarn prepare || travis_terminate 1
-      - commitlint-travis || travis_terminate 1
       - yarn prepare:fscodestyle || travis_terminate 1
       - yarn lint || travis_terminate 1
       - yarn test --coverage --ci && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || travis_terminate 1
-      - yarn build:storybook
+      - yarn build:storybook || travis_terminate 1
+      - commitlint-travis
   - stage: test
     language: generic
     sudo: true


### PR DESCRIPTION
This moves commitlint to the end of the commands run to validate PRs. This way we can see if the "real" tests pass first even if commitlint fails.