### PR TITLE
[FS-1893] Update Targeted Devices Wrong Regex

### DIFF
--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -68,13 +68,12 @@ export function targetedDevice(configuration: Config): void {
       Universal: `"1,2"`
     };
 
-    const productNameRx = new RegExp(`PRODUCT_NAME\\s*=\\s*${configuration.name}`, 'g');
+    const targetedDeviceRegex = new RegExp(`TARGETED_DEVICE_FAMILY = "1"`, 'g');
 
     fs.update(
       path.ios.pbxprojFilePath(configuration),
-      productNameRx,
-      `PRODUCT_NAME = ${configuration.name};
-        TARGETED_DEVICE_FAMILY = ${devices[configuration.targetedDevices]}`
+      targetedDeviceRegex,
+      `TARGETED_DEVICE_FAMILY = ${devices[configuration.targetedDevices]}`
     );
   }
 }


### PR DESCRIPTION
Ticket: https://brandingbrand.atlassian.net/browse/FS-1893

# Description
1. Update global regex to look for `TARGETED_DEVICE_FAMILY = "1,2"`