### PR TITLE
feat: make permissions a soft dependency in fsengage

### DIFF
--- a/packages/fsengage/package.json
+++ b/packages/fsengage/package.json
@@ -22,7 +22,8 @@
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
-    "sinon": "^8.0.2"
+    "sinon": "^8.0.2",
+    "react-native-permissions": "^2.2.0"
   },
   "peerDependencies": {
     "react-native-permissions": "^2.2.0"

--- a/packages/fsengage/package.json
+++ b/packages/fsengage/package.json
@@ -19,11 +19,13 @@
     "decimal.js": "^10.0.0",
     "react": "^16.13.1",
     "react-native": "^0.63.2",
-    "react-native-permissions": "^2.2.0",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {
     "sinon": "^8.0.2"
+  },
+  "peerDependencies": {
+    "react-native-permissions": "^2.2.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
+++ b/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
@@ -30,7 +30,7 @@ export async function isGeolocationAllowed(): Promise<boolean> {
   const permissionToCheck = getPermissionToCheck();
 
   if (permissionToCheck) {
-    return rnPermissions.check(getPermissionToCheck())
+    return rnPermissions.check(permissionToCheck)
       .then((status: any) => status === rnPermissions.RESULTS.GRANTED)
       .catch((error: Error) => {
         if (__DEV__) {
@@ -53,7 +53,7 @@ export async function requestGeolocationPermission(): Promise<boolean> {
   const permissionToCheck = getPermissionToCheck();
 
   if (permissionToCheck) {
-    return rnPermissions.request(getPermissionToCheck())
+    return rnPermissions.request(permissionToCheck)
       .then((status: any) => status === rnPermissions.RESULTS.GRANTED);
   }
 

--- a/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
+++ b/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
@@ -1,29 +1,61 @@
-import {check, Permission, PERMISSIONS, request, RESULTS} from 'react-native-permissions';
 import { Platform } from 'react-native';
 
-function getPermissionToCheck(): Permission {
+// Geolocation is currently bundled with fsengage even though apps may not use location-based
+// targeting. Because react-native-permissions requires apps to expose the permissions they use,
+// this makes permissions a "soft" dependency that apps can opt into by including rn-permissions
+// as a dependency. TODO - refactor fsengage so that location-based permissions are taken out of
+// engage core.
+let rnPermissions: any = null;
+
+try {
+  rnPermissions = require('react-native-permissions');
+} catch (e) {
+  console.warn(
+    'react-native-permissions must be added to your project'
+    + ' to enable granular geolocation in fsengage'
+  );
+}
+
+function getPermissionToCheck(): any {
+  if (!rnPermissions) {
+    return null;
+  }
+
   return Platform.OS === 'ios' ?
-    PERMISSIONS.IOS.LOCATION_WHEN_IN_USE : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+    rnPermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
+      : rnPermissions.PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
 }
 
 export async function isGeolocationAllowed(): Promise<boolean> {
-  return check(getPermissionToCheck())
-    .then(status => status === RESULTS.GRANTED)
-    .catch(error => {
-      if (__DEV__) {
-        console.log(
-          `%cLocator\n%c Function: isGeolocationAllowed\n Error: `,
-          'color: blue',
-          'color: grey',
-          error
-        );
-      }
+  const permissionToCheck = getPermissionToCheck();
 
-      throw error;
-    });
+  if (permissionToCheck) {
+    return rnPermissions.check(getPermissionToCheck())
+      .then((status: any) => status === rnPermissions.RESULTS.GRANTED)
+      .catch((error: Error) => {
+        if (__DEV__) {
+          console.log(
+            `%cLocator\n%c Function: isGeolocationAllowed\n Error: `,
+            'color: blue',
+            'color: grey',
+            error
+          );
+        }
+
+        throw error;
+      });
+  }
+
+  return Promise.resolve(false);
 }
 
 export async function requestGeolocationPermission(): Promise<boolean> {
-  return request(getPermissionToCheck())
-    .then(status => status === RESULTS.GRANTED);
+  const permissionToCheck = getPermissionToCheck();
+
+  if (permissionToCheck) {
+    return rnPermissions.request(getPermissionToCheck())
+      .then((status: any) => status === rnPermissions.RESULTS.GRANTED);
+  }
+
+  return Promise.resolve(false);
 }

--- a/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
+++ b/packages/fsengage/src/modules/cms/requesters/contentManagementSystemLocatorPermission.ts
@@ -1,11 +1,12 @@
 import { Platform } from 'react-native';
+import type { default as RNPermissions, Permission } from 'react-native-permissions';
 
 // Geolocation is currently bundled with fsengage even though apps may not use location-based
 // targeting. Because react-native-permissions requires apps to expose the permissions they use,
 // this makes permissions a "soft" dependency that apps can opt into by including rn-permissions
 // as a dependency. TODO - refactor fsengage so that location-based permissions are taken out of
 // engage core.
-let rnPermissions: any = null;
+let rnPermissions: typeof RNPermissions | null = null;
 
 try {
   rnPermissions = require('react-native-permissions');
@@ -16,22 +17,20 @@ try {
   );
 }
 
-function getPermissionToCheck(): any {
-  if (!rnPermissions) {
-    return null;
-  }
-
+function getPermissionToCheck(rnPermissions: typeof RNPermissions): Permission {
   return Platform.OS === 'ios' ?
     rnPermissions.PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
       : rnPermissions.PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
 }
 
 export async function isGeolocationAllowed(): Promise<boolean> {
-  const permissionToCheck = getPermissionToCheck();
+  const permissions = rnPermissions;
 
-  if (permissionToCheck) {
-    return rnPermissions.check(permissionToCheck)
-      .then((status: any) => status === rnPermissions.RESULTS.GRANTED)
+  if (permissions) {
+    const permissionToCheck = getPermissionToCheck(permissions);
+
+    return permissions.check(permissionToCheck)
+      .then(status => status === permissions.RESULTS.GRANTED)
       .catch((error: Error) => {
         if (__DEV__) {
           console.log(
@@ -50,11 +49,13 @@ export async function isGeolocationAllowed(): Promise<boolean> {
 }
 
 export async function requestGeolocationPermission(): Promise<boolean> {
-  const permissionToCheck = getPermissionToCheck();
+  const permissions = rnPermissions;
 
-  if (permissionToCheck) {
-    return rnPermissions.request(permissionToCheck)
-      .then((status: any) => status === rnPermissions.RESULTS.GRANTED);
+  if (permissions) {
+    const permissionToCheck = getPermissionToCheck(permissions);
+
+    return permissions.request(permissionToCheck)
+      .then(status => status === permissions.RESULTS.GRANTED);
   }
 
   return Promise.resolve(false);

--- a/packages/pirateship/env/common.js
+++ b/packages/pirateship/env/common.js
@@ -45,14 +45,6 @@ module.exports = {
     android: 'com.brandingbrand.reactnative.and.pirateship',
     ios: 'com.brandingbrand.reactnative.pirateship',
   },
-  permissions: {
-    ios: {
-      LOCATION_WHEN_IN_USE: 'Test Description'
-    },
-    android: [
-      'ACCESS_FINE_LOCATION'
-    ]
-  },
   associatedDomains: [],
   targetedDevices: 'Universal'
 };

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -56,7 +56,6 @@
     "react-native-htmlview": "^0.15.0",
     "react-native-localize": "^1.3.0",
     "react-native-navigation": "^6.0.0",
-    "react-native-permissions": "^2.2.0",
     "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "^5.5.0",
     "react-native-svg": "^10.0.0",


### PR DESCRIPTION
fsengage is a dependency on a number of fs packages, and fsengage had a hard dependency on react native permissions due to its geolocation handler for the core cms provider. react-native-permissions requires native setup and exposes itself to end users, which is not ideal given that most projects that use fsengage don't need geolocation functionality. This PR makes permissions a peer dependency and updates the geolocation handler to return false if react native permissions isn't available in the project.