### PR TITLE
fix(fsweb): Add languages to navigator

### DIFF
--- a/packages/fsweb/polyfills/navigator.js
+++ b/packages/fsweb/polyfills/navigator.js
@@ -1,0 +1,1 @@
+export const languages = [];

--- a/packages/pirateship/src/index.web.ts
+++ b/packages/pirateship/src/index.web.ts
@@ -27,7 +27,5 @@ if (window.initialState) {
   };
 }
 
-console.log(webConfig.initialState);
-
 const app = new FSApp(webConfig);
 export default app;


### PR DESCRIPTION
Needed for react-native-localize to run server-side. Also removed a console.log