### PR TITLE
fix(ssr): fix server side rendering of the $1 instances

### DIFF
--- a/packages/fsapp/src/lib/ssr.ts
+++ b/packages/fsapp/src/lib/ssr.ts
@@ -128,7 +128,7 @@ async function renderApp(
 
       const variables = JSON.stringify(updatedConfig.variables || {});
 
-      const document = baseHTML.replace(/(<head>)/, `$1
+      const document = baseHTML.replace(/<head>/, `<head>
         ${helmet.title.toString()}
         ${helmet.meta.toString()}
         ${helmet.link.toString()}
@@ -137,7 +137,7 @@ async function renderApp(
           var initialState = ${state};
           var variables = ${variables};
         </script>
-      `).replace(/(\<div id="root"\>)/, `$1
+      `).replace(/\<div id="root"\>/, `<div id="root">
         ${html}
       `);
 


### PR DESCRIPTION
## Description

BREAKING CHANGE:
Fix the rendering on the server side when the body or variables contain $1 instances.

## Test

- set any variable in the initial data function that contain a string with `$1`, e.g. `test = 'the price is $100 - $125'`
- render some text element that contain a string `$1`, e.g. `<Text>the price is $100 - $125</Text>
- load the page and view source.

ER: the variables are rendered as JSON correctly, the page body is rendered correctly.

