### PR TITLE
fix: fix android release variant compilation

### DIFF
--- a/packages/flagship/android/app/src/debug/java/com/brandingbrand/reactnative/and/flagship/ReactNativeFlipper.java
+++ b/packages/flagship/android/app/src/debug/java/com/brandingbrand/reactnative/and/flagship/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package CONFIG_BUNDLE_ID;
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;
 import com.facebook.flipper.android.utils.FlipperUtils;

--- a/packages/flagship/android/app/src/main/java/com/brandingbrand/reactnative/and/flagship/MainApplication.java
+++ b/packages/flagship/android/app/src/main/java/com/brandingbrand/reactnative/and/flagship/MainApplication.java
@@ -102,7 +102,7 @@ public class MainApplication extends NavigationApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.rndiffapp.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("CONFIG_BUNDLE_ID.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -142,6 +142,7 @@ function initAndroid(
   rename.source('FLAGSHIP', configuration.name, 'android');
   rename.source('CONFIG_BUNDLE_ID', pkgId, 'android');
   rename.pkgDirectory(TEMPLATE_ANDROID_PACKAGE, pkgId, path.android.mainPath(), 'java');
+  rename.pkgDirectory(TEMPLATE_ANDROID_PACKAGE, pkgId, path.android.debugPath(), 'java');
 
   fastlane.configure(path.android.fastfilePath(), configuration); // Update Fastfile
 

--- a/packages/flagship/src/lib/path.ts
+++ b/packages/flagship/src/lib/path.ts
@@ -205,6 +205,14 @@ function getMainPath(): string {
 }
 
 /**
+ * Returns the path to the main directory.
+ * @returns {string} The path to the main directory.
+ */
+function getDebugPath(): string {
+  return resolvePathFromProject('android', 'app', 'src', 'debug');
+}
+
+/**
  * Returns the path to the assets directory.
  * @returns {string} The path to the assets directory.
  */
@@ -282,6 +290,7 @@ export const android = {
   gradlePath: getGradlePath,
   gradlePropertiesPath: getGradlePropertiesPath,
   mainPath: getMainPath,
+  debugPath: getDebugPath,
   assetsPath: getAssetsPath,
   resourcesPath: getResourcesPath,
   stringsPath: getStringsPath,


### PR DESCRIPTION
- adds path function to get debug android src folder
- adds init step to rename debug src folder structure to match package
- fixes flipper package name
- moves flipper to only be included in debug