### PR TITLE
chore: remove appcenter_app_bundle lane from android template

### DIFF
--- a/packages/flagship/__tests__/mock_project/android/fastlane/Fastfile
+++ b/packages/flagship/__tests__/mock_project/android/fastlane/Fastfile
@@ -11,19 +11,6 @@ lane :appcenter do
   )
 end
 
-# Use this lane if you want to generate app bundle: https://developer.android.com/guide/app-bundle
-lane :appcenter_app_bundle do
-  # build the release variant
-  gradle(task: "assembleBundle")
-
-  appcenter_upload(
-    #PROJECT_MODIFY_FLAG_appcenter_api_token
-    destination_type: "store",
-    owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
-    app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
-  )
-end
-
 lane :build do
 
   # build the release variant

--- a/packages/flagship/android/fastlane/Fastfile
+++ b/packages/flagship/android/fastlane/Fastfile
@@ -11,18 +11,6 @@ lane :appcenter do
   )
 end
 
-# Use this lane if you want to generate app bundle: https://developer.android.com/guide/app-bundle
-lane :appcenter_app_bundle do
-  # build the release variant
-  gradle(task: "assembleBundle")
-
-  appcenter_upload(
-    #PROJECT_MODIFY_FLAG_appcenter_api_token
-    owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
-    app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
-  )
-end
-
 lane :build do
 
   # build the release variant


### PR DESCRIPTION
This lane made a couple incorrect assumptions about making android app bundles.

1. It called the gradle task assembleBundle which isn't a real task -- the task name is bundleRelease
2. It tried to perform an Appcenter Upload, but Appcenter can only handle APKs not AABs

At this time our existing Fastlane processes will continue to work to upload APKs to Appcenter.