### PR TITLE
fix: host border props

### DIFF
--- a/packages/fscomponents/src/lib/style.ts
+++ b/packages/fscomponents/src/lib/style.ts
@@ -40,8 +40,10 @@ const HOST_STYLES = [
   /left/,
   /right/,
   /bottom/,
-  /height/i,
-  /width/i
+  /height/,
+  /maxHeight/,
+  /width/,
+  /maxWidth/
 ];
 
 /**


### PR DESCRIPTION
## Description

This fixes the false positives that `borderWidth` was getting via `/width/i` which was separating it form the `borderColor` and other border props.