### PR TITLE
fix(flagship): made rn camera patch script work again

### DIFF
--- a/packages/flagship/src/lib/modules/android/react-native-camera.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-camera.ts
@@ -11,9 +11,9 @@ export function postLink(configuration: Config): void {
   let gradleAppBuild = fs.readFileSync(path.android.gradlePath(), { encoding: 'utf8' });
 
   gradleAppBuild = gradleAppBuild.replace(
-    /(missingDimensionStrategy)/,
-    `missingDimensionStrategy 'react-native-camera', 'general'
-    $1`
+    'defaultConfig {',
+    `defaultConfig {
+        missingDimensionStrategy 'react-native-camera', 'general'`
   );
 
   fs.writeFileSync(path.android.gradlePath(), gradleAppBuild);


### PR DESCRIPTION
react-native-camera needs a missingDimensionStrategy line added to build.gradle to build properly. Our script to patch this was looking to do a string replace on a value that no longer exists in the file.