### PR TITLE
fix: FS-2071 - remove padding from host style

### DIFF
--- a/packages/fscomponents/src/lib/style.ts
+++ b/packages/fscomponents/src/lib/style.ts
@@ -33,7 +33,6 @@ const HOST_STYLES = [
   /flexShrink/,
   /flexGrow/,
   /Self/,
-  /padding/,
   /margin/,
   /position/,
   /top/,


### PR DESCRIPTION
Ticket: https://brandingbrand.atlassian.net/browse/FS-2071

## Description

This fixes the padding behavior so that it is on the inside of the host.