### PR TITLE
fix(fsapp): broken links

### DIFF
--- a/packages/fsapp/src/beta-app/utils.base.tsx
+++ b/packages/fsapp/src/beta-app/utils.base.tsx
@@ -10,9 +10,6 @@ export const StaticImplements = <T extends any>() => <U extends T>(_constructor:
 
 export const isDefined = <T extends any>(value: T | undefined): value is T => value !== undefined;
 
-const routeCollectionPath = (route: Route | RouteCollection) => {
-  return 'initialPath' in route ? `/${route.initialPath?.replace(/^\//, '') ?? ''}` : undefined;
-};
 const pathFromRoute = (route: Route, prefix?: string) => {
   return route.path !== undefined
     ? `${prefix?.replace(/\/$/, '') ?? ''}/${route.path?.replace(/^\//, '') ?? ''}`
@@ -20,7 +17,7 @@ const pathFromRoute = (route: Route, prefix?: string) => {
 };
 
 export const buildPath = (route: Route | RouteCollection, prefix?: string) => {
-  const path = routeCollectionPath(route) || pathFromRoute(route, prefix);
+  const path = pathFromRoute(route, prefix);
   const id = path || `${prefix ?? ''}/undefined`;
   return { id, path };
 };


### PR DESCRIPTION
The following route was being registered as `shop/shop/category/:categoryId`.
```ts
{
    initialPath: 'shop',
    tab: Shop,
    children: [
      {
        path: 'shop/category/:categoryId',
        loadComponent: () => import('./screens/Category').then(({ Category }) => Category)
      },
   ]
}
```
With the `initialPath` prepended when it shouldn't have been.
This fixes that.