### PR TITLE
fix(fsweb): Remove svgs module

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = ({ config, env }) => {
   ];
 
   config.resolve.alias["react-native"] = "react-native-web";
-  config.resolve.alias["react-native-svg"] = "svg";
   config.resolve.alias['react-native-web/dist/exports/DatePickerIOS'] = '@react-native-community/datetimepicker';
   config.resolve.alias['react-native-web/dist/exports/PickerIOS'] = 'react-native-web/dist/exports/Picker';
   config.resolve.alias['react-native-web/dist/exports/ProgressBarAndroid'] = 'react-native-web/dist/exports/ProgressBar';

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "react-native-web": "^0.13.12",
     "react-native-web-modal": "^1.0.1",
     "rimraf": "^3.0.0",
-    "svgs": "^4.1.0",
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.0.0",
     "typedoc": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-native-web": "^0.13.12",
     "react-native-web-modal": "^1.0.1",
     "rimraf": "^3.0.0",
+    "svgs": "^4.1.0",
     "ts-jest": "^24.1.0",
     "ts-loader": "^6.0.0",
     "typedoc": "^0.15.0",

--- a/packages/fsweb/package.json
+++ b/packages/fsweb/package.json
@@ -51,7 +51,6 @@
     "react-native-web-modal": "^1.0.1",
     "react-native-web-webview": "^0.2.8",
     "style-loader": "^1.0.0",
-    "svgs": "^4.1.0",
     "swiper": "^5.0.0",
     "terser-webpack-plugin": "^1.4.2",
     "ts-loader": "^6.0.0",

--- a/packages/fsweb/webpack.config.js
+++ b/packages/fsweb/webpack.config.js
@@ -56,7 +56,6 @@ const globalConfig = {
     ],
     alias: {
       'react-native': 'react-native-web',
-      'react-native-svg': 'svgs',
       'react-native-web/dist/exports/DatePickerIOS': '@react-native-community/datetimepicker',
       'react-native-web/dist/exports/PickerIOS': 'react-native-web/dist/exports/Picker',
       'react-native-web/dist/exports/ProgressBarAndroid': 'react-native-web/dist/exports/ProgressBar',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15077,11 +15077,6 @@ rimraf@~2.2.6:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
 
-rip-out@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rip-out/-/rip-out-1.0.0.tgz#d622a7b607e1cdadc8b079bf9fb3da42c13b98e3"
-  integrity sha1-1iKntgfhza3IsHm/n7PaQsE7mOM=
-
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -16138,14 +16133,6 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-svgs@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/svgs/-/svgs-4.1.1.tgz#cff1b5caaf9e3a5e51e75c1ea16df6fa54941505"
-  integrity sha512-5QDy6nu4EcBvebNoRQ6iiXfqt/IB2hKdeh5rXwEuoywKX/YtfK8xFggQWSwR24dKpK+C1n7kzBAhPa0bUOrV6A==
-  dependencies:
-    prop-types "^15.5.10"
-    rip-out "^1.0.0"
 
 sweetalert@^2.1.0:
   version "2.1.2"


### PR DESCRIPTION
react-native-svg has web support now, so a separate module isn't needed.