### PR TITLE
fix(flagship): set proper device targets in ios template

### DIFF
--- a/packages/flagship/ios/FLAGSHIP.xcodeproj/project.pbxproj
+++ b/packages/flagship/ios/FLAGSHIP.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = FLAGSHIP;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -409,7 +409,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = FLAGSHIP;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/packages/flagship/src/lib/__tests__/ios.test.ts
+++ b/packages/flagship/src/lib/__tests__/ios.test.ts
@@ -305,7 +305,6 @@ test(`set env switcher initial env`, () => {
   );
 });
 
-
 test(`copy sentry properties`, () => {
   ios.sentryProperties({
     name: appName,
@@ -322,6 +321,22 @@ test(`copy sentry properties`, () => {
     .toString();
 
   expect(sentryPropertiesPathSource).toEqual(sentryPropertiesPath);
+});
+
+test('targeted device should default to ios only', () => {
+  const realPbxprojFile: string = fs
+    .readFileSync(nodePath.join(
+      __dirname, '..', '..', '..', 'ios', 'FLAGSHIP.xcodeproj', 'project.pbxproj'
+    ))
+    .toString();
+
+  const targetMatches = realPbxprojFile.match(/TARGETED_DEVICE_FAMILY = "[1-9\,]+"/g);
+
+  expect((targetMatches || []).length).toEqual(2);
+
+  (targetMatches || []).forEach(match => {
+    expect(match).toEqual('TARGETED_DEVICE_FAMILY = "1"');
+  });
 });
 
 // Force to be treated as a module


### PR DESCRIPTION
Flagship only supports iOS on the Apple side, so we should only be targeting TARGETED_DEVICE_FAMILY="1" in the pbxproj file. We were incorrectly targeting 1,2 which corresponds to a universal app.

I also added a unit test to try to avoid any regressions in the future.