### PR TITLE
fix(fscomponents): fix web carousel only showing one image

### DIFF
--- a/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
+++ b/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
@@ -47,9 +47,9 @@ export class Carousel extends Component<CarouselProps> {
           >
             {React.Children.map(_children, (child, i) => {
               return (
-                <View key={i} style={{ height }}>
+                <div key={i} style={{ height }}>
                   {child}
-                </View>
+                </div>
               );
             })}
           </Swiper>


### PR DESCRIPTION
This fixes an odd regression in which the Carousel component for web is only displaying one image. The cause seems to be that using <View> causes react-native-web to create a <div> with a class attached; this class seems to prevent the react-id-swiper library from binding to the slide. This replaces the <View> with <div> which seems to resolve the problem.

Test:
1. Run `yarn dev:storybook`
2. Navigate to the Carousel story
3. Verify that the Carousel story displays multiple slides