### PR TITLE
[FS-2158] Incorrect usageDescriptionKey for App Tracking Transparency Permission

### DIFF
--- a/packages/flagship/src/lib/modules/ios/react-native-permissions.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-permissions.ts
@@ -15,7 +15,7 @@ interface IOSPermissionMeta {
 const permissionPods: {[k in IOSPermissionKeys]: IOSPermissionMeta} = {
   APP_TRACKING_TRANSPARENCY: {
     pod: 'pod \'Permission-AppTrackingTransparency\', :path => "../node_modules/react-native-permissions/ios/AppTrackingTransparency.podspec"',
-    usageDescriptionKey: 'NSAppleMusicUsageDescription'
+    usageDescriptionKey: 'NSUserTrackingUsageDescription'
   },
   BLUETOOTH_PERIPHERAL: {
     pod: 'pod \'Permission-BluetoothPeripheral\', :path => "../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec"',


### PR DESCRIPTION
Ticket: https://brandingbrand.atlassian.net/browse/FS-2158

# Description
1. The current `usageDescriptionKey` for App Tracking Transparency is `NSAppleMusicUsageDescription` which is incorrect and will render an error message if you attempt to request the ATT permission.
2. Replace `NSAppleMusicUsageDescription` with `NSUserTrackingUsageDescription` per https://developer.apple.com/documentation/bundleresources/information_property_list/nsusertrackingusagedescription and https://github.com/zoontek/react-native-permissions#ios