### PR TITLE
fix(fscomponents): Use div for web multicarousel

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -1,7 +1,6 @@
-import React, { Component } from 'react';
+import React, { Component, MouseEvent, TouchEvent } from 'react';
 import {
   Animated,
-  ScrollView,
   StyleSheet,
   TouchableOpacity,
   View
@@ -12,8 +11,6 @@ import FSI18n, { translationKeys } from '@brandingbrand/fsi18n';
 import { MultiCarouselProps } from './MultiCarouselProps';
 import { animatedScrollTo } from '../../lib/helpers';
 import { PageIndicator } from '../PageIndicator';
-
-const ScrollViewCopy: any = ScrollView;
 
 export interface MultiCarouselState {
   containerWidth: number;
@@ -68,7 +65,7 @@ const S = StyleSheet.create({
 });
 
 export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, MultiCarouselState> {
-  scrollView: any;
+  scrollView?: React.RefObject<HTMLDivElement>;
   mouseDown: boolean = false;
   currentScrollX: number = 0;
   initialScrollX: number = 0;
@@ -85,6 +82,8 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
       itemWidth: 0,
       opacity: new Animated.Value(this.props.itemUpdated ? 0 : 1)
     };
+
+    this.scrollView = React.createRef();
   }
 
   componentDidUpdate(
@@ -159,7 +158,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
   }
 
   goTo = (index: number, options?: any) => {
-    const scrollViewElement = findDOMNode(this.scrollView);
+    const scrollViewElement = findDOMNode(this.scrollView?.current);
 
     if (scrollViewElement instanceof Element) {
       animatedScrollTo(
@@ -212,9 +211,19 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
     );
   }
 
-  handleTouchStart = (e: any) => {
-    const scrollViewNode = findDOMNode(this.scrollView);
-    this.initialScrollX = e.nativeEvent.pageX;
+  handleMouseStart = (e: MouseEvent) => {
+    this.handleStart(e.pageX);
+  }
+
+  handleTouchStart = (e: TouchEvent) => {
+    if (e.touches.length) {
+      this.handleStart(e.touches[0].pageX);
+    }
+  }
+
+  handleStart = (pageX: number) => {
+    const scrollViewNode = findDOMNode(this.scrollView?.current);
+    this.initialScrollX = pageX;
     if (scrollViewNode instanceof Element) {
       this.currentScrollX = scrollViewNode.scrollLeft;
     }
@@ -222,9 +231,23 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
     this.mouseDown = true;
   }
 
-  handleTouchEnd = (e: any) => {
+  handleMouseEnd = (e: MouseEvent) => {
+    this.handleEnd(e.pageX);
+  }
+
+  handleTouchEnd = (e: TouchEvent) => {
+    if (e.touches.length) {
+      this.handleEnd(e.touches[0].pageX);
+    } else {
+      const pageX = this.initialScrollX + this.currentScrollX -
+        (this.scrollView?.current?.scrollLeft || 0);
+      this.handleEnd(pageX);
+    }
+  }
+
+  handleEnd = (pageX: number) => {
     this.mouseDown = false;
-    const dx = this.initialScrollX - e.nativeEvent.pageX;
+    const dx = this.initialScrollX - pageX;
     const vx = dx / (this.initialScrollXTime - Date.now());
 
     if (dx > 80 || vx < -0.3) {
@@ -236,13 +259,23 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
     }
   }
 
-  handleTouchMove = (e: any) => {
+  handleMouseMove = (e: MouseEvent) => {
+    this.handleMove(e.pageX);
+  }
+
+  handleTouchMove = (e: TouchEvent) => {
+    if (e.touches.length) {
+      this.handleMove(e.touches[0].pageX);
+    }
+  }
+
+  handleMove = (pageX: number) => {
     if (this.mouseDown) {
-      const dx = this.initialScrollX - e.nativeEvent.pageX;
+      const dx = this.initialScrollX - pageX;
       const scrollX = this.currentScrollX + dx;
-      this.scrollView.scrollTo({
-        x: scrollX,
-        y: 0
+      this.scrollView?.current?.scrollTo({
+        left: scrollX,
+        top: 0
       });
     }
   }
@@ -264,14 +297,8 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
     );
   }
 
-  _saveScrollViewRef = (ref: any) => this.scrollView = ref;
-
   // tslint:disable-next-line:cyclomatic-complexity
   render(): React.ReactNode {
-    const snapToInterval =
-      this.state.itemWidth *
-      Math.floor(this.props.itemsPerPage || this.defaultItemsPerPage);
-
     const pageNum = this.getPageNum();
 
     if (this.props.items.length <= 1) {
@@ -284,23 +311,23 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
           this.props.style,
           { opacity: this.state.opacity, overflow: 'hidden' }
         ]}
+        onLayout={this.handleContainerSizeChange}
       >
-        <ScrollViewCopy
-          className='carousel-scroll-view'
-          onLayout={this.handleContainerSizeChange}
-          horizontal={true}
-          ref={this._saveScrollViewRef}
-          decelerationRate={0}
-          snapToAlignment={'start'}
-          snapToInterval={snapToInterval}
-          showsHorizontalScrollIndicator={false}
+        <div
+          ref={this.scrollView}
           onTouchStart={this.handleTouchStart}
           onTouchEnd={this.handleTouchEnd}
           onTouchMove={this.handleTouchMove}
-          style={{ flexBasis: 'auto' }}
-          onMouseDown={this.handleTouchStart}
-          onMouseUp={this.handleTouchEnd}
-          onMouseMove={this.handleTouchMove}
+          style={{
+            display: 'flex',
+            flexBasis: 'auto',
+            flexDirection: 'row',
+            overflowY: 'hidden',
+            overflowX: 'scroll'
+          }}
+          onMouseDown={this.handleMouseStart}
+          onMouseUp={this.handleMouseEnd}
+          onMouseMove={this.handleMouseMove}
         >
           <View
             style={{ width: this.props.centerMode ? this.props.peekSize : 0 }}
@@ -322,7 +349,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
               );
             })
           }
-        </ScrollViewCopy>
+        </div>
 
         {this.props.renderPageIndicator ? (
           this.props.renderPageIndicator(
@@ -366,13 +393,6 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
               </TouchableOpacity>
             </div>
           )}
-
-        <style>
-          {/* tslint:disable:jsx-use-translation-function */}
-          {`.carousel-scroll-view {
-          overflow: hidden
-        }`}
-        </style>
       </Animated.View>
     );
   }


### PR DESCRIPTION
The onTouch and onMouse events, as well as className, are no longer supported by react-native-web. This changes that element to be a React div, which will support them.