### PR TITLE
chore: fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
     node_js: '12'
     script:
       - yarn prepare || travis_terminate 1
+      - yarn ship:init-web # needed to populate project_env_index for fsapp (depended upon by some components)
       - yarn prepare:fscodestyle || travis_terminate 1
       - yarn lint || travis_terminate 1
       - yarn test --coverage --ci && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js || travis_terminate 1


### PR DESCRIPTION
The build storybook step of CI was failing because fscomponents had a dependency on fsapp, and fsapp has a dependency on project_env_index.js being set. project_env_index.js is created as part of the init process. This adds init to the test stage to address the error.