### PR TITLE
[FS-2160] Update All CFBundleShortVersionString To Be shortVersion

### DIFF
--- a/packages/flagship/src/lib/ios.ts
+++ b/packages/flagship/src/lib/ios.ts
@@ -325,11 +325,14 @@ export function version(configuration: Config, newVersion: string): void {
   );
 }
 
+// tslint:disable:cyclomatic-complexity
 export function iosExtensions(configuration: Config, version: string): void {
   if (!configuration?.ios?.extensions) {
     return;
   }
   helpers.logInfo(`Adding iOS App Extensions`);
+  const shortVersion = (configuration.ios && configuration.ios.shortVersion)
+    || version;
   const bundleVersion = (configuration.ios && configuration.ios.buildVersion)
   || versionLib.normalize(version);
   const extensions = configuration?.ios?.extensions;
@@ -415,7 +418,7 @@ export function iosExtensions(configuration: Config, version: string): void {
     fs.update(
       extPlistPath,
       /\<key\>CFBundleShortVersionString\<\/key\>[\n\r\s]+\<string\>[^\s]+<\/string\>/,
-      `<key>CFBundleShortVersionString</key>\n\t<string>${version}</string>`
+      `<key>CFBundleShortVersionString</key>\n\t<string>${shortVersion}</string>`
     );
     fs.update(
       extPlistPath,


### PR DESCRIPTION
Ticket: https://brandingbrand.atlassian.net/browse/FS-2160

# Description
1. Update extension `Info.plist` `CFBundleShortVersionString` to be `shortVersion` to be consistent with iOS app `Info.plist`
2. For apps that do not use `package.json` `version` as the actual version in the app will run into the following error:
```
WARNING ITMS-90473: "CFBundleShortVersionString Mismatch. The CFBundleShortVersionString value '1.0.0' of extension 'LeviStraussAmericasApp.app/PlugIns/Notifications.appex' does not match the CFBundleShortVersionString value '##.##.##' of its containing iOS application '<app_name>.app'
```