### PR TITLE
feat: add ExtractPropertyNames type

### DIFF
--- a/packages/fsfoundation/src/ExtractPropertyNames.ts
+++ b/packages/fsfoundation/src/ExtractPropertyNames.ts
@@ -1,0 +1,20 @@
+/**
+ * Extracts the property names from a given object whose values are assignable to a given type
+ *
+ * Example:
+ * interface MyObject {
+ *  a: string;
+ *  b: string;
+ *  c: () => void;
+ *  d: number;
+ * }
+ * type StringProperties = ExtractPropertyNames<MyObject, string>;
+ *                     ^ = type StringProperties = 'a' | 'b'
+ *
+ * type NumberProperties = ExtractPropertyNames<MyObject, number>;
+ *                     ^ = type NumberProperties = 'd'
+ *
+ */
+export type ExtractPropertyNames<T, S> = {
+  [K in keyof T]: T[K] extends S ? K : never;
+}[keyof T];

--- a/packages/fsfoundation/src/index.ts
+++ b/packages/fsfoundation/src/index.ts
@@ -2,5 +2,6 @@ export * from './Arguments';
 export * from './DeepPartial';
 export * from './Dictionary';
 export * from './Distance';
+export * from './ExtractPropertyNames';
 export * from './GeoLocation';
 export * from './Omit';


### PR DESCRIPTION
Extracts the property names from a given object whose values are assignable to a given type

Example:

```
interface MyObject {
  a: string;
  b: string;
  c: () => void;
  d: number;
}

type StringProperties = ExtractPropertyNames<MyObject, string>;
//                  ^ = type StringProperties = 'a' | 'b'

type NumberProperties = ExtractPropertyNames<MyObject, number>;
//                  ^ = type NumberProperties = 'd'
```