### PR TITLE
feat(category): allow fetchCategory query to have levels parameter

### DIFF
--- a/packages/fscommerce/src/Commerce/types/CategoryQuery.ts
+++ b/packages/fscommerce/src/Commerce/types/CategoryQuery.ts
@@ -22,4 +22,12 @@ export interface CategoryQuery {
    * @example 2
    */
   page?: number;
+
+  /**
+   * Specifies how many levels of nested subcategories you want the server to return.
+   * The default value is 2.
+   *
+   * @example 3
+   */
+  levels?: number;
 }


### PR DESCRIPTION
## Description

RELATED PR:
https://github.com/brandingbrand/submarine/pull/257

The query for fetchCategory function can specify 'levels' parameter to get more levels of categories.
This allows to avoid additional requests in some cases when we need to get more than 2 levels of categories,
that are provided by default.
