### PR TITLE
fix(fsengagement): fix twitching on carousels

### DIFF
--- a/packages/fsengagement/src/inboxblocks/CustomCarouselBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/CustomCarouselBlock.tsx
@@ -114,9 +114,6 @@ export default class CustomCarouselBlock
       ...restProps
     };
 
-    console.log('components',components)
-    console.log('item',item)
-    console.log('props',props)
     if (!components?.[private_type]) {
       return null;
     }
@@ -173,9 +170,11 @@ export default class CustomCarouselBlock
   }
   _onLayout = (event: LayoutChangeEvent) => {
     var { height } = event.nativeEvent.layout;
-    this.setState({
-      overallHeight: height
-    });
+    if (height - this.state.overallHeight >= 1) {
+      this.setState({
+        overallHeight: height
+      });
+    }
   }
 
   onSnapToItem = (index: number): void => {

--- a/packages/fsengagement/src/inboxblocks/ImageCarouselBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/ImageCarouselBlock.tsx
@@ -131,9 +131,11 @@ export default class ImageCarouselBlock
 
   _onLayout = (event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
-    this.setState({
-      overallHeight: height
-    });
+    if (height - this.state.overallHeight >= 1) {
+      this.setState({
+        overallHeight: height
+      });
+    }
   }
 
   onSnapToItem = (index: number): void => {


### PR DESCRIPTION
Found a bug where if there is an image of a certain height above a carousel it causes the carousel to try to continuously change its height by a tiny amount, causing it to become unusable.