### PR TITLE
fix: audit usenativedriver settings for animations

### DIFF
--- a/packages/fscheckout/src/components/StepTracker.tsx
+++ b/packages/fscheckout/src/components/StepTracker.tsx
@@ -97,7 +97,7 @@ export default class StepTracker extends Component<StepTrackerProps, StepTracker
     if (prevActiveStep !== currActiveStep || prevItemWidth !== currItemWidth) {
       if (this.props.animated) {
         Animated.timing(this.sliderPosition, {
-          useNativeDriver: true,
+          useNativeDriver: false,
           duration: 300,
           toValue: currActiveStep * this.state.itemWidth
         }).start();

--- a/packages/fscomponents/src/components/Accordion.tsx
+++ b/packages/fscomponents/src/components/Accordion.tsx
@@ -353,7 +353,7 @@ export class Accordion extends Component<AccordionProps, AccordionState> {
       Animated.spring(this.state.contentHeightAnimation, {
         bounciness: 0,
         toValue: height,
-        useNativeDriver: true
+        useNativeDriver: false
       }).start();
     } else {
       this.state.contentHeightAnimation.setValue(height);

--- a/packages/fscomponents/src/components/ModalHalfScreen.tsx
+++ b/packages/fscomponents/src/components/ModalHalfScreen.tsx
@@ -131,7 +131,7 @@ export class ModalHalfScreen extends PureComponent<ModalHalfScreenProps, ModalHa
       // Open the drawer after we start the modal fade animation
       Animated.spring(this.state.contentOffset, {
         toValue: 1,
-        useNativeDriver: true,
+        useNativeDriver: false,
         bounciness: 0
       }).start();
     });
@@ -141,7 +141,7 @@ export class ModalHalfScreen extends PureComponent<ModalHalfScreenProps, ModalHa
     // Close the drawer
     Animated.spring(this.state.contentOffset, {
       toValue: 0,
-      useNativeDriver: true,
+      useNativeDriver: false,
       bounciness: 0
     }).start();
 

--- a/packages/fscomponents/src/components/SearchBar.tsx
+++ b/packages/fscomponents/src/components/SearchBar.tsx
@@ -290,7 +290,7 @@ export class SearchBar extends PureComponent<SearchBarProps, SearchBarState> {
       Animated.timing(this.state.cancelButtonWidth, {
         toValue: cancelButtonWidth || kCancelButtonWidthDefault,
         duration: kCancelButtonAnimationDuration,
-        useNativeDriver: true
+        useNativeDriver: false
       }).start();
     }
   }
@@ -309,7 +309,7 @@ export class SearchBar extends PureComponent<SearchBarProps, SearchBarState> {
       Animated.timing(this.state.cancelButtonWidth, {
         toValue: 0,
         duration: kCancelButtonAnimationDuration,
-        useNativeDriver: true
+        useNativeDriver: false
       }).start();
     }
   }

--- a/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.tsx
+++ b/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.tsx
@@ -272,7 +272,7 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
     Animated.timing(this.scrollViewPosition, {
       toValue: { x: nextOffsetX, y: 0 },
       easing: APPLE_EASING,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 
@@ -292,7 +292,7 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
     Animated.timing(this.scrollViewPosition, {
       toValue: { x: nextOffsetX, y: 0 },
       easing: APPLE_EASING,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 
@@ -305,12 +305,12 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
       Animated.timing(this.openScale, {
         toValue: 1,
         easing: APPLE_EASING,
-        useNativeDriver: true
+        useNativeDriver: false
       }),
       Animated.timing(this.scrollViewPosition, {
         toValue: { x: nextOffsetX, y: 0 },
         easing: APPLE_EASING,
-        useNativeDriver: true
+        useNativeDriver: false
       })
     ]).start();
   }
@@ -353,14 +353,14 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
             Animated.parallel([
               Animated.spring(this.openScale, {
                 toValue: 1,
-                useNativeDriver: true
+                useNativeDriver: false
               }),
               Animated.spring(this.scrollViewSize, {
                 toValue: SCREEN_WIDTH,
-                useNativeDriver: true
+                useNativeDriver: false
               }),
               Animated.spring(this.scrollViewPosition, {
-                useNativeDriver: true,
+                useNativeDriver: false,
                 toValue: {
                   x:
                     -this.state.currentIndex * SCREEN_WIDTH -
@@ -401,16 +401,16 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
             toValue: 0,
             duration: 250,
             easing: APPLE_EASING,
-            useNativeDriver: true
+            useNativeDriver: false
           }),
           Animated.timing(this.scrollViewSize, {
             toValue: this.imageWidth,
             duration: 250,
-            useNativeDriver: true
+            useNativeDriver: false
           }),
           Animated.timing(this.scrollViewPosition, {
             duration: 250,
-            useNativeDriver: true,
+            useNativeDriver: false,
             toValue: {
               x:
                 -this.state.currentIndex * offsetWidth -

--- a/packages/fscomponents/src/components/ZoomCarousel/ZoomCarouselItem.tsx
+++ b/packages/fscomponents/src/components/ZoomCarousel/ZoomCarouselItem.tsx
@@ -102,11 +102,11 @@ export class ZoomCarouselItem extends PureComponent<ZoomCarouselItemProps, ZoomC
           Animated.parallel([
             Animated.spring(this.state.zoomImageSize, {
               toValue: SCREEN_WIDTH,
-              useNativeDriver: true
+              useNativeDriver: false
             }),
             Animated.spring(this.state.zoomImagePosition, {
               toValue: { x: 0, y: 0 },
-              useNativeDriver: true
+              useNativeDriver: false
             })
           ]).start();
           this.props.onZoomRelease(this.distanceDiff);

--- a/packages/fsengagement/src/EngagementComp.tsx
+++ b/packages/fsengagement/src/EngagementComp.tsx
@@ -521,7 +521,7 @@ export default function(
         return (
           <Animatable.View
             ref={this.handleWelcomeRef}
-            useNativeDriver
+            useNativeDriver={false}
             style={{
               transform: [
                 { translateY: -100 }
@@ -771,7 +771,7 @@ export default function(
           <Fragment>
             <Animatable.View
               ref={this.handleAnimatedRef}
-              useNativeDriver
+              useNativeDriver={false}
               style={[styles.animatedContainer]}
             >
               {this.renderScrollView()}
@@ -779,7 +779,7 @@ export default function(
             {backButton && (
               <Animatable.View
                 ref={this.handleAppleCloseRef}
-                useNativeDriver
+                useNativeDriver={false}
                 style={styles.closeModalButton}
               >
                 <TouchableOpacity activeOpacity={1} onPress={this.onAnimatedClose}>
@@ -799,7 +799,7 @@ export default function(
           <Fragment>
             <Animatable.View
               ref={this.handleAnimatedRef}
-              useNativeDriver
+              useNativeDriver={false}
               style={[styles.animatedContainer]}
             >
               {this.renderScrollView()}
@@ -976,7 +976,7 @@ export default function(
               scrollEventThrottle={16}
               onScroll={Animated.event(
                 [{ nativeEvent: { contentOffset: { y: this.state.scrollY } } }],
-                { useNativeDriver: true }
+                { useNativeDriver: false }
               )}
               ListHeaderComponent={this.renderFlatlistHeader}
               ListFooterComponent={this.renderFlatlistFooter}
@@ -1044,7 +1044,7 @@ export default function(
             (
               <Animatable.View
                 ref={this.handlePageCounterRef}
-                useNativeDriver
+                useNativeDriver={false}
                 style={[styles.pageCounter, this.pageCounterStyle]}
               >
                 <Text
@@ -1059,7 +1059,7 @@ export default function(
             <Animatable.Text
               style={[styles.navBarTitle, navBarTitleStyle]}
               ref={this.handleNavTitleRef}
-              useNativeDriver
+              useNativeDriver={false}
             >
               {navBarTitle}
             </Animatable.Text>

--- a/packages/fsengagement/src/EngagementProductModal.tsx
+++ b/packages/fsengagement/src/EngagementProductModal.tsx
@@ -506,7 +506,7 @@ export default class EngagementProductModal extends
       <View style={styles.growStretch}>
         <Animatable.View
           ref={this.handleAnimatedRef}
-          useNativeDriver
+          useNativeDriver={false}
           style={styles.background}>
           <TouchableOpacity
             style={styles.modalBackground}
@@ -516,7 +516,7 @@ export default class EngagementProductModal extends
         </Animatable.View>
         <Animatable.View
           ref={this.handleAnimatedContentRef}
-          useNativeDriver
+          useNativeDriver={false}
           style={{
             marginTop: 50,
             transform: [

--- a/packages/fsengagement/src/inboxblocks/FullScreenImageCard.tsx
+++ b/packages/fsengagement/src/inboxblocks/FullScreenImageCard.tsx
@@ -221,13 +221,13 @@ export default class FullScreenImageCard extends Component<FullScreenCardProps> 
             <Animatable.Image
               source={contents.Image.source}
               ref={this.handleImageRef}
-              useNativeDriver
+              useNativeDriver={false}
               style={[StyleSheet.absoluteFill, styles.fullScreen]}
             />
             <Animatable.View
               style={styles.bottom}
               ref={this.handleTextRef}
-              useNativeDriver
+              useNativeDriver={false}
             >
               {this.props.isNew &&
                 (

--- a/packages/fsengagement/src/inboxblocks/InboxWrapper.tsx
+++ b/packages/fsengagement/src/inboxblocks/InboxWrapper.tsx
@@ -56,7 +56,7 @@ export default class InboxWrapper extends Component<CardProps> {
               height: '100%'
             }]}
             ref={this.handleFadeInRef}
-            useNativeDriver
+            useNativeDriver={false}
           >
             {this.props.children}
           </Animatable.View>

--- a/packages/fsengagement/src/inboxblocks/RoundedImageCard.tsx
+++ b/packages/fsengagement/src/inboxblocks/RoundedImageCard.tsx
@@ -263,7 +263,7 @@ export default class RoundedImageCardCard extends Component<RoundedImageCardProp
           <Animatable.Image
             source={contents.Image.source}
             ref={this.handleImageRef}
-            useNativeDriver
+            useNativeDriver={false}
             style={[StyleSheet.absoluteFill, styles.fullScreen]}
           />
           <View
@@ -274,7 +274,7 @@ export default class RoundedImageCardCard extends Component<RoundedImageCardProp
           >
             <Animatable.View
               ref={this.handleContentRef}
-              useNativeDriver
+              useNativeDriver={false}
               style={[styles.bottom, textContainerStyle]}
             >
               <TextBlock

--- a/packages/fslocator/src/components/LocatorMapSlideList.tsx
+++ b/packages/fslocator/src/components/LocatorMapSlideList.tsx
@@ -71,13 +71,13 @@ export default class LocatorMapSlideList extends Component<
 
     Animated.spring(this.state.listButtonY, {
       toValue: 0,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     Animated.spring(this.state.listY, {
       bounciness: 0,
       toValue: MAP_HEIGHT,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 
@@ -90,13 +90,13 @@ export default class LocatorMapSlideList extends Component<
 
     Animated.spring(this.state.listButtonY, {
       toValue: 0,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     Animated.spring(this.state.listY, {
       bounciness: 0,
       toValue: this.getPositionY('bottom'),
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 
@@ -108,13 +108,13 @@ export default class LocatorMapSlideList extends Component<
 
     Animated.spring(this.state.listButtonY, {
       toValue: 0,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     Animated.spring(this.state.listY, {
       bounciness: 0,
       toValue: this.getPositionY('top'),
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 
@@ -179,7 +179,7 @@ export default class LocatorMapSlideList extends Component<
       setTimeout(() => {
         Animated.spring(this.state.listButtonY, {
           toValue: -SHOW_LIST_BUTTON_HEIGHT,
-          useNativeDriver: true
+          useNativeDriver: false
         }).start();
         this.expandMap();
       }, 200);
@@ -188,7 +188,7 @@ export default class LocatorMapSlideList extends Component<
     Animated.spring(this.state.listY, {
       bounciness: 0,
       toValue: this.getPositionY(nextPostion),
-      useNativeDriver: true
+      useNativeDriver: false
     }).start(() => {
       this.setState({ scrollable: true });
     });
@@ -235,13 +235,13 @@ export default class LocatorMapSlideList extends Component<
 
     Animated.spring(this.state.listButtonY, {
       toValue: 0,
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
 
     Animated.spring(this.state.listY, {
       bounciness: 0,
       toValue: this.getPositionY('top'),
-      useNativeDriver: true
+      useNativeDriver: false
     }).start();
   }
 


### PR DESCRIPTION
Per the React Native docs, using the native driver for animations will only work for non-layout transforms like opacity and rotation. RN appears to have silently ignored invalid transforms in the past, but in RN 63 it displays a promiment warning. This updates all invalid transforms using native drivers to set useNativeDriver to false.

Reference which is from 2017 but still appears to be valid per my research: https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated.html#caveats