### PR TITLE
feat(fscomponents): add ability to hide oveflow on carousel

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -310,7 +310,7 @@ export class MultiCarousel<ItemT> extends Component<MultiCarouselProps<ItemT>, M
             flexBasis: 'auto',
             flexDirection: 'row',
             overflowY: 'hidden',
-            overflowX: 'scroll'
+            overflowX: this.props.hideOverflow ? 'hidden' : 'scroll'
           }}
           onMouseDown={this.handleMouseStart}
           onMouseUp={this.handleMouseEnd}

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarouselProps.ts
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarouselProps.ts
@@ -36,4 +36,5 @@ export interface MultiCarouselProps<ItemT> {
   keyExtractor?: (item: ItemT, index: number) => string;
   hideZoomButton?: boolean;
   contentContainerStyle?: StyleProp<ViewStyle>;
+  hideOverflow?: boolean;
 }

--- a/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
+++ b/packages/fscomponents/src/components/ZoomCarousel/ZoomCarousel.web.tsx
@@ -375,6 +375,7 @@ export class ZoomCarousel extends Component<ZoomCarouselProps, ZoomCarouselState
                style={this.props.fillContainer ? S.fullHeight : null}
                nextArrowOnBlur={this.props.nextArrowOnBlur}
                hidePageIndicator={this.props.hidePageIndicator}
+               hideOverflow={this.props.hideOverflow}
              />
 
              {!this.props.hideZoomButton && (

--- a/packages/fscomponents/src/components/ZoomCarousel/types.ts
+++ b/packages/fscomponents/src/components/ZoomCarousel/types.ts
@@ -40,6 +40,7 @@ export interface ZoomCarouselProps {
   showThumbnails?: boolean;
   thumbnailStyle?: any;
   thumbnailContainerStyle?: any;
+  hideOverflow?: boolean;
 
   /**
    * The styling of the container that holds the image carousel and thumbnails

--- a/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/ZoomCarousel.story.tsx
@@ -57,4 +57,15 @@ storiesOf('ZoomCarousel', module)
       showThumbnails={boolean('Show Thumbnails', true)}
       showImageCounter={boolean('Show Image Counter', true)}
     />
+)).add('without horizontal overflow', () => (
+  <ZoomCarousel
+    images={object('Images', defaultImages)}
+    peekSize={number('Peek Size', 20)}
+    gapSize={number('Gap Size', 10)}
+    centerMode={boolean('Center Mode', true)}
+    showArrow={boolean('Show Arrow', true)}
+    hideZoomButton={boolean('Hide Zoom Button', false)}
+    fillContainer={boolean('Fill Container', false)}
+    hideOverflow={true}
+  />
 ));


### PR DESCRIPTION
 - optional prop for horizontal scroll, allows for movement exclusively by left right swipes


This is the same as https://github.com/brandingbrand/flagship/pull/2104, but for v11