### PR TITLE
feat: replaced tcomb-form-native with bb fork

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -22,7 +22,10 @@ module.exports = ({ config, env }) => {
 
   config.module.rules.push({
     test: /\.jsx?$/,
-    include: path.resolve('node_modules/tcomb-form-native/'),
+    include: [
+      path.resolve('node_modules/@brandingbrand/tcomb-form-native/'),
+      path.resolve('node_modules/@react-native-community/picker')
+    ],
     loader: require.resolve('babel-loader'),
     options: {
       cacheDirectory: true

--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -16,6 +16,7 @@
     "@brandingbrand/fsfoundation": "^10.0.0-alpha.5",
     "@brandingbrand/fsi18n": "^10.0.0-alpha.5",
     "@brandingbrand/fsnetwork": "^10.0.0-alpha.5",
+    "@brandingbrand/tcomb-form-native": "^0.6.20",
     "@react-native-community/async-storage": "^1.6.1",
     "@types/yup": "^0.28.1",
     "credit-card": "^3.0.1",
@@ -34,7 +35,6 @@
     "react-native-swiper": "1.6.0",
     "react-native-web-modal": "^1.0.1",
     "sweetalert": "^2.1.0",
-    "tcomb-form-native": "^0.6.12",
     "yup": "^0.29.0"
   },
   "publishConfig": {

--- a/packages/fscomponents/src/components/AddressForm.tsx
+++ b/packages/fscomponents/src/components/AddressForm.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { cloneDeep, merge, pickBy } from 'lodash-es';
 import { emailRegex } from '../lib/email';
 import { Form, FormLabelPosition } from './Form';

--- a/packages/fscomponents/src/components/CMSFeedback.tsx
+++ b/packages/fscomponents/src/components/CMSFeedback.tsx
@@ -11,7 +11,7 @@ import {
 
 import FSNetwork from '@brandingbrand/fsnetwork';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const TcForm = require('tcomb-form-native');
+const TcForm = require('@brandingbrand/tcomb-form-native');
 import { cloneDeep } from 'lodash-es';
 import { stringify } from 'qs';
 

--- a/packages/fscomponents/src/components/ChangePasswordComponent.tsx
+++ b/packages/fscomponents/src/components/ChangePasswordComponent.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from './Form';
 import { Button } from './Button';
 import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';

--- a/packages/fscomponents/src/components/CreditCardForm.tsx
+++ b/packages/fscomponents/src/components/CreditCardForm.tsx
@@ -12,7 +12,7 @@ import {
 // @ts-ignore TODO: Update credit-card to support typing
 import * as creditCard from 'credit-card';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import {
   creditCardAboveLabelTemplate,
   creditCardFloatingLabelTemplate,

--- a/packages/fscomponents/src/components/EmailForm.tsx
+++ b/packages/fscomponents/src/components/EmailForm.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import { emailRegex } from '../lib/email';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { SingleLineForm } from './SingleLineForm';
 import { FormLabelPosition } from './Form';
 import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';

--- a/packages/fscomponents/src/components/Form/Form.tsx
+++ b/packages/fscomponents/src/components/Form/Form.tsx
@@ -5,7 +5,7 @@ import memoize from 'memoize-one';
 import { Dictionary } from '@brandingbrand/fsfoundation';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import {
   aboveLabels,
   floatingLabels,

--- a/packages/fscomponents/src/components/LoginForm.tsx
+++ b/packages/fscomponents/src/components/LoginForm.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { StyleProp, TextStyle, View, ViewStyle } from 'react-native';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { emailRegex } from '../lib/email';
 import { Form, FormLabelPosition } from './Form';
 import { Button } from './Button';

--- a/packages/fscomponents/src/components/PromoForm.tsx
+++ b/packages/fscomponents/src/components/PromoForm.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { SingleLineForm, SingleLineFormProps } from './SingleLineForm';
 import { Omit } from '@brandingbrand/fsfoundation';
 import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';

--- a/packages/fscomponents/src/components/RegistrationForm.tsx
+++ b/packages/fscomponents/src/components/RegistrationForm.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { StyleSheet, View } from 'react-native';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { emailRegex } from '../lib/email';
 import { Form } from './Form';
 import { Button } from './Button';

--- a/packages/fscomponents/src/components/UpdateNameOrEmail.tsx
+++ b/packages/fscomponents/src/components/UpdateNameOrEmail.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { View } from 'react-native';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { emailRegex } from '../lib/email';
 import { Form } from './Form';
 import { Button } from './Button';

--- a/packages/fscomponents/src/components/__stories__/Form.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/Form.story.tsx
@@ -9,7 +9,7 @@ import {
 // tslint:disable-next-line no-implicit-dependencies
 } from '@storybook/addon-knobs';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from '../Form/Form';
 import { FormLabelPosition } from '../Form/Templates/fieldTemplates';
 import { Button } from '../Button';

--- a/packages/fsweb/webpack.config.js
+++ b/packages/fsweb/webpack.config.js
@@ -99,7 +99,8 @@ const globalConfig = {
             test: /\.m?jsx?$/,
             include: [
               new RegExp('node_modules' + escapedSep + 'react-native-'),
-              new RegExp('node_modules' + escapedSep + 'tcomb-form-native'),
+              new RegExp('node_modules' + escapedSep + '@brandingbrand' + escapedSep + 'tcomb-form-native'),
+              new RegExp('node_modules' + escapedSep + '@react-native-community' + escapedSep + 'picker'),
               new RegExp('packages' + escapedSep + 'fs'),
               new RegExp('node_modules' + escapedSep + '@brandingbrand' + escapedSep + 'fs'),
               new RegExp('node_modules' + escapedSep + '@brandingbrand' + escapedSep + 'react-native-')

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -42,6 +42,7 @@
     "@brandingbrand/fsweb": "^10.0.0-alpha.5",
     "@brandingbrand/react-native-leanplum": "^5.0.0",
     "@brandingbrand/react-native-payments": "^0.10.0",
+    "@brandingbrand/tcomb-form-native": "^0.6.20",
     "@react-native-community/async-storage": "^1.6.2",
     "@react-native-community/cli-platform-android": "^4.7.0",
     "@react-native-community/cli-platform-ios": "^4.7.0",
@@ -62,8 +63,7 @@
     "react-native-touch-id": "~4.4.0",
     "react-native-video": "^5.0.0",
     "react-native-webview": "^10.9.0",
-    "react-redux": "^7.0.0",
-    "tcomb-form-native": "^0.6.12"
+    "react-redux": "^7.0.0"
   },
   "flagship": {
     "webEnabled": false,

--- a/packages/pirateship/src/components/ContactInfoForm.tsx
+++ b/packages/pirateship/src/components/ContactInfoForm.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import React, { Component } from 'react';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from '@brandingbrand/fscomponents';
 import { EMAIL_REGEX } from '../lib/constants';
 import { select, textbox } from '../lib/formTemplate';

--- a/packages/pirateship/src/components/PSAddressForm.tsx
+++ b/packages/pirateship/src/components/PSAddressForm.tsx
@@ -15,7 +15,7 @@ import { border, color, fontSize, padding, palette } from '../styles/variables';
 import formFieldStyles from '../styles/FormField';
 import { select, textbox } from '../lib/formTemplate';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from '@brandingbrand/fscomponents';
 import { merge } from 'lodash-es';
 import { EMAIL_REGEX } from '../lib/constants';

--- a/packages/pirateship/src/components/PSCreditCardForm.tsx
+++ b/packages/pirateship/src/components/PSCreditCardForm.tsx
@@ -4,7 +4,7 @@ import formFieldStyles from '../styles/FormField';
 import { select, textbox, textboxWithRightIcon } from '../lib/formTemplate';
 import { Form } from '@brandingbrand/fscomponents';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import CCType, { CardBrand } from 'credit-card-type';
 
 const months = require('../../assets/months.json');

--- a/packages/pirateship/src/components/PSSignInForm.tsx
+++ b/packages/pirateship/src/components/PSSignInForm.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Form } from '@brandingbrand/fscomponents';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { merge } from 'lodash-es';
 import TouchId, { AuthenticationError, IsSupportedError } from 'react-native-touch-id';
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';

--- a/packages/pirateship/src/screens/EmailSignUp.tsx
+++ b/packages/pirateship/src/screens/EmailSignUp.tsx
@@ -9,7 +9,7 @@ import {
 import { Options } from 'react-native-navigation';
 
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const tcomb = require('tcomb-form-native');
+const tcomb = require('@brandingbrand/tcomb-form-native');
 import { CMSBannerStacked, Form } from '@brandingbrand/fscomponents';
 
 import { NavButton, ScreenProps } from '../lib/commonTypes';

--- a/packages/pirateship/src/screens/ForgotPassword.tsx
+++ b/packages/pirateship/src/screens/ForgotPassword.tsx
@@ -3,7 +3,7 @@ import { navBarHide } from '../styles/Navigation';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Options } from 'react-native-navigation';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from '@brandingbrand/fscomponents';
 import PSScreenWrapper from '../components/PSScreenWrapper';
 import React, { Component } from 'react';

--- a/packages/pirateship/src/screens/TrackOrderLanding.tsx
+++ b/packages/pirateship/src/screens/TrackOrderLanding.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Linking, StyleSheet, Text, View } from 'react-native';
 import { Options } from 'react-native-navigation';
 // Using import with tcomb-form-native seems to cause issues with the object being undefined.
-const t = require('tcomb-form-native');
+const t = require('@brandingbrand/tcomb-form-native');
 import { Form } from '@brandingbrand/fscomponents';
 import PSScreenWrapper from '../components/PSScreenWrapper';
 import PSButton from '../components/PSButton';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,6 +2084,15 @@
     uuid "^3.1.0"
     validator "^7.0.0"
 
+"@brandingbrand/tcomb-form-native@^0.6.20":
+  version "0.6.20"
+  resolved "https://registry.yarnpkg.com/@brandingbrand/tcomb-form-native/-/tcomb-form-native-0.6.20.tgz#57c93717b5eb00f041154493503eafcf1b5022d5"
+  integrity sha512-yYaZbIMQMVUwqU7Sehc9uzaB4+Qpf+neHuEnR0zKdt1aveEy1kTWhEakF25SjOawvuvPBVyH7vPqv/AstGdkXw==
+  dependencies:
+    "@react-native-community/datetimepicker" "^3.0.2"
+    "@react-native-community/picker" "^1.8.0"
+    tcomb-validation "^3.0.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -3643,10 +3652,22 @@
   dependencies:
     invariant "^2.2.4"
 
+"@react-native-community/datetimepicker@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-3.0.2.tgz#6e52cda7fa46ecebfb216f5520cfbf2754348299"
+  integrity sha512-NLcV3HLrjtvyYM4CU4O+nWJ+LsjB4XnkUiXjK52PgnlRrg5i3hJQHcp/GsrHQbB62UC+Zn96+Hy+jiw4K5Rw/w==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native-community/geolocation@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/geolocation/-/geolocation-2.0.2.tgz#ba8b40f560ead8d014740d1cdea970b33f19312e"
   integrity sha512-tTNXRCgnhJBu79mulQwzabXRpDqfh/uaDqfHVpvF0nX4NTpolpy6mvTRiFg7eWFPGRArsnZz1EYp6rHfJWGgEA==
+
+"@react-native-community/picker@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/picker/-/picker-1.8.0.tgz#32425321af1e29e3da882fbd627a71ea142c75e4"
+  integrity sha512-aS506wjynNzKDZjynlDasbc665GKGHdhrCob9KdOprPFlE+zMnoR3k0Ce0OkIuGHcY/GMVvQqTc+LYVm2UOmbg==
 
 "@react-native-community/push-notification-ios@^1.0.0":
   version "1.5.0"
@@ -18623,13 +18644,6 @@ tar@^5.0.0:
     minizlib "^2.1.0"
     mkdirp "^0.5.0"
     yallist "^4.0.0"
-
-tcomb-form-native@^0.6.12:
-  version "0.6.20"
-  resolved "https://registry.yarnpkg.com/tcomb-form-native/-/tcomb-form-native-0.6.20.tgz#81771faf86536a5d4c0f492885eb229324d47ea5"
-  integrity sha512-tuvLmdii2zvkevzFKMS1lYbmE5BeKuRF+sokVqllfjwrViLjgdSCD2Y8WZHUYbUMTbBfEUF65F0vd5zP+Owr2Q==
-  dependencies:
-    tcomb-validation "^3.0.0"
 
 tcomb-validation@^3.0.0:
   version "3.4.1"


### PR DESCRIPTION
tcomb-form-native hasn't been updated in several years and therefore still had dependencies on React Native that had been moved to separate packages as part of the RN lean core project.

We created a Branding Brand fork, @brandingbrand/tcomb-form-native, that addresses these issues. This updates Flagship to use the forked version.