### PR TITLE
feat(fsengage): FS-2222 add ability to set traffic attribution data

### DIFF
--- a/packages/fsengage/package.json
+++ b/packages/fsengage/package.json
@@ -16,7 +16,7 @@
     "@brandingbrand/fsfoundation": "^10.11.2",
     "@brandingbrand/fsnetwork": "^10.11.2",
     "@brandingbrand/react-native-adobe-marketing-cloud": "^0.1.1",
-    "@brandingbrand/react-native-google-analytics": "^2.1.0",
+    "@brandingbrand/react-native-google-analytics": "^2.2.0",
     "@brandingbrand/react-native-leanplum": "^5.0.0",
     "decimal.js": "^10.0.0",
     "react": "^16.13.1",

--- a/packages/fsengage/src/modules/analytics/Analytics.ts
+++ b/packages/fsengage/src/modules/analytics/Analytics.ts
@@ -104,6 +104,40 @@ export interface TransactionAction extends BaseEvent {
   coupons?: string[];
 }
 
+export interface Campaign extends BaseEvent {
+  /**
+   * Campaign id; used to identify particular campaign by an external identifier
+   */
+  id?: string;
+
+  /**
+   * Campaign source; used to identify a search engine, newsletter, or other source
+   */
+  source?: string;
+
+  /**
+   * Campaign medium; used to identify a medium such as email or cost-per-click (cpc)
+   */
+  medium?: string;
+
+  /**
+   * Campaign name; used for keyword analysis to identify a specific product promotion or
+   * strategic campaign
+   */
+  campaign?: string;
+
+  /**
+   * Campaign term; used with paid search to supply the keywords for ads
+   */
+  term?: string;
+
+  /**
+   * Campaign content; used for A/B testing and content-targeted ads to differentiate ads or
+   * links that point to the same URL
+   */
+  content?: string;
+}
+
 // Class
 
 export default class Analytics {
@@ -776,5 +810,9 @@ export default class Analytics {
       },
       action
     ));
+  }
+
+  setTrafficSource(campaignData: Campaign): void {
+    this.triggerTask(provider => provider.setTrafficSource(campaignData));
   }
 }

--- a/packages/fsengage/src/modules/analytics/Analytics.ts
+++ b/packages/fsengage/src/modules/analytics/Analytics.ts
@@ -104,7 +104,7 @@ export interface TransactionAction extends BaseEvent {
   coupons?: string[];
 }
 
-export interface Campaign extends BaseEvent {
+export interface Campaign {
   /**
    * Campaign id; used to identify particular campaign by an external identifier
    */

--- a/packages/fsengage/src/modules/analytics/providers/AnalyticsProvider.ts
+++ b/packages/fsengage/src/modules/analytics/providers/AnalyticsProvider.ts
@@ -1,5 +1,6 @@
 import AnalyticsProviderConfiguration from './types/AnalyticsProviderConfiguration';
 import Decimal from 'decimal.js';
+import { Campaign } from '../Analytics';
 type BaseEvent = import ('../Analytics').BaseEvent;
 
 // Common Interface
@@ -190,7 +191,7 @@ export default abstract class AnalyticsProvider {
     });
   }
 
-  abstract async asyncInit(): Promise<void>;
+  abstract asyncInit(): Promise<void>;
 
   // Commerce Functions
 
@@ -239,4 +240,8 @@ export default abstract class AnalyticsProvider {
   // App Lifecycle Function
 
   abstract lifecycle(properties: App): void;
+
+  setTrafficSource(properties: Campaign): void {
+    // no-op
+  }
 }

--- a/packages/fsengage/src/modules/analytics/providers/google/GoogleAnalyticsProvider.ts
+++ b/packages/fsengage/src/modules/analytics/providers/google/GoogleAnalyticsProvider.ts
@@ -28,6 +28,7 @@ import AnalyticsProvider, {
 } from '../AnalyticsProvider';
 
 import AnalyticsProviderConfiguration from '../types/AnalyticsProviderConfiguration';
+import { Campaign } from '../../Analytics';
 
 export interface GoogleAnalyticsProviderConfiguration {
   trackerId: string | Promise<string>;
@@ -389,6 +390,25 @@ export default class GoogleAnalyticsProvider extends AnalyticsProvider {
       category: properties.eventAction,
       label: properties.lifecycle
     }, extraData);
+  }
+
+  setTrafficSource(properties: Campaign): void {
+    if (this.client) {
+      this.client.set(new GAHits.TrafficSource({
+        utm_id: properties.id,
+        utm_source: properties.source,
+        utm_medium: properties.medium,
+        utm_campaign: properties.campaign,
+        utm_term: properties.term,
+        utm_content: properties.content
+      }));
+    } else {
+      this.queue.unshift({
+        // tslint:disable-next-line: no-unbound-method
+        func: this.setTrafficSource,
+        params: arguments
+      });
+    }
   }
 
   // Trigger Functions

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,10 +1362,10 @@
   resolved "https://registry.yarnpkg.com/@brandingbrand/react-native-adobe-marketing-cloud/-/react-native-adobe-marketing-cloud-0.1.1.tgz#6ddd9c6fb599d6095ab452082348cf16718cf2c2"
   integrity sha512-kN1A93y7onxci/XlPUSUwdOJB9+SGG3gxYiOznqWrXo9fdRw9Gs68yl8daSMPMZNM+pdu/exVZIcoo3AAfBymQ==
 
-"@brandingbrand/react-native-google-analytics@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@brandingbrand/react-native-google-analytics/-/react-native-google-analytics-2.1.0.tgz#3c45f1d5135d0264af5ba30c0a11991825407044"
-  integrity sha512-7ULYv5yYjTnwSUPgx0p72AwwF9XxZ6yyplScRG7KDLwZLzgIZy/8OVF6QG6x7WEfAbZoZMr5dg9lOoQAx/ZPcw==
+"@brandingbrand/react-native-google-analytics@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@brandingbrand/react-native-google-analytics/-/react-native-google-analytics-2.2.0.tgz#2b4892cbe93424e0e9d9705398f0de514e413c47"
+  integrity sha512-+iUxUulpgg9/huac8QsmJIhbDkdJcXm3bfr5ILsekjTfYEiM4Qcx2zFU8CH/bYWp8hWcQKwh1YRbnB98sVFzFQ==
 
 "@brandingbrand/react-native-leanplum@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
Depends on: https://github.com/brandingbrand/react-native-google-analytics/pull/15

example:

```js
// params to be parsed from url
Analytics.setTrafficSource({
  id: params.utm_id,
  source: params.utm_source,
  medium: params.utm_medium,
  campaign: params.utm_campaign,
  term: params.utm_term,
  content: params.utm_content
});
```