### PR TITLE
fix(fscomponents): serializable image styling

### DIFF
--- a/packages/fscomponents/src/components/serializable/SerializableImage.tsx
+++ b/packages/fscomponents/src/components/serializable/SerializableImage.tsx
@@ -29,7 +29,7 @@ export const FSSerializableImage = React.memo<SerializableImageProps>(
     const [host, self] = extractHostStyles(style);
 
     if (!onPress) {
-      return <Image {...props} style={[host, self]} />;
+      return <Image {...props} style={[self, host]} />;
     }
 
     return (


### PR DESCRIPTION
This fixes a bug with SerializableImage where when a given hight is specified it would ignore it unless `onPress` was also provided.