### PR TITLE
chore(fsnetwork): upgrade axios to 0.21.0

### DIFF
--- a/packages/fsnetwork/package.json
+++ b/packages/fsnetwork/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@brandingbrand/fsfoundation": "^10.2.0",
-    "axios": "~0.20.0"
+    "axios": "~0.21.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Axios v0.20.0 introduces some bugs which fails several actions. They are resolved in v0.21.0.

**Note:** This version doesn't include any new features or breaking changes.

**Release change logs:** https://github.com/axios/axios/releases/tag/v0.21.0