### PR TITLE
feat(fscomponents): FS-2308 - allow serializableImage to have children

### DIFF
--- a/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
+++ b/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
@@ -35,12 +35,12 @@ export interface PreStandardizedSerializableImageProps
 export type SerializableImageProps = StandardContainerProps<PreStandardizedSerializableImageProps>;
 
 export const SerializableImage: FC<SerializableImageProps> =
-  ({ children, style = {}, uri, ...props }) => {
+  ({ children, containerStyle, style = {}, uri, ...props }) => {
     const source = useMemo(() => ({ uri }), [uri]);
     const { alignItems, justifyContent, ...restStyles } = style;
 
     return (
-      <View style={restStyles}>
+      <View style={[restStyles, containerStyle]}>
         <ImageBackground
           {...props}
           source={source}

--- a/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
+++ b/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react';
-import { Image, ImageProps, ImageStyle } from 'react-native';
+import { ImageBackground, ImageProps, ImageStyle, View, ViewStyle } from 'react-native';
 
 export interface SerializableImageProps
   extends Pick<
@@ -14,16 +14,27 @@ export interface SerializableImageProps
     | 'progressiveRenderingEnabled'
     | 'resizeMethod'
     | 'resizeMode'
-    | 'style'
     | 'testID'
   > {
   uri?: string;
-  height?: number;
-  width?: number;
-  style?: ImageStyle;
+  style?: ViewStyle;
+  imageStyle?: ImageStyle;
+  children?: React.ReactNode;
 }
 
-export const SerializableImage: FC<SerializableImageProps> = ({ uri, height, width, ...props }) => {
-  const source = useMemo(() => ({ uri, height, width }), [uri, height, width]);
-  return <Image {...props} source={source} />;
-};
+export const SerializableImage: FC<SerializableImageProps> =
+  ({ children, style, uri, ...props }) => {
+    const source = useMemo(() => ({ uri }), [uri]);
+
+    return (
+      <View style={style}>
+        <ImageBackground
+          {...props}
+          source={source}
+          style={[{ flex: 1 }, style]}
+        >
+          {children}
+        </ImageBackground>
+      </View>
+    );
+  };

--- a/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
+++ b/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useMemo } from 'react';
-import { ImageBackground, ImageProps, ImageStyle, View, ViewStyle } from 'react-native';
+import { FlexStyle, ImageBackground, ImageProps, ImageStyle, View, ViewStyle } from 'react-native';
+import { StandardContainerProps } from '../../../models';
 
-export interface SerializableImageProps
+export interface PreStandardizedSerializableImageProps
   extends Pick<
     ImageProps,
     | 'accessibilityLabel'
@@ -16,11 +17,22 @@ export interface SerializableImageProps
     | 'resizeMode'
     | 'testID'
   > {
-  uri?: string;
-  style?: ViewStyle;
+  uri: string;
   imageStyle?: ImageStyle;
-  children?: React.ReactNode;
+  style: ViewStyle;
+
+  /**
+   * @TJS-ignore
+   */
+  containerStyle: FlexStyle;
+
+  /**
+   * @TJS-ignore
+   */
+  children: React.ReactNode;
 }
+
+export type SerializableImageProps = StandardContainerProps<PreStandardizedSerializableImageProps>;
 
 export const SerializableImage: FC<SerializableImageProps> =
   ({ children, style, uri, ...props }) => {

--- a/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
+++ b/packages/fscomponents/src/components/serializable/vNext/SerializableImage.tsx
@@ -35,15 +35,20 @@ export interface PreStandardizedSerializableImageProps
 export type SerializableImageProps = StandardContainerProps<PreStandardizedSerializableImageProps>;
 
 export const SerializableImage: FC<SerializableImageProps> =
-  ({ children, style, uri, ...props }) => {
+  ({ children, style = {}, uri, ...props }) => {
     const source = useMemo(() => ({ uri }), [uri]);
+    const { alignItems, justifyContent, ...restStyles } = style;
 
     return (
-      <View style={style}>
+      <View style={restStyles}>
         <ImageBackground
           {...props}
           source={source}
-          style={[{ flex: 1 }, style]}
+          style={{
+            flex: 1,
+            alignItems,
+            justifyContent
+          }}
         >
           {children}
         </ImageBackground>


### PR DESCRIPTION
This replaces the plain SerializableImage component to one that accept children and can act as an overlay.  If you haven't used the `ImageBackground` component much before the code for it is here: https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageBackground.js

It's basically a wrapped/styled Image component and it does have web support.

- remove height/width from the image `source`.  We really should never have been passing it in with the source object, it's why we need the ImagePropsTransformer in the app to undo this.  Instead it should only be in the style object
- I wrapped `ImageBackground` in another view because it allows padding (and possibly a background color) for the image, which is I believe what a user would expect when adding padding (see picture).  Because of `StyleSheet.absoluteFill` being applied to the Image in `ImageBackground` we need to pass the `style` into `ImageBackground` as well.
<img src="https://user-images.githubusercontent.com/2859495/120533990-56ed0880-c3af-11eb-9f1c-f72db712d0f1.png" width="300">


I've tested it in a variety of different styles of overlay and seems to work well in creating what we need to create.