### PR TITLE
refactor(fscomponents): remove duplicate export

### DIFF
--- a/packages/fscomponents/src/styles/index.ts
+++ b/packages/fscomponents/src/styles/index.ts
@@ -15,4 +15,3 @@ export { style as SelectorStyles } from './Selector';
 export { style as StepperStyles } from './Stepper';
 export { style as SwatchesStyles } from './Swatches';
 export * from './variables';
-export * from './weights';


### PR DESCRIPTION
`./variables` already exports `weights` and metro throws the following error with this conflict in some circumstances.
```
TypeError: Attempting to change the getter of an unconfigurable property
```

This fixes that.