### PR TITLE
feat(fsapp): notFoundRedirect

### DIFF
--- a/packages/fsapp/src/components/DrawerRouter.web.tsx
+++ b/packages/fsapp/src/components/DrawerRouter.web.tsx
@@ -14,6 +14,7 @@ import { AppConfigType, DrawerConfig } from '../types';
 import Drawer from '../components/Drawer.web';
 import FSNetwork from '@brandingbrand/fsnetwork';
 import { pathForScreen } from '../lib/helpers';
+import { NotFound } from './NotFound';
 
 // hack to avoid ts complaint about certain web-only properties not being valid
 const StyleSheetCreate: ((obj: any) => StyleSheet.NamedStyles<any>) = StyleSheet.create;
@@ -145,6 +146,18 @@ export default class DrawerRouter extends Component<PropType, AppStateTypes> {
         />
       );
     });
+
+    if (appConfig.notFoundRedirect) {
+      screensRoutes.push((
+        <Route
+          key={'not-found'}
+          path={'*'}
+          render={this._renderDrawerWrapper(
+            screenWrapper(NotFound(appConfig.notFoundRedirect), appConfig, api, this.toggleDrawer)
+          )}
+        />
+      ));
+    }
 
     return [rootComponent, ...screensRoutes];
   }

--- a/packages/fsapp/src/components/NotFound.tsx
+++ b/packages/fsapp/src/components/NotFound.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View } from 'react-native';
+import NavWrapper from '../lib/nav-wrapper';
+import { NavLayout } from '../types';
+
+export interface NotFoundProps {
+  navigator: NavWrapper;
+}
+
+export const NotFound = (redirect: NavLayout | true) => {
+  return React.memo((props: NotFoundProps) => {
+    React.useEffect(() => {
+      if (redirect === true) {
+        props.navigator.popToRoot().catch(e => console.error(e));
+      } else {
+        props.navigator.setStackRoot(redirect).catch(e => console.error(e));
+      }
+    }, []);
+    return <View />;
+  });
+};

--- a/packages/fsapp/src/fsapp/FSApp.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.tsx
@@ -18,6 +18,7 @@ import NativeConstants from '../lib/native-constants';
 import { FSAppBase, WebApplication } from './FSAppBase';
 import DevMenu from '../components/DevMenu';
 import { Store } from 'redux';
+import { NotFound } from '../components/NotFound';
 
 const LAST_SCREEN_KEY = 'lastScreen';
 const DEV_KEEP_SCREEN = 'devKeepPage';
@@ -58,6 +59,13 @@ export class FSApp extends FSAppBase {
       enhancedScreens.unshift({
         key: 'devMenu',
         Screen: screenWrapper(DevMenu, this.appConfig, this.api)
+      });
+    }
+
+    if (this.appConfig.notFoundRedirect) {
+      enhancedScreens.unshift({
+        key: '*',
+        Screen: screenWrapper(NotFound(this.appConfig.notFoundRedirect), this.appConfig, this.api)
       });
     }
 

--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -108,6 +108,7 @@ export interface AppConfigType {
   defaultOptions?: Options;
   bottomTabsId?: string;
   bottomTabsOptions?: Options;
+  notFoundRedirect?: NavLayout | true;
   uncachedData?: (initialState: any, req?: Request) => Promise<SSRData>;
   cachedData?: (initialState: any, req?: Request) => Promise<SSRData>;
 }

--- a/packages/pirateship/src/appConfig.ts
+++ b/packages/pirateship/src/appConfig.ts
@@ -97,6 +97,7 @@ export const appConfig: FSAppTypes.AppConfigType = {
   bottomTabsId: 'bottomTabs',
   variables: {},
   webRouterType: 'browser',
+  notFoundRedirect: true,
   cachedData: async (
     initialData: FSAppTypes.SSRData, req: any
   ): Promise<FSAppTypes.SSRData> => {


### PR DESCRIPTION
When failing to find a matching path, this adds a fallback catchall route that will either redirect to a given screen with setStackRoot or call popToRoot. Generally you will only use setStackRoot with single screen apps, because it will make any tabs redirect to that same screen, while popToRoot will go to the initial screen for a given tab.