### PR TITLE
feat: public js docs

### DIFF
--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -11,7 +11,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
-    "removeComments": true,
+    "removeComments": false,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
## Description

This makes the comments public so that JS Doc comments are not removed from bundles.
This means that hover over docs in VS Code will work.
This means that Serializable Components will not have their `TJS-Ignore` comments removed﻿
