### PR TITLE
feat(fsweb): Add support for an array of endpoints

### DIFF
--- a/packages/fsweb/src/lib/proxy.ts
+++ b/packages/fsweb/src/lib/proxy.ts
@@ -17,6 +17,41 @@ const proxyBaseConfig: Partial<proxy.Options> = {
   logLevel: 'silent'
 };
 
+const proxyEndpoint = (
+  endpoint: string,
+  app: express.Express,
+  proxyConfig: Partial<proxy.Options>,
+  preProxy?: () => void
+) => {
+  const upstream = url.parse(endpoint);
+  const upstreamTarget = url.format({
+    protocol: upstream.protocol,
+    host: upstream.host
+  });
+
+  if (upstream.path) {
+    const upstreamPath = upstream.path;
+    // If there's anything that needs to be done before attaching the proxy,
+    // like adding middleware that only should be attached if there is a proxy running,
+    // it should happen in this function
+    if (preProxy) {
+      preProxy();
+    }
+    app.use(
+      upstreamPath,
+      proxy.createProxyMiddleware({
+        target: upstreamTarget,
+        pathRewrite: (path, _req) => {
+          return path.replace(endpoint, upstreamPath);
+        },
+        ...proxyConfig
+      })
+    );
+    return true;
+  }
+  return false;
+};
+
 // Returns true if a proxy was set up
 export const addProxy = (app: express.Express, env: any, preProxy?: () => void): boolean => {
   if (env.dataSource && env.dataSource.enableProxy) {
@@ -41,31 +76,24 @@ export const addProxy = (app: express.Express, env: any, preProxy?: () => void):
       const endpoint = apiConfig.endpoint;
 
       if (endpoint) {
-        const upstream = url.parse(endpoint);
-        const upstreamTarget = url.format({
-          protocol: upstream.protocol,
-          host: upstream.host
-        });
-
-        if (upstream.path) {
-          const upstreamPath = upstream.path;
-          // If there's anything that needs to be done before attaching the proxy,
-          // like adding middleware that only should be attached if there is a proxy running,
-          // it should happen in this function
-          if (preProxy) {
-            preProxy();
-          }
-          app.use(
-            upstreamPath,
-            proxy.createProxyMiddleware({
-              target: upstreamTarget,
-              pathRewrite: (path, _req) => {
-                return path.replace(endpoint, upstreamPath);
-              },
-              ...proxyConfig
-            })
-          );
-          return true;
+        if (Array.isArray(endpoint)) {
+          let proxySuccess = true;
+          let hasPreProxied = false;
+          // Makes sure preProxy is only called once, regardless of the number of endpoints
+          const preProxyOnce = () => {
+            if (!hasPreProxied && preProxy) {
+              hasPreProxied = true;
+              preProxy();
+            }
+          };
+          endpoint.forEach(endpointEntry => {
+            if (!proxyEndpoint(endpointEntry, app, proxyConfig, preProxyOnce)) {
+              proxySuccess = false;
+            }
+          });
+          return proxySuccess;
+        } else {
+          return proxyEndpoint(endpoint, app, proxyConfig, preProxy);
         }
       } else {
         console.error('"endpoint" key is required for Proxy Configuration');


### PR DESCRIPTION
For cases where there are endpoints on multiple paths, this allows you to specify multiple ones. Complex paths aren't really supported because they need to fit both path-to-regexp and http-proxy's target, which uses the url module. This also allows you to specify endpoints on different domains, if they have different paths.