### PR TITLE
fix(fscomponents): button linking

### DIFF
--- a/packages/fscomponents/src/components/serializable/SerializableButton.tsx
+++ b/packages/fscomponents/src/components/serializable/SerializableButton.tsx
@@ -61,9 +61,7 @@ export const FSSerializableButton = React.memo<
     noPadding,
     palette,
     href,
-    onPress = (href: string) => {
-      // default
-    },
+    onPress,
     ...props
   }) => {
     const [host, self] = extractHostStyles(style);


### PR DESCRIPTION
## Description

This fixes button linking not triggering due to `onPress` always being defined.