### PR TITLE
fix(fsengagement): address cannot set state on unmounted component error

### DIFF
--- a/packages/fsengagement/src/EngagementComp.tsx
+++ b/packages/fsengagement/src/EngagementComp.tsx
@@ -259,6 +259,8 @@ export default function(
     scrollPosition: number = 0;
     AnimatedAppleClose: any;
     AnimatedWelcome: any;
+    componentIsMounted: boolean = false;
+
     constructor(props: EngagementScreenProps) {
       super(props);
       this.state = {
@@ -288,8 +290,12 @@ export default function(
           this.props.onBack();
         }
       }
+
+      this.componentIsMounted = false;
     }
     componentDidMount(): void {
+      this.componentIsMounted = true;
+
       if (this.props.animate) {
         if (this.props.json && this.props.json.tabbedItems && this.props.json.tabbedItems.length) {
           this.setState({ showDarkX: true });
@@ -321,7 +327,9 @@ export default function(
       }
       if (!(this.props.json && this.props.json.private_type === 'story')) {
         setTimeout(() => {
-          this.setState({ showCarousel: true });
+          if (this.componentIsMounted) {
+            this.setState({ showCarousel: true });
+          }
         }, 500);
       }
     }


### PR DESCRIPTION
This addresses a warning regarding updating state on an unmounted component in EngagementComp. It adds a simple boolean keeping track of whether the component is currently mounted so that async operations can check before running.