### PR TITLE
feat(fscomponents): add NestingButtons component

### DIFF
--- a/packages/fscomponents/src/components/NestingButtons.tsx
+++ b/packages/fscomponents/src/components/NestingButtons.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View, ViewStyle } from 'react-native';
+import { Button, ButtonProps } from './Button';
+import { ModalHalfScreen, ModalHalfScreenProps } from './ModalHalfScreen';
+
+const styles = StyleSheet.create({
+  button: {
+    margin: 5
+  }
+});
+
+export interface NestingButtonsProps {
+  showMoreTitle: string;
+  buttonsProps: ButtonProps[];
+  maxCount?: number;
+  style?: ViewStyle;
+  containerStyle?: ViewStyle;
+  showMoreButtonProps?: ButtonProps;
+  modalProps?: Omit<ModalHalfScreenProps, 'visible' | 'onRequestClose'>;
+}
+
+export const NestingButtons: React.FC<NestingButtonsProps> = React.memo(props => {
+  const [modalVisible, setModalVisibile] = useState<boolean>(false);
+  const toggleModal = () => setModalVisibile(!modalVisible);
+  const {
+    buttonsProps,
+    showMoreTitle,
+    showMoreButtonProps,
+    modalProps,
+    containerStyle,
+    style,
+    maxCount = 3
+  } = props;
+
+  const buttons = buttonsProps.map((buttonProps, index) => (
+    <Button
+      key={index}
+      {...buttonProps}
+      style={[styles.button, buttonProps.style]}
+    />
+  ));
+
+  const buttonsContainer = (
+    <View style={style}>
+      {buttons}
+    </View>
+  );
+
+  if (buttons.length <= maxCount) {
+    return buttonsContainer;
+  }
+
+  return (
+    <View style={containerStyle}>
+      <Button
+        title={showMoreTitle}
+        onPress={toggleModal}
+        {...showMoreButtonProps}
+        style={[styles.button, showMoreButtonProps?.style]}
+      />
+      <ModalHalfScreen
+        visible={modalVisible}
+        onRequestClose={toggleModal}
+        {...modalProps}
+      >
+        <ScrollView>
+          {buttonsContainer}
+        </ScrollView>
+      </ModalHalfScreen>
+    </View>
+  );
+});

--- a/packages/fscomponents/src/components/__stories__/NestingButtons.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/NestingButtons.story.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react'; // tslint:disable-line:no-implicit-dependencies
+import {
+  number,
+  text
+// tslint:disable-next-line no-implicit-dependencies
+} from '@storybook/addon-knobs';
+import { NestingButtons } from '../NestingButtons';
+
+const onPress = (index: number) => () => console.log(`Button ${index} pressed.`);
+const generateButtons = (num: number) => {
+  return new Array(num).fill(null).map((n, index) => ({
+    title: `Button ${index}`,
+    onPress: onPress(index)
+  }));
+};
+
+storiesOf('NestingButtons', module)
+  .add('basic usage', () => (
+    <NestingButtons
+      showMoreTitle={text('Show More Title', 'Checkout Options')}
+      maxCount={number('Max Number of Buttons', 3)}
+      buttonsProps={generateButtons(number('Number of Buttons', 5))}
+    />
+  ));


### PR DESCRIPTION
Accepts an array of button props and generates buttons based on those. If the number of buttons
exceeds a configurable threshold, the buttons will be hidden behind a modal.

![nesting-buttons](https://user-images.githubusercontent.com/3847536/95586617-eef84500-0a0e-11eb-8b6b-a496165438f7.gif)
