### PR TITLE
fix: use tab id instead of title for tabAffinity

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/utils.base.ts
+++ b/packages/fsapp/src/beta-app/router/history/utils.base.ts
@@ -66,7 +66,7 @@ const matchPath = (path: string | undefined, route: Route) => {
 
 const buildMatcher = async (
   route: Route,
-  tab: Tab = '',
+  tab: Tab = { id: '' },
   prefix = ''
 ): Promise<
   (readonly [
@@ -82,7 +82,7 @@ const buildMatcher = async (
         matchPath(path, route),
         {
           id,
-          tabAffinity: typeof tab === 'string' ? tab : tab.id,
+          tabAffinity: tab.id,
           ...route
         }
       ] as const)

--- a/packages/fsapp/src/beta-app/router/history/utils.base.ts
+++ b/packages/fsapp/src/beta-app/router/history/utils.base.ts
@@ -66,7 +66,7 @@ const matchPath = (path: string | undefined, route: Route) => {
 
 const buildMatcher = async (
   route: Route,
-  tab: Tab = { id: '' },
+  tab?: Tab,
   prefix = ''
 ): Promise<
   (readonly [
@@ -82,7 +82,7 @@ const buildMatcher = async (
         matchPath(path, route),
         {
           id,
-          tabAffinity: tab.id,
+          tabAffinity: tab?.id,
           ...route
         }
       ] as const)

--- a/packages/fsapp/src/beta-app/router/types.ts
+++ b/packages/fsapp/src/beta-app/router/types.ts
@@ -41,7 +41,7 @@ Component<{ componentId: string }, State> {
   static buttons?: ScreenOptions['buttons'];
 }
 export type ScreenComponentType = ScreenFC | typeof ScreenComponent;
-export type Tab = string | (OptionsBottomTab & { id: string });
+export type Tab = (OptionsBottomTab & { id: string });
 
 export type RouteData = Dictionary<unknown | undefined>;
 export type RouteParams = Dictionary<string | undefined>;

--- a/packages/fsapp/src/beta-app/router/utils.ts
+++ b/packages/fsapp/src/beta-app/router/utils.ts
@@ -54,9 +54,8 @@ export const resolveRoutes = async ({
 
   const withTabAffinity = (route: ExternalRoute): ExternalRoute => {
     const tab = findRoute(route);
-    const tabTitle = typeof tab === 'string' ? tab : tab?.text;
 
-    return { tabAffinity: tabTitle, ...route };
+    return { tabAffinity: tab?.id, ...route };
   };
 
   const tabbedExternalRoutes = externalRoutes.map(withTabAffinity);
@@ -69,7 +68,7 @@ export const resolveRoutes = async ({
           ...tabbedExternalRoutes
               .filter(
                 ({ tabAffinity }) =>
-                  tabAffinity === (typeof route.tab === 'string' ? route.tab : route.tab?.text)
+                  tabAffinity === route.tab?.id
               )
               .map(external => ({
                 ...external,


### PR DESCRIPTION
@bweissbart @wSedlacek 
- change type `Tab` to be a tab object only (not a string)
- set tabAffinity to be the id of the tab instead of the title