### PR TITLE
fix(flagship): Remove animated image patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react": "^16.13.1",
     "react-art": "^16.4.0",
     "react-dom": "^16.9.0",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-navigation": "^6.0.0",
     "react-native-svg": "^10.0.0",
     "react-native-web": "^0.13.12",

--- a/packages/flagship/package.json
+++ b/packages/flagship/package.json
@@ -17,7 +17,7 @@
     "glob": "^7.1.2",
     "jsc-android": "241213.x.x",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "replace-in-file": "^5.0.2",
     "xcode": "^3.0.0",
     "yargs": "^15.0.1"

--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -217,7 +217,6 @@ function initIOS(
   ios.sentryProperties(configuration);
   ios.iosExtensions(configuration, version); // Add extension targets
   ios.setEnvSwitcherInitialEnv(configuration, environmentIdentifier);
-  ios.patchRCTUIImageViewAnimated();
 
   if (configuration.ios) {
     if (configuration.ios.pods) {

--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -492,31 +492,3 @@ export function setEnvSwitcherInitialEnv(configuration: Config, env: string): vo
     `@"${env}"; // [EnvSwitcher initialEnvName]`
   );
 }
-
-/**
- * Patches RCTUIImageViewAnimated.m to fix displayLayer() to support iOS 14.
- *
- * @see https://github.com/facebook/react-native/issues/29268
- */
-export function patchRCTUIImageViewAnimated(): void {
-  helpers.logInfo(`patching RCTUIImageViewAnimated.m to support iOS 14`);
-
-  const rnImagePath = path.project.resolve(
-    'node_modules', 'react-native', 'Libraries', 'Image', 'RCTUIImageViewAnimated.m'
-  );
-
-  fs.update(
-    rnImagePath,
-    /\(void\)displayLayer[\s\S]+?(?=#pragma)/g,
-    `(void)displayLayer:(CALayer *)layer
-{
-  if (_currentFrame) {
-    layer.contentsScale = self.animatedImageScale;
-    layer.contents = (__bridge id)_currentFrame.CGImage;
-  }
-  [super displayLayer:layer];
-}
-
-`
-  );
-}

--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -21,7 +21,7 @@
     "qs": "^6.7.0",
     "react": "^16.13.1",
     "react-dom": "^16.9.0",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^5.0.0",
     "react-native-navigation": "^6.0.0",

--- a/packages/fscart/package.json
+++ b/packages/fscart/package.json
@@ -15,7 +15,7 @@
     "@brandingbrand/fscomponents": "^10.7.0",
     "@brandingbrand/fsi18n": "^10.7.0",
     "react": "^16.13.1",
-    "react-native": "^0.63.2"
+    "react-native": "^0.63.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fscategory/package.json
+++ b/packages/fscategory/package.json
@@ -15,7 +15,7 @@
     "@brandingbrand/fscomponents": "^10.7.0",
     "react": "^16.13.1",
     "react-content-loader": "^5.1.2",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-svg": "^10.0.0"
   },
   "publishConfig": {

--- a/packages/fscheckout/package.json
+++ b/packages/fscheckout/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "^16.13.1",
-    "react-native": "^0.63.2"
+    "react-native": "^0.63.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/fscommerce/package.json
+++ b/packages/fscommerce/package.json
@@ -18,7 +18,7 @@
     "lodash-es": "^4.17.10",
     "qs": "^6.9.1",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-cookies": "^3.3.0",
     "react-native-sensitive-info": "^5.5.0"
   },

--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -30,7 +30,7 @@
     "react-content-loader": "^5.1.2",
     "react-dom": "^16.11.0",
     "react-id-swiper": "^2.0.0",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-masked-text": "^1.13.0",
     "react-native-picker-select": "^8.0.0",
     "react-native-svg": "^10.0.0",

--- a/packages/fsengage/package.json
+++ b/packages/fsengage/package.json
@@ -20,7 +20,7 @@
     "@brandingbrand/react-native-leanplum": "^5.0.0",
     "decimal.js": "^10.0.0",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/packages/fsengagement/package.json
+++ b/packages/fsengagement/package.json
@@ -17,7 +17,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.13.1",
     "react-content-loader": "^5.1.2",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-animatable": "^1.3.2",
     "react-native-device-info": "^5.0.0",
     "react-native-fcm": "^16.0.0",

--- a/packages/fslocator/package.json
+++ b/packages/fslocator/package.json
@@ -21,7 +21,7 @@
     "lodash-es": "^4.17.10",
     "prop-types": "^15.6.2",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-geocoder": "^0.5.0",
     "react-native-maps": "^0.26.0",
     "react-native-open-settings": "^1.0.1",

--- a/packages/fsproductdetail/package.json
+++ b/packages/fsproductdetail/package.json
@@ -17,7 +17,7 @@
     "lodash-es": "^4.17.10",
     "react": "^16.13.1",
     "react-content-loader": "^5.1.2",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-svg": "^10.0.0",
     "redux": "^4.0.0"
   },

--- a/packages/fsproductindex/package.json
+++ b/packages/fsproductindex/package.json
@@ -18,7 +18,7 @@
     "pluralize": "^8.0.0",
     "react": "^16.13.1",
     "react-content-loader": "^5.1.2",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-svg": "^10.0.0",
     "redux": "^4.0.0"
   },

--- a/packages/fstestproject/package.json
+++ b/packages/fstestproject/package.json
@@ -42,7 +42,7 @@
     "@react-native-community/push-notification-ios": "^1.0.0",
     "jsc-android": "241213.x.x",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^5.0.0",
     "react-native-navigation": "^6.0.0"

--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -53,7 +53,7 @@
     "jsc-android": "241213.x.x",
     "lodash-es": "^4.17.10",
     "react": "^16.13.1",
-    "react-native": "^0.63.2",
+    "react-native": "^0.63.3",
     "react-native-cookies": "^3.3.0",
     "react-native-device-info": "^5.0.0",
     "react-native-htmlview": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14377,10 +14377,10 @@ react-native-webview@^10.9.0:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
 
-react-native@^0.63.2:
-  version "0.63.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.63.3.tgz#4a7f6540e049ff41810887bbd1125abc4672f3bf"
-  integrity sha512-71wq13uNo5W8QVQnFlnzZ3AD+XgUBYGhpsxysQFW/hJ8GAt/J5o+Bvhy81FXichp6IBDJDh/JgfHH2gNji8dFA==
+react-native@^0.63.3:
+  version "0.63.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.63.4.tgz#2210fdd404c94a5fa6b423c6de86f8e48810ec36"
+  integrity sha512-I4kM8kYO2mWEYUFITMcpRulcy4/jd+j9T6PbIzR0FuMcz/xwd+JwHoLPa1HmCesvR1RDOw9o4D+OFLwuXXfmGw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^4.10.0"


### PR DESCRIPTION
React-native has been updated with its own fix for this issue, with a slight difference:
```
if (_currentFrame) {
    layer.contentsScale = self.animatedImageScale;
    layer.contents = (__bridge id)_currentFrame.CGImage;
  } else {
    [super displayLayer:layer];
  }
```
vs
```
  if (_currentFrame) {
    layer.contentsScale = self.animatedImageScale;
    layer.contents = (__bridge id)_currentFrame.CGImage;
  }
  [super displayLayer:layer];
```

The version without the else was breaking gifs on iOS 12, so this removes the patch.