### PR TITLE
feat(fsapp): Screen option for notFoundRedirect

### DIFF
--- a/packages/fsapp/src/components/DrawerRouter.web.tsx
+++ b/packages/fsapp/src/components/DrawerRouter.web.tsx
@@ -148,15 +148,27 @@ export default class DrawerRouter extends Component<PropType, AppStateTypes> {
     });
 
     if (appConfig.notFoundRedirect) {
-      screensRoutes.push((
-        <Route
-          key={'not-found'}
-          path={'*'}
-          render={this._renderDrawerWrapper(
-            screenWrapper(NotFound(appConfig.notFoundRedirect), appConfig, api, this.toggleDrawer)
-          )}
-        />
-      ));
+      if (typeof appConfig.notFoundRedirect === 'function') {
+        screensRoutes.push((
+          <Route
+            key={'not-found'}
+            path={'*'}
+            render={this._renderDrawerWrapper(
+              screenWrapper(appConfig.notFoundRedirect, appConfig, api, this.toggleDrawer)
+            )}
+          />
+        ));
+      } else {
+        screensRoutes.push((
+          <Route
+            key={'not-found'}
+            path={'*'}
+            render={this._renderDrawerWrapper(
+              screenWrapper(NotFound(appConfig.notFoundRedirect), appConfig, api, this.toggleDrawer)
+            )}
+          />
+        ));
+      }
     }
 
     return [rootComponent, ...screensRoutes];

--- a/packages/fsapp/src/fsapp/FSApp.tsx
+++ b/packages/fsapp/src/fsapp/FSApp.tsx
@@ -63,10 +63,17 @@ export class FSApp extends FSAppBase {
     }
 
     if (this.appConfig.notFoundRedirect) {
-      enhancedScreens.unshift({
-        key: '*',
-        Screen: screenWrapper(NotFound(this.appConfig.notFoundRedirect), this.appConfig, this.api)
-      });
+      if (typeof this.appConfig.notFoundRedirect === 'function') {
+        enhancedScreens.unshift({
+          key: '*',
+          Screen: screenWrapper(this.appConfig.notFoundRedirect, this.appConfig, this.api)
+        });
+      } else {
+        enhancedScreens.unshift({
+          key: '*',
+          Screen: screenWrapper(NotFound(this.appConfig.notFoundRedirect), this.appConfig, this.api)
+        });
+      }
     }
 
     enhancedScreens.forEach(({ key, Screen }) => {

--- a/packages/fsapp/src/types/index.ts
+++ b/packages/fsapp/src/types/index.ts
@@ -108,7 +108,7 @@ export interface AppConfigType {
   defaultOptions?: Options;
   bottomTabsId?: string;
   bottomTabsOptions?: Options;
-  notFoundRedirect?: NavLayout | true;
+  notFoundRedirect?: RoutableComponentClass | NavLayout | true;
   uncachedData?: (initialState: any, req?: Request) => Promise<SSRData>;
   cachedData?: (initialState: any, req?: Request) => Promise<SSRData>;
 }


### PR DESCRIPTION
Allows passing a screen to notFoundRedirect config. Effectively works as a 404 page.