### PR TITLE
fix(fsapp): updating title

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/history.ts
+++ b/packages/fsapp/src/beta-app/router/history/history.ts
@@ -246,17 +246,20 @@ export class History implements FSRouterHistory {
   }
 
   @boundMethod
-  public updateTitle(title: RequiredTitle): void {
-    Navigation.mergeOptions(stringifyLocation(this.location), {
-      topBar: {
-        title:
-          typeof title === 'string'
-            ? {
-              text: title
-            }
-            : title
-      }
-    });
+  public updateTitle(title: RequiredTitle, componentId?: string): void {
+    const key = componentId ?? this.location.key;
+    if (key) {
+      Navigation.mergeOptions(key, {
+        topBar: {
+          title:
+            typeof title === 'string'
+              ? {
+                text: title
+              }
+              : title
+        }
+      });
+    }
   }
 
   private observeNavigation(): void {

--- a/packages/fsapp/src/beta-app/router/history/types.ts
+++ b/packages/fsapp/src/beta-app/router/history/types.ts
@@ -33,7 +33,7 @@ export interface FSRouterHistory extends History {
   observeLoading(listener: LoadingListener): UnregisterCallback;
   registerResolver(id: string, listener: ResolverListener): UnregisterCallback;
 
-  updateTitle(title: RequiredTitle): void;
+  updateTitle(title: RequiredTitle, componentId?: string): void;
 }
 
 export type Blocker = string | boolean | TransitionPromptHook;


### PR DESCRIPTION
## Description

This fixes the native .updateTitle() function to properly affect the current location rather than the component registration for the current path.
This adds a new parameter to specify which componentId to affect.﻿
