### PR TITLE
fix(fsproductindex): Fix typing and add check

### DIFF
--- a/packages/fscommerce/src/Commerce/types/ProductQuery.ts
+++ b/packages/fscommerce/src/Commerce/types/ProductQuery.ts
@@ -56,6 +56,6 @@ export interface ProductQuery extends Partial<Pageable> {
    *  'cgid': ['womens']
    * }
    */
-  refinements?: any;
+  refinements?: Record<string, string[]>;
 
 }

--- a/packages/fscomponents/src/components/FilterList/FilterListDrilldown.tsx
+++ b/packages/fscomponents/src/components/FilterList/FilterListDrilldown.tsx
@@ -53,7 +53,10 @@ export interface FilterListDrilldownProps {
     i: number,
     selectedValues: string[],
     handlePress: () => void,
-    renderFilterItem: (info: ListRenderItemInfo<FilterItem>) => JSX.Element
+    renderFilterItem: (
+      info: Omit<ListRenderItemInfo<FilterItem>, 'separators'>,
+      skipCustomRender: boolean
+    ) => JSX.Element
   ) => JSX.Element;
   renderFilterItemValue?: (
     item: FilterItem,
@@ -64,7 +67,7 @@ export interface FilterListDrilldownProps {
     renderFilterItemValue: (
       item: FilterItem,
       skipCustomRender?: boolean
-    ) => (info: ListRenderItemInfo<FilterItemValue>) => JSX.Element
+    ) => (info: Omit<ListRenderItemInfo<FilterItemValue>, 'separators'>) => JSX.Element
   ) => JSX.Element;
   renderSecondLevel?: (
     item: FilterItem,
@@ -285,7 +288,7 @@ export class FilterListDrilldown extends PureComponent<
   renderFilterItemValue = (filterItem: FilterItem, skipCustomRender?: boolean) => ({
     item,
     index
-  }: ListRenderItemInfo<FilterItemValue>): JSX.Element => {
+  }: Omit<ListRenderItemInfo<FilterItemValue>, 'separators'>): JSX.Element => {
     const selected =
       this.state.selectedItems[filterItem.id] &&
       this.state.selectedItems[filterItem.id].indexOf(item.value) > -1;
@@ -314,7 +317,7 @@ export class FilterListDrilldown extends PureComponent<
 
   // tslint:disable cyclomatic-complexity
   renderFilterItem = (
-    { item, index }: ListRenderItemInfo<FilterItem>,
+    { item, index }: Omit<ListRenderItemInfo<FilterItem>, 'separators'>,
     skipCustomRender: boolean = false
   ): JSX.Element => {
     const selectedValues = this.state.selectedItems[item.id] || [];

--- a/packages/fsmockdatasources/src/commerce/mixins/ProductCatalog.ts
+++ b/packages/fsmockdatasources/src/commerce/mixins/ProductCatalog.ts
@@ -186,7 +186,7 @@ export const ProductCatalogMixin = <T extends Constructor>(superclass: T) => {
 
     public applyRefinementFilters(
       products: CommerceTypes.Product[],
-      refinements?: import ('@brandingbrand/fsfoundation').Dictionary<string>
+      refinements?: import ('@brandingbrand/fsfoundation').Dictionary<string[]>
     ): CommerceTypes.Product[] {
       if (refinements) {
         products = Object.keys(refinements).reduce((filteredProducts, key) => {

--- a/packages/fsproductindex/src/components/ProductIndexGrid.tsx
+++ b/packages/fsproductindex/src/components/ProductIndexGrid.tsx
@@ -8,6 +8,8 @@ import { WithProductIndexProps } from './ProductIndexProvider';
 import ProductList from './ProductList';
 
 import {
+  FilterItem,
+  FilterItemValue,
   FilterList,
   FilterListDrilldown,
   Loading,
@@ -274,10 +276,12 @@ export default class ProductIndexGrid extends Component<
     }
   }
 
-  handleSortChange = (selectedItems: any) => (sortItem: CommerceTypes.SortingOption) => {
-    let refinementsQuery = {};
+  handleSortChange = (selectedItems?: Record<string, string[]>) => (
+    sortItem: CommerceTypes.SortingOption
+  ) => {
+    let refinementsQuery: CommerceTypes.ProductQuery = {};
 
-    if (Object.keys(selectedItems).length > 0) {
+    if (selectedItems && Object.keys(selectedItems).length > 0) {
       refinementsQuery = {refinements: selectedItems};
     }
 
@@ -485,7 +489,8 @@ export default class ProductIndexGrid extends Component<
     const selectedOption = commerceData?.selectedSortingOption ?
       commerceData?.selectedSortingOption : 'default';
 
-    const selectedItems = this.props.mergeSortToFilter && commerceData?.selectedSortingOption
+    const selectedItems: Record<string, string[]> | undefined = this.props.mergeSortToFilter &&
+      commerceData?.selectedSortingOption
       ? this.mergeSelectedRefinementsAndSort(
         commerceData.selectedRefinements,
         commerceData.selectedSortingOption
@@ -543,25 +548,28 @@ export default class ProductIndexGrid extends Component<
     );
   }
 
-  mergeRefinementsAndSort = (refinementsData: any, sortingData: any) => {
-    const refinements = [...refinementsData];
+  mergeRefinementsAndSort = (
+    refinementsData?: CommerceTypes.Refinement[],
+    sortingData?: CommerceTypes.SortingOption[]
+  ) => {
+    const refinements = refinementsData ? [...refinementsData] : [];
     refinements.unshift({
       id: SORT_ITEM_KEY,
       title: 'Sort By',
-      values: sortingData.map((item: any) => ({
+      values: sortingData ? sortingData.map((item: CommerceTypes.SortingOption) => ({
         id: item.id,
         value: item.id,
         title: item.title
-      }))
+      })) : []
     });
 
     return refinements;
   }
 
   mergeSelectedRefinementsAndSort = (
-    selectedRefinements: any,
+    selectedRefinements: Record<string, string[]> | undefined,
     selectedSortId: string
-  ) => {
+  ): Record<string, string[]> => {
     return {
       ...selectedRefinements,
       [SORT_ITEM_KEY]: [selectedSortId]
@@ -648,11 +656,14 @@ export default class ProductIndexGrid extends Component<
   }
 
   renderItemForCombinedFilterAndSort = (
-    item: any,
-    index: any,
-    selectedValues: any,
-    handlePress: any,
-    renderFilterItem: any
+    item: FilterItem,
+    index: number,
+    selectedValues: string[],
+    handlePress: () => void,
+    renderFilterItem: (
+      info: Omit<ListRenderItemInfo<FilterItem>, 'separators'>,
+      skipCustomRender: boolean
+    ) => JSX.Element
   ) => {
     if (item.id === SORT_ITEM_KEY) {
       return (
@@ -671,12 +682,15 @@ export default class ProductIndexGrid extends Component<
   }
 
   renderItemValueForCombinedFilterAndSort = (
-    item: any,
-    index: any,
-    value: any,
-    handleSelect: any,
-    selected: any,
-    renderFilterItemValue: any
+    item: FilterItem,
+    index: number,
+    value: FilterItemValue,
+    handleSelect: () => void,
+    selected: boolean,
+    renderFilterItemValue: (
+      item: FilterItem,
+      skipCustomRender?: boolean
+    ) => (info: Omit<ListRenderItemInfo<FilterItemValue>, 'separators'>) => JSX.Element
   ) => {
     if (item.id === SORT_ITEM_KEY) {
       const selectableRowProps =

--- a/packages/fstestproject/src/screens/fscommerce/MockCommerceDataSource.tsx
+++ b/packages/fstestproject/src/screens/fscommerce/MockCommerceDataSource.tsx
@@ -12,7 +12,7 @@ const exampleCategoryId = 'electronics-digital-cameras';
 const exampleProductId1 = 'sony-alpha350-wlen';
 const exampleProductId2 = 'canon-powershot-g10';
 const exampleSearchTerm = 'Sony';
-const examplePipRefinement = { brand: 'Sony' };
+const examplePipRefinement = { brand: ['Sony'] };
 const validPromoCode = 'VALID';
 const invalidPromoCode = 'INVALID';
 


### PR DESCRIPTION
When sorting, if no refinements were applied, it would check the keys of the undefined refinements and crash. This adds proper typing to the sort handling and the appropriate check.