### PR TITLE
fix(fscommerce): session manager

### DIFF
--- a/packages/fscommerce/src/Commerce/interfaces/CartDataSource.ts
+++ b/packages/fscommerce/src/Commerce/interfaces/CartDataSource.ts
@@ -181,4 +181,13 @@ export default interface CartDataSource {
    * @returns {Promise.<Cart>} A Promise representing metadata about the updated cart
    */
   removePromo(promoItemId: string): Promise<Cart>;
+
+  /**
+   * Requests missing detailed info for the products in the cart
+   *
+   * @param {T} cartData - raw cart data from the datasource, may contain previously requested
+   *   detailed info for the products in the cart
+   * @returns {Promise.<Array.<Product>>} A Promise representing products with detailed info
+   */
+  mutateCartDataWithProductDetail?<T>(cartData: T): Promise<Product[]>;
 }

--- a/packages/fscommerce/src/Commerce/sessions/CommerceCookieSessionManager.web.ts
+++ b/packages/fscommerce/src/Commerce/sessions/CommerceCookieSessionManager.web.ts
@@ -23,6 +23,15 @@ export default class CommerceCookieSessionManager extends CommerceSessionManager
   }
 
   /**
+   * Provides cookies to decide if the session can be converted to JWT
+   *
+   * @returns {Promise.<string | null>} A Promise representing cookies string
+   */
+  async getCookies(): Promise<string | null> {
+    return document.cookie;
+  }
+
+  /**
    * Returns current token for the session.
    *
    * Only one invocation at a time is allowed. If it's called again
@@ -32,9 +41,9 @@ export default class CommerceCookieSessionManager extends CommerceSessionManager
    *
    * The token is refreshed automatically upon expiration if `refreshToken` method was provided.
    *
-   * If no token exist it will attempt to convert current session into JWT,
-   * but only if the cookie `dwanonymous_*` is present.
-   * Otherwise, it will create new token for the guest user.
+   * If no token exist it will attempt to convert current session into JWT.
+   *
+   * If we could not convert current session, it will create new token for the guest user.
    *
    * @returns {Promise.<SessionToken | null>} A Promise representing token
    */
@@ -61,14 +70,10 @@ export default class CommerceCookieSessionManager extends CommerceSessionManager
       }
 
       // no token - get a token from the session
-      const sessionCookiesPresent = document.cookie?.includes('dwanonymous_');
-
-      if (sessionCookiesPresent) {
-        try {
-          token = await this.options.sessionCookiesToToken();
-        } catch (e) {
-          /* let it fail sliently */
-        }
+      try {
+        token = await this.options.sessionCookiesToToken();
+      } catch (e) {
+        /* let it fail sliently */
       }
 
       // got a token - store it
@@ -82,12 +87,7 @@ export default class CommerceCookieSessionManager extends CommerceSessionManager
       if (this.options.restoreCookies) {
         try {
           await this.options.restoreCookies();
-
-          const sessionCookiesPresent = document.cookie?.includes('dwanonymous_');
-
-          if (sessionCookiesPresent) {
-            token = await this.options.sessionCookiesToToken();
-          }
+          token = await this.options.sessionCookiesToToken();
         } catch (e) {
           /* let it fail sliently */
         }

--- a/packages/fscommerce/src/Commerce/sessions/CommerceCookieSessionManager.web.ts
+++ b/packages/fscommerce/src/Commerce/sessions/CommerceCookieSessionManager.web.ts
@@ -1,13 +1,19 @@
-import CommerceSessionManager from './CommerceSessionManager';
+import CommerceSessionManager, { CommerceSessionManagerOptions } from './CommerceSessionManager';
 import { SessionToken } from '../types/SessionToken';
+
+export interface CommerceCookieSessionManagerOptions extends CommerceSessionManagerOptions {
+  sessionCookiesToToken: () => Promise<SessionToken | null>;
+  restoreCookies?: () => Promise<void>;
+}
 
 /**
  * Implementation of CommerceSessionManager token based authentication(jwt, oauth, etc.)
  */
 export default class CommerceCookieSessionManager extends CommerceSessionManager {
-  options: any;
+  options: CommerceCookieSessionManagerOptions;
+  getPromise!: Promise<SessionToken | null>;
 
-  constructor(options: any) {
+  constructor(options: CommerceCookieSessionManagerOptions) {
     super(options);
     this.options = options;
   }
@@ -16,40 +22,108 @@ export default class CommerceCookieSessionManager extends CommerceSessionManager
     return true;
   }
 
-  async get(): Promise<SessionToken> {
-    let token: SessionToken | null = null;
+  /**
+   * Returns current token for the session.
+   *
+   * Only one invocation at a time is allowed. If it's called again
+   * it will have to wait until the previous invocation is complete.
+   *
+   * The token is cached locally and re-used until it expires.
+   *
+   * The token is refreshed automatically upon expiration if `refreshToken` method was provided.
+   *
+   * If no token exist it will attempt to convert current session into JWT,
+   * but only if the cookie `dwanonymous_*` is present.
+   * Otherwise, it will create new token for the guest user.
+   *
+   * @returns {Promise.<SessionToken | null>} A Promise representing token
+   */
+  // tslint:disable:cyclomatic-complexity
+  async get(): Promise<SessionToken | null> {
+    // allow no more than one invocation at a time
+    this.getPromise = (this.getPromise || Promise.resolve()).then(async () => {
+      let token: SessionToken | null | undefined = this.token;
 
-    try {
-      token = await this.options.sessionCookiesToToken();
-    } catch (e) {
-      /* let it fail sliently */
-    }
+      // we have expired token stored locally
+      if (token && this.isExpired(token)) {
+        // refresh it
+        token = await this.options.refreshToken(token);
 
-    if (token) {
-      return token;
-    }
-
-    if (this.options.restoreCookies) {
-      try {
-        await this.options.restoreCookies();
-        token = await this.options.sessionCookiesToToken();
-      } catch (e) {
-        /* let it fail sliently */
+        // got new token - store it
+        if (token) {
+          await this.set(token);
+        }
       }
 
+      // got old token
       if (token) {
         return token;
       }
-    }
 
-    return this.options.createGuestToken();
+      // no token - get a token from the session
+      const sessionCookiesPresent = document.cookie?.includes('dwanonymous_');
+
+      if (sessionCookiesPresent) {
+        try {
+          token = await this.options.sessionCookiesToToken();
+        } catch (e) {
+          /* let it fail sliently */
+        }
+      }
+
+      // got a token - store it
+      if (token) {
+        await this.set(token);
+
+        return token;
+      }
+
+      // no token - try to restore the cookie and the a token from the session
+      if (this.options.restoreCookies) {
+        try {
+          await this.options.restoreCookies();
+
+          const sessionCookiesPresent = document.cookie?.includes('dwanonymous_');
+
+          if (sessionCookiesPresent) {
+            token = await this.options.sessionCookiesToToken();
+          }
+        } catch (e) {
+          /* let it fail sliently */
+        }
+      }
+
+      // got a token - store it
+      if (token) {
+        await this.set(token);
+
+        return token;
+      }
+
+      // no token - try to create new guest token
+      token = await this.options.createGuestToken();
+
+      // got a token - store it
+      if (token) {
+        await this.set(token);
+
+        return token;
+      }
+
+      // no token
+      return null;
+    });
+
+    return this.getPromise;
   }
 
   async set(token: SessionToken): Promise<boolean> {
+    this.token = token;
+
     return true;
   }
 
-  async restore(): Promise<SessionToken> {
+  async restore(): Promise<SessionToken | null> {
     return this.get();
   }
 }

--- a/packages/fscommerce/src/Commerce/sessions/CommerceSessionManager.ts
+++ b/packages/fscommerce/src/Commerce/sessions/CommerceSessionManager.ts
@@ -76,4 +76,14 @@ export default abstract class CommerceSessionManager {
       }, refreshMilliseconds);
     }
   }
+
+  /**
+   * Provides cookies to decide if the session can be converted to JWT.
+   * Defaults to returning null. Platform specific implementation is optional.
+   *
+   * @returns {Promise.<string | null>} A Promise representing cookies string
+   */
+  async getCookies(): Promise<string | null> {
+    return null;
+  }
 }

--- a/packages/fscommerce/src/Commerce/types/Cart.ts
+++ b/packages/fscommerce/src/Commerce/types/Cart.ts
@@ -38,6 +38,12 @@ export interface Cart<T extends CartItem = CartItem> {
   items: T[];
 
   /**
+   * An array of products with detailed info for variants in the cart, their master
+   * products and bonus products in the cart.
+   */
+  product_details?: Product[];
+
+  /**
    * The total cost of the products in the cart before shipping feeds and taxes have
    * been added.
    *

--- a/packages/fscommerce/src/Commerce/types/Cart.ts
+++ b/packages/fscommerce/src/Commerce/types/Cart.ts
@@ -41,7 +41,7 @@ export interface Cart<T extends CartItem = CartItem> {
    * An array of products with detailed info for variants in the cart, their master
    * products and bonus products in the cart.
    */
-  product_details?: Product[];
+  productDetails?: Product[];
 
   /**
    * The total cost of the products in the cart before shipping feeds and taxes have

--- a/packages/fscommerce/src/Commerce/types/CartQuery.ts
+++ b/packages/fscommerce/src/Commerce/types/CartQuery.ts
@@ -1,3 +1,5 @@
+import { Cart } from './Cart';
+
 /**
  * An interface that prescribes the options that can be passed into a data source's fetchCart
  * method.
@@ -8,5 +10,16 @@ export interface CartQuery {
    * additional requests beyond retrieving the cart itself. If true, no additional data
    * will be retrieved.
    */
-  noExtraData: boolean;
+  noExtraData?: boolean;
+
+  /**
+   * Whether to make new request if old data is available. If true, and the cart's data is
+   * available, no additional requests will be made.
+   */
+  noNewRequest?: boolean;
+
+  /**
+   * The updated normalized cart to return in the `fetchCart` promise
+   */
+  updatedCart?: Cart;
 }

--- a/packages/fscommerce/src/Commerce/types/Product.ts
+++ b/packages/fscommerce/src/Commerce/types/Product.ts
@@ -189,4 +189,20 @@ export interface Product extends BaseProduct {
    * @example 'Buy one get one free!'
    */
   productPromotions?: ProductPromotion[];
+
+  /**
+   * An id of the primary category
+   *
+   * @example 'skincare'
+   */
+  primaryCategoryId?: string;
+
+  /**
+   * The master product information. Only for types master, variation group and variant.
+   */
+  master?: {
+    id?: string;
+    orderable?: boolean;
+    price?: CurrencyValue;
+  };
 }


### PR DESCRIPTION
## Description

BREAKING CHANGE:
- allow only one invocation of the session manager `get` method at a time.
- provide types for the `fetchCart` method to allow only one invocation of the method at a time.

## Test

Test together with the related PR.
https://github.com/brandingbrand/submarine/pull/365