### PR TITLE
feat(fsapp): Add additional options to SSR

### DIFF
--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -68,6 +68,11 @@ export interface RoutableComponentClass extends React.ComponentClass<any> {
   paramKeys?: any[];
   cache?: number;
   loadInitialData?: (initialState: any, req: Request) => Promise<any>;
+  // Set to true to call next immediately if this is matched
+  instantNext?: boolean;
+  // Function to call to determine programmatically whether to call next
+  // Includes data after running loadInitialState
+  shouldNext?: (data: SSRData, req: Request) => Promise<boolean>;
 }
 
 export interface SSRData {

--- a/packages/pirateship/src/ssr.ts
+++ b/packages/pirateship/src/ssr.ts
@@ -1,7 +1,7 @@
 import { appConfig } from './appConfig';
 import type { FSAppTypes } from '@brandingbrand/fsapp';
 // tslint:disable-next-line: no-submodule-imports
-import { attachSSR } from '@brandingbrand/fsapp/dist/lib/ssr';
+import { attachSSR, SSROptions } from '@brandingbrand/fsapp/dist/lib/ssr';
 import Analytics from './lib/analytics';
 
 const webConfig: FSAppTypes.AppConfigType = {
@@ -20,6 +20,6 @@ const webConfig: FSAppTypes.AppConfigType = {
   analytics: Analytics
 };
 
-export default function(app: any): void {
-  attachSSR(app, webConfig);
+export default function(app: any, options?: SSROptions): void {
+  attachSSR(app, webConfig, options);
 }


### PR DESCRIPTION
Can now set options to call next() on certain screens, so middleware after the SSR can run. Also allows turning off rendering the app for the root path and overriding the html that is used as the base, in case the file is in a different location or you want to pass in some other string.