### PR TITLE
fix: add stack id to enable tab switching on native

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/utils.native.tsx
+++ b/packages/fsapp/src/beta-app/router/history/utils.native.tsx
@@ -156,6 +156,7 @@ export const activateStacks = async (
       root: {
         ...root,
         bottomTabs: {
+          id: ROOT_STACK,
           children: await Promise.all(
             activated.map(([route, activated], i) => {
               const layout = root.bottomTabs?.children?.[i] as LayoutTabsChildren;

--- a/packages/fsapp/src/beta-app/router/router.tsx
+++ b/packages/fsapp/src/beta-app/router/router.tsx
@@ -63,12 +63,12 @@ export class FSRouter extends FSRouterBase {
       const { path, id } = buildPath(route, prefix);
       const LoadingPlaceholder = () => <>{this.options.loading}</>;
       if ('component' in route || 'loadComponent' in route) {
-        const LazyComponent = lazyComponent(
+        const LazyComponent = lazyComponent<{ componentId: string }>(
           async () => {
             const AwaitedComponent =
               'component' in route ? route.component : await route.loadComponent(routeDetails);
 
-            return () => {
+            return ({ componentId }) => {
               const [loading, setLoading] = useState(false);
               const activatedRoute = useMemo(() => routeDetails, []);
               useEffect(() => this.history.observeLoading(setLoading), []);
@@ -82,7 +82,7 @@ export class FSRouter extends FSRouterBase {
                   <ModalProvider>
                     <ButtonProvider>
                       <VersionOverlay>
-                        <AwaitedComponent />
+                        <AwaitedComponent componentId={componentId} />
                       </VersionOverlay>
                     </ButtonProvider>
                   </ModalProvider>
@@ -94,10 +94,10 @@ export class FSRouter extends FSRouterBase {
         );
 
         const Wrapper = this.options.screenWrap ?? Fragment;
-        const WrappedComponent: NavigationFunctionComponent = () => (
+        const WrappedComponent: NavigationFunctionComponent = ({ componentId }) => (
           <Wrapper>
             <NavigatorProvider value={this.history}>
-              <LazyComponent />
+              <LazyComponent componentId={componentId} />
             </NavigatorProvider>
           </Wrapper>
         );

--- a/packages/fsapp/src/beta-app/router/router.web.tsx
+++ b/packages/fsapp/src/beta-app/router/router.web.tsx
@@ -68,19 +68,19 @@ export class FSRouter extends FSRouterBase {
 
       const LazyComponent = useMemo(
         () =>
-          lazyComponent(
+          lazyComponent<{ componentId: string }>(
             async () => {
               const AwaitedComponent =
                 'loadComponent' in route
                   ? await route.loadComponent(routeDetails)
                   : route.component;
 
-              return React.memo(() => {
+              return React.memo(({ componentId }) => {
                 useEffect(() => {
                   trackView(this.options.analytics, route, filteredRoute, path);
                 }, [filteredRoute]);
 
-                return <AwaitedComponent />;
+                return <AwaitedComponent componentId={componentId} />;
               });
             },
             { fallback: this.options.loading }
@@ -92,7 +92,7 @@ export class FSRouter extends FSRouterBase {
         <Screen key={id} path={path} exact={route.exact}>
           <ActivatedRouteProvider {...filteredRoute} loading={loading}>
             <ModalProvider>
-              <LazyComponent />
+              <LazyComponent componentId={id} />
             </ModalProvider>
           </ActivatedRouteProvider>
         </Screen>

--- a/packages/fsapp/src/beta-app/router/types.ts
+++ b/packages/fsapp/src/beta-app/router/types.ts
@@ -35,8 +35,9 @@ export interface ScreenOptions {
  * @see useRouteQuery - hook into the query context
  * @see useRouteData - hook into the the data context
  */
-export type ScreenFC = FC & ScreenOptions;
-export abstract class ScreenComponent<State = {}> extends Component<{}, State> {
+export type ScreenFC = FC<{ componentId: string }> & ScreenOptions;
+export abstract class ScreenComponent<State = {}> extends
+Component<{ componentId: string }, State> {
   static buttons?: ScreenOptions['buttons'];
 }
 export type ScreenComponentType = ScreenFC | typeof ScreenComponent;


### PR DESCRIPTION
@bweissbart debugging session with @wSedlacek led to the need to include the root stack id to enable switching tabs via `navigator.open` on native