### PR TITLE
fix(flagship): Remove animated image patch

### DIFF
--- a/packages/flagship/src/commands/init.ts
+++ b/packages/flagship/src/commands/init.ts
@@ -217,7 +217,6 @@ function initIOS(
   ios.sentryProperties(configuration);
   ios.iosExtensions(configuration, version); // Add extension targets
   ios.setEnvSwitcherInitialEnv(configuration, environmentIdentifier);
-  ios.patchRCTUIImageViewAnimated();
 
   if (configuration.ios) {
     if (configuration.ios.pods) {

--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -492,31 +492,3 @@ export function setEnvSwitcherInitialEnv(configuration: Config, env: string): vo
     `@"${env}"; // [EnvSwitcher initialEnvName]`
   );
 }
-
-/**
- * Patches RCTUIImageViewAnimated.m to fix displayLayer() to support iOS 14.
- *
- * @see https://github.com/facebook/react-native/issues/29268
- */
-export function patchRCTUIImageViewAnimated(): void {
-  helpers.logInfo(`patching RCTUIImageViewAnimated.m to support iOS 14`);
-
-  const rnImagePath = path.project.resolve(
-    'node_modules', 'react-native', 'Libraries', 'Image', 'RCTUIImageViewAnimated.m'
-  );
-
-  fs.update(
-    rnImagePath,
-    /\(void\)displayLayer[\s\S]+?(?=#pragma)/g,
-    `(void)displayLayer:(CALayer *)layer
-{
-  if (_currentFrame) {
-    layer.contentsScale = self.animatedImageScale;
-    layer.contents = (__bridge id)_currentFrame.CGImage;
-  }
-  [super displayLayer:layer];
-}
-
-`
-  );
-}


### PR DESCRIPTION
cherry-pick first commit from this PR: https://github.com/brandingbrand/flagship/pull/1865

React-native has been updated with its own fix for this issue, with a slight difference:
```
if (_currentFrame) {
    layer.contentsScale = self.animatedImageScale;
    layer.contents = (__bridge id)_currentFrame.CGImage;
  } else {
    [super displayLayer:layer];
  }
```
vs
```
  if (_currentFrame) {
    layer.contentsScale = self.animatedImageScale;
    layer.contents = (__bridge id)_currentFrame.CGImage;
  }
  [super displayLayer:layer];
```

The version without the else was breaking gifs on iOS 12, so this removes the patch.