### PR TITLE
fix(fsweb): deliver react bundle on all fall-through requests

### DIFF
--- a/packages/fsweb/src/server.prod.ts
+++ b/packages/fsweb/src/server.prod.ts
@@ -23,6 +23,11 @@ healthCheck(app, env);
 
 addProxy(app, env);
 
+app.all('*', (req, res) => {
+  // Send the react bundle to all requests that haven't been handled by the above middleware.
+  res.sendFile(path.resolve(__dirname, rootDir, buildPath, 'index.html'));
+});
+
 app.listen(port, () => {
   console.info(`Proxy listening on port ${port}`);
 }).on('error', err => {


### PR DESCRIPTION
if a route isn't handled by one of the middlewares (eg. static files, proxy), deliver the react
bundle. the application router will handle rendering the proper content.