### PR TITLE
fix(flagship): update RNFirebase pod

### DIFF
--- a/packages/flagship/src/lib/modules/ios/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-firebase.ts
@@ -45,7 +45,7 @@ export function preLink(configuration: Config): void {
 
   // Add Firebase pod to Podfile
   const podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
-  const firebasePod = `pod 'Firebase/Core', '5.12.0'`;
+  const firebasePod = `pod 'Firebase/Core', '6.13.0'`;
 
   if (podfile.indexOf(firebasePod) === -1) {
     pods.add([firebasePod]);
@@ -54,7 +54,7 @@ export function preLink(configuration: Config): void {
 
   // Firebase includes GoogleAppMeasurement as a dependency automatically, but the latest version
   // 5.4.0 was compiled with Xcode 10 which is not yet supported by Flagship
-  const googleMeasurementPod = `pod 'GoogleAppMeasurement', '5.3.0'`;
+  const googleMeasurementPod = `pod 'GoogleAppMeasurement', '6.1.6'`;
 
   if (podfile.indexOf(googleMeasurementPod) === -1) {
     pods.add([googleMeasurementPod]);


### PR DESCRIPTION
**Description**
- the `react-native-firebase` module was adding `Firebase/Core 5.1.2` to the Podfile
- this was causing a build error because the react-native 60+ is dependent on iOS SDK 6.13+ 
- updating to add 6.13 to the Podfile and its dependency `pod 'GoogleAppMeasurement', '6.1.6'`
 
from https://www.npmjs.com/package/react-native-firebase
![image](https://user-images.githubusercontent.com/38706174/96170679-e5307f00-0ef1-11eb-9ae1-1ded17a2ebcc.png)
 