### PR TITLE
feat: static context reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ packages/pirateship/android
 packages/pirateship/ios
 packages/pirateship/web
 packages/pirateship/env/env.js
+
+# Incremental Builds
+**/*.tsbuildinfo

--- a/packages/fsapp/package.json
+++ b/packages/fsapp/package.json
@@ -15,6 +15,7 @@
     "@brandingbrand/fscommerce": "^11.0.1-alpha.9",
     "@brandingbrand/fsengage": "^11.0.1-alpha.9",
     "@brandingbrand/fsfoundation": "^11.0.1-alpha.9",
+    "@brandingbrand/fslinker": "^11.0.1-alpha.9",
     "@brandingbrand/fsnetwork": "^11.0.1-alpha.9",
     "@loadable/component": "^5.14.1",
     "@react-native-community/async-storage": "^1.9.0",

--- a/packages/fsapp/src/beta-app/app/app.base.ts
+++ b/packages/fsapp/src/beta-app/app/app.base.ts
@@ -21,6 +21,7 @@ import { getVersion } from './utils';
 
 export const APP_VERSION_TOKEN = new InjectionToken<string>('APP_VERSION_TOKEN');
 export const APP_CONFIG_TOKEN = new InjectionToken<AppConfig>('APP_CONFIG_TOKEN');
+export const API_TOKEN = new InjectionToken<FSNetwork>('API_TOKEN');
 
 export abstract class FSAppBase implements IApp {
   public static async bootstrap<S extends GenericState, A extends Action, T extends FSAppBase>(
@@ -50,6 +51,7 @@ export abstract class FSAppBase implements IApp {
       version,
       config,
       router,
+      api,
       store as S extends GenericState ? (A extends Action ? Store<S, A> : undefined) : undefined
     );
     if (!config.serverSide) {
@@ -64,14 +66,16 @@ export abstract class FSAppBase implements IApp {
     public readonly version: string,
     public readonly config: AppConfig,
     protected readonly router: FSRouter,
+    public readonly api?: FSNetwork,
     public readonly store?: Store
   ) {
-    Injector.provide({ provide: APP_VERSION_TOKEN, useValue: version });
+    Injector.provide({ provide: API_TOKEN, useValue: api });
+    Injector.provide({ provide: REDUX_STORE_TOKEN, useValue: store });
     Injector.provide({ provide: APP_CONFIG_TOKEN, useValue: config });
+    Injector.provide({ provide: APP_VERSION_TOKEN, useValue: version });
     Injector.provide({ provide: API_CONTEXT_TOKEN, useValue: APIContext });
     Injector.provide({ provide: APP_CONTEXT_TOKEN, useValue: AppContext });
     Injector.provide({ provide: REDUX_CONTEXT_TOKEN, useValue: ReactReduxContext });
-    Injector.provide({ provide: REDUX_STORE_TOKEN, useValue: store });
   }
 
   @boundMethod

--- a/packages/fsapp/src/beta-app/app/app.base.ts
+++ b/packages/fsapp/src/beta-app/app/app.base.ts
@@ -2,12 +2,25 @@ import type { Action, Store } from 'redux';
 import type { AppConfig, AppConstructor, IApp } from './types';
 
 import FSNetwork from '@brandingbrand/fsnetwork';
+import { InjectionToken, Injector } from '@brandingbrand/fslinker';
 import { boundMethod } from 'autobind-decorator';
+import { ReactReduxContext } from 'react-redux';
 
+import {
+  API_CONTEXT_TOKEN,
+  APIContext,
+  APP_CONTEXT_TOKEN,
+  AppContext,
+  REDUX_CONTEXT_TOKEN,
+  REDUX_STORE_TOKEN
+} from './context';
 import { FSRouter, Routes } from '../router';
 import { GenericState, StoreManager } from '../store';
 import { makeScreenWrapper } from './screen.wrapper';
 import { getVersion } from './utils';
+
+export const APP_VERSION_TOKEN = new InjectionToken<string>('APP_VERSION_TOKEN');
+export const APP_CONFIG_TOKEN = new InjectionToken<AppConfig>('APP_CONFIG_TOKEN');
 
 export abstract class FSAppBase implements IApp {
   public static async bootstrap<S extends GenericState, A extends Action, T extends FSAppBase>(
@@ -52,7 +65,14 @@ export abstract class FSAppBase implements IApp {
     public readonly config: AppConfig,
     protected readonly router: FSRouter,
     public readonly store?: Store
-  ) {}
+  ) {
+    Injector.provide({ provide: APP_VERSION_TOKEN, useValue: version });
+    Injector.provide({ provide: APP_CONFIG_TOKEN, useValue: config });
+    Injector.provide({ provide: API_CONTEXT_TOKEN, useValue: APIContext });
+    Injector.provide({ provide: APP_CONTEXT_TOKEN, useValue: AppContext });
+    Injector.provide({ provide: REDUX_CONTEXT_TOKEN, useValue: ReactReduxContext });
+    Injector.provide({ provide: REDUX_STORE_TOKEN, useValue: store });
+  }
 
   @boundMethod
   public async openUrl(url: string): Promise<void> {

--- a/packages/fsapp/src/beta-app/app/app.ts
+++ b/packages/fsapp/src/beta-app/app/app.ts
@@ -7,6 +7,8 @@ import { DEV_KEEP_SCREEN, LAST_SCREEN_KEY } from '../constants';
 import { StaticImplements } from '../utils';
 import { FSAppBase } from './app.base';
 
+export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app.base';
+
 @StaticImplements<AppConstructor>()
 export class FSAppBeta extends FSAppBase {
   public async startApplication(): Promise<void> {

--- a/packages/fsapp/src/beta-app/app/app.ts
+++ b/packages/fsapp/src/beta-app/app/app.ts
@@ -7,7 +7,7 @@ import { DEV_KEEP_SCREEN, LAST_SCREEN_KEY } from '../constants';
 import { StaticImplements } from '../utils';
 import { FSAppBase } from './app.base';
 
-export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app.base';
+export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN, API_TOKEN } from './app.base';
 
 @StaticImplements<AppConstructor>()
 export class FSAppBeta extends FSAppBase {

--- a/packages/fsapp/src/beta-app/app/app.web.ts
+++ b/packages/fsapp/src/beta-app/app/app.web.ts
@@ -5,6 +5,8 @@ import { AppRegistry } from 'react-native';
 import { StaticImplements } from '../utils';
 import { FSAppBase } from './app.base';
 
+export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app.base';
+
 @StaticImplements<AppConstructor>()
 export class FSAppBeta extends FSAppBase {
   private root: Element | null =

--- a/packages/fsapp/src/beta-app/app/app.web.ts
+++ b/packages/fsapp/src/beta-app/app/app.web.ts
@@ -5,7 +5,7 @@ import { AppRegistry } from 'react-native';
 import { StaticImplements } from '../utils';
 import { FSAppBase } from './app.base';
 
-export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app.base';
+export { APP_CONFIG_TOKEN, APP_VERSION_TOKEN, API_TOKEN } from './app.base';
 
 @StaticImplements<AppConstructor>()
 export class FSAppBeta extends FSAppBase {

--- a/packages/fsapp/src/beta-app/app/context/api.context.ts
+++ b/packages/fsapp/src/beta-app/app/context/api.context.ts
@@ -1,7 +1,12 @@
+import { createContext } from 'react';
 import FSNetwork from '@brandingbrand/fsnetwork';
+import { InjectionToken } from '@brandingbrand/fslinker';
 
-import { createContext, useContext } from 'react';
+import { useDependencyContext } from '../../lib/use-dependency';
 
+const DEFAULT_NETWORK = new FSNetwork();
 
-export const APIContext = createContext<FSNetwork>(new FSNetwork());
-export const useAPI = () => useContext(APIContext);
+export const APIContext = createContext<FSNetwork>(DEFAULT_NETWORK);
+export const API_CONTEXT_TOKEN = new InjectionToken<typeof APIContext>('API_CONTEXT_TOKEN');
+
+export const useAPI = () => useDependencyContext(API_CONTEXT_TOKEN) ?? DEFAULT_NETWORK;

--- a/packages/fsapp/src/beta-app/app/context/app.context.tsx
+++ b/packages/fsapp/src/beta-app/app/context/app.context.tsx
@@ -1,9 +1,16 @@
 import type { IApp } from '../types';
 
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useMemo } from 'react';
+import { InjectionToken } from '@brandingbrand/fslinker';
+
+import { useDependencyContext } from '../../lib/use-dependency';
 
 export const AppContext = createContext<() => IApp | undefined>(() => undefined);
+export const APP_CONTEXT_TOKEN = new InjectionToken<typeof AppContext>('APP_CONTEXT_TOKEN');
+
 export const useApp = () => {
-  const context = useContext(AppContext);
-  return useMemo(context, []);
+  const context = useDependencyContext(APP_CONTEXT_TOKEN);
+
+  // tslint:disable-next-line: no-unnecessary-callback-wrapper -- Optional Chaining
+  return useMemo(() => context?.(), [context]);
 };

--- a/packages/fsapp/src/beta-app/app/context/index.ts
+++ b/packages/fsapp/src/beta-app/app/context/index.ts
@@ -1,2 +1,3 @@
 export * from './api.context';
 export * from './app.context';
+export * from './store.context';

--- a/packages/fsapp/src/beta-app/app/context/store.context.tsx
+++ b/packages/fsapp/src/beta-app/app/context/store.context.tsx
@@ -1,0 +1,36 @@
+import React, { FC } from 'react';
+import { Action, AnyAction, Store } from 'redux';
+import { Provider, ProviderProps, ReactReduxContext, ReactReduxContextValue } from 'react-redux';
+import { InjectionToken } from '@brandingbrand/fslinker';
+
+import { useDependency, useDependencyContext } from '../../lib/use-dependency';
+
+export const REDUX_CONTEXT_TOKEN = new InjectionToken<typeof ReactReduxContext>(
+  'REDUX_CONTEXT_TOKEN'
+);
+
+export const REDUX_STORE_TOKEN = new InjectionToken<Store>('REDUX_STORE_TOKEN');
+
+export const InjectedReduxProvider: FC<Partial<Omit<ProviderProps, 'context'>>> = ({
+  store,
+  children
+}) => {
+  const context = useDependency(REDUX_CONTEXT_TOKEN);
+  return context && store ? (
+    <Provider store={store} context={context} children={children} />
+  ) : (
+    <>{children}</>
+  );
+};
+
+const useRedux = <S, A extends Action = AnyAction>(): ReactReduxContextValue<S, A> | undefined => {
+  return useDependencyContext(REDUX_CONTEXT_TOKEN) as ReactReduxContextValue<S, A> | undefined;
+};
+
+export const useStore = <T, A extends Action = AnyAction>() => {
+  return useRedux<T, A>()?.store;
+};
+
+export const useDispatch = <A extends Action = AnyAction>() => {
+  return useRedux<unknown, A>()?.store.dispatch;
+};

--- a/packages/fsapp/src/beta-app/app/index.ts
+++ b/packages/fsapp/src/beta-app/app/index.ts
@@ -1,4 +1,13 @@
-export { FSAppBeta } from './app';
-export { APIContext, useAPI, useApp } from './context';
+export { FSAppBeta, APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app';
+export {
+  useAPI,
+  useApp,
+  API_CONTEXT_TOKEN,
+  APP_CONTEXT_TOKEN,
+  REDUX_CONTEXT_TOKEN,
+  REDUX_STORE_TOKEN,
+  useDispatch,
+  useStore
+} from './context';
 
 export type { AppConfig, IApp as AppType, AppConstructor, WebApplication } from './types';

--- a/packages/fsapp/src/beta-app/app/index.ts
+++ b/packages/fsapp/src/beta-app/app/index.ts
@@ -1,4 +1,4 @@
-export { FSAppBeta, APP_CONFIG_TOKEN, APP_VERSION_TOKEN } from './app';
+export { FSAppBeta, APP_CONFIG_TOKEN, APP_VERSION_TOKEN, API_TOKEN } from './app';
 export {
   useAPI,
   useApp,

--- a/packages/fsapp/src/beta-app/app/screen.wrapper.tsx
+++ b/packages/fsapp/src/beta-app/app/screen.wrapper.tsx
@@ -3,9 +3,9 @@ import type FSNetwork from '@brandingbrand/fsnetwork';
 import type { IApp } from './types';
 
 import React, { FC } from 'react';
-import * as ReduxContext from 'react-redux';
 
-import { APIContext, AppContext } from './context';
+import { InjectedContextProvider } from '../lib/use-dependency';
+import { API_CONTEXT_TOKEN, APP_CONTEXT_TOKEN, InjectedReduxProvider } from './context';
 
 export interface Wrappers {
   readonly store?: Store<any, any>;
@@ -14,14 +14,18 @@ export interface Wrappers {
 }
 
 export const makeScreenWrapper = ({ api, app, store }: Wrappers): FC => {
-  const App: React.FC = ({ children }) => <AppContext.Provider value={app} children={children} />;
+  const App: React.FC = ({ children }) => (
+    <InjectedContextProvider token={APP_CONTEXT_TOKEN} value={app} children={children} />
+  );
 
   const Store: React.FC = store
-    ? ({ children }) => <ReduxContext.Provider store={store} children={children} />
+    ? ({ children }) => <InjectedReduxProvider store={store} children={children} />
     : ({ children }) => <>{children}</>;
 
   const API: React.FC = api
-    ? ({ children }) => <APIContext.Provider value={api} children={children} />
+    ? ({ children }) => (
+        <InjectedContextProvider token={API_CONTEXT_TOKEN} value={api} children={children} />
+      )
     : ({ children }) => <>{children}</>;
 
   return ({ children }) => {

--- a/packages/fsapp/src/beta-app/app/types.ts
+++ b/packages/fsapp/src/beta-app/app/types.ts
@@ -1,9 +1,10 @@
 import type { Action, AnyAction, Store } from 'redux';
 import type { Analytics } from '@brandingbrand/fsengage';
-import type { FSNetworkRequestConfig } from '@brandingbrand/fsnetwork';
 import type { FSRouter, RouterConfig, Routes } from '../router';
 import type { GenericState, StoreConfig } from '../store';
 import type { ShellConfig } from '../shell.web';
+
+import FSNetwork, { FSNetworkRequestConfig } from '@brandingbrand/fsnetwork';
 
 export interface WebApplication {
   readonly element: JSX.Element;
@@ -45,6 +46,6 @@ export interface IApp {
 }
 
 export interface AppConstructor<T extends IApp = IApp> {
-  new (version: string, config: AppConfig, router: FSRouter, store?: Store): T;
+  new (version: string, config: AppConfig, router: FSRouter, api?: FSNetwork, store?: Store): T;
   bootstrap(options: AppConfig): Promise<T>;
 }

--- a/packages/fsapp/src/beta-app/index.ts
+++ b/packages/fsapp/src/beta-app/index.ts
@@ -3,3 +3,5 @@ export * from './modal';
 export * from './router';
 export * from './shell.web';
 export * from './store';
+
+export * from './lib/use-dependency';

--- a/packages/fsapp/src/beta-app/lib/use-dependency.tsx
+++ b/packages/fsapp/src/beta-app/lib/use-dependency.tsx
@@ -1,0 +1,28 @@
+import React, { Context, createContext, useContext, useMemo } from 'react';
+import { InjectionToken, Injector } from '@brandingbrand/fslinker';
+
+const UNDEFINED_CONTEXT = createContext(undefined);
+
+export const useDependency = <T, >(token: InjectionToken<T>) => {
+  return useMemo(() => Injector.get(token), [token]);
+};
+
+export const useDependencyContext = <T, >(token: InjectionToken<Context<T>>) => {
+  const context = useMemo(() => Injector.get(token), [token]);
+  return useContext((context ?? UNDEFINED_CONTEXT) as Context<T | undefined>);
+};
+
+export interface InjectedContextProviderProps<T> {
+  token: InjectionToken<Context<T>>;
+  value: T;
+  children?: React.ReactNode;
+}
+
+export const InjectedContextProvider = <T, >({
+  token,
+  value,
+  children
+}: InjectedContextProviderProps<T>) => {
+  const Context = useDependency(token);
+  return Context ? <Context.Provider value={value} children={children} /> : <>{children}</>;
+};

--- a/packages/fsapp/src/beta-app/modal/modal.context.web.tsx
+++ b/packages/fsapp/src/beta-app/modal/modal.context.web.tsx
@@ -1,22 +1,31 @@
 import type { Dictionary } from '@brandingbrand/fsfoundation';
 import type { ModalComponentType, ModalProviderProps, ModalService } from './types';
 
-import React, { createContext, FC, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, FC, useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, TouchableWithoutFeedback, View } from 'react-native';
 import { uniqueId } from 'lodash-es';
 
 // @ts-ignore TODO: Update `react-native-web` and replace this
 import Modal from 'react-native-web-modal';
 
+import { InjectionToken } from '@brandingbrand/fslinker';
+
 import { useNavigator } from '../router';
 import { lockScroll, unlockScroll } from '../utils.web';
 
 import { NO_MODAL_CONTEXT_ERROR } from './constants';
+import { InjectedContextProvider, useDependencyContext } from '../lib/use-dependency';
 import { ActivatedRouteProvider, NavigatorProvider, useActivatedRoute } from '../router/context';
-import { APIContext, AppContext, useAPI, useApp } from '../app/context';
-import { Provider, useStore } from 'react-redux';
+import {
+  API_CONTEXT_TOKEN,
+  APP_CONTEXT_TOKEN,
+  InjectedReduxProvider,
+  useAPI,
+  useApp,
+  useStore
+} from '../app/context';
 
-const ModalContext = createContext<ModalService>({
+const DEFAULT_MODAL_SERVICE = {
   showModal: async () => {
     throw new Error(NO_MODAL_CONTEXT_ERROR);
   },
@@ -26,9 +35,11 @@ const ModalContext = createContext<ModalService>({
   dismissAllModals: async () => {
     throw new Error(NO_MODAL_CONTEXT_ERROR);
   }
-});
+};
 
-export const useModals = () => useContext(ModalContext);
+export const ModalContext = createContext<ModalService>(DEFAULT_MODAL_SERVICE);
+export const MODAL_CONTEXT_TOKEN = new InjectionToken<typeof ModalContext>('MODAL_CONTEXT_TOKEN');
+export const useModals = () => useDependencyContext(MODAL_CONTEXT_TOKEN) ?? DEFAULT_MODAL_SERVICE;
 
 const navStyle = StyleSheet.create({
   backdrop: {
@@ -132,10 +143,10 @@ export const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
                 onRequestClose={handleReject}
                 {...modal.options}
               >
-                <AppContext.Provider value={getApp}>
-                  <APIContext.Provider value={api}>
+                <InjectedContextProvider token={APP_CONTEXT_TOKEN} value={getApp}>
+                  <InjectedContextProvider token={API_CONTEXT_TOKEN} value={api}>
                     <NavigatorProvider value={navigator}>
-                      <Provider store={store}>
+                      <InjectedReduxProvider store={store}>
                         <ActivatedRouteProvider {...route}>
                           <TouchableWithoutFeedback onPress={handleReject}>
                             <View style={[navStyle.backdrop, modal.options?.backdropStyle]} />
@@ -149,10 +160,10 @@ export const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
                             />
                           </View>
                         </ActivatedRouteProvider>
-                      </Provider>
+                      </InjectedReduxProvider>
                     </NavigatorProvider>
-                  </APIContext.Provider>
-                </AppContext.Provider>
+                  </InjectedContextProvider>
+                </InjectedContextProvider>
               </Modal>
             );
           }
@@ -163,11 +174,14 @@ export const ModalProvider: FC<ModalProviderProps> = ({ children }) => {
   );
 
   return (
-    <ModalContext.Provider value={{ showModal, dismissModal, dismissAllModals }}>
+    <InjectedContextProvider
+      token={MODAL_CONTEXT_TOKEN}
+      value={{ showModal, dismissModal, dismissAllModals }}
+    >
       {children}
       {Object.entries(modals).map(([id, Modal]) => (
         <Modal key={id} />
       ))}
-    </ModalContext.Provider>
+    </InjectedContextProvider>
   );
 };

--- a/packages/fsapp/src/beta-app/router/context/activated-route.context.tsx
+++ b/packages/fsapp/src/beta-app/router/context/activated-route.context.tsx
@@ -1,7 +1,11 @@
 import type { ActivatedRoute, RouteData, RouteParams, RouteQuery } from '../types';
 
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useMemo } from 'react';
 import { defaults } from 'lodash-es';
+
+import { InjectionToken } from '@brandingbrand/fslinker';
+
+import { InjectedContextProvider, useDependencyContext } from '../../lib/use-dependency';
 
 export const defaultActivatedRoute: ActivatedRoute = {
   path: undefined,
@@ -12,22 +16,37 @@ export const defaultActivatedRoute: ActivatedRoute = {
 };
 
 export const LoadingContext = createContext<boolean>(defaultActivatedRoute.loading);
-export const useRouteLoading = () => useContext(LoadingContext);
+export const LOADING_CONTEXT_TOKEN = new InjectionToken<typeof LoadingContext>(
+  'LOADING_CONTEXT_TOKEN'
+);
+export const useRouteLoading = () =>
+  useDependencyContext(LOADING_CONTEXT_TOKEN) ?? defaultActivatedRoute.loading;
 
 export const DataContext = createContext<Readonly<RouteData>>(defaultActivatedRoute.data);
-export const useRouteData = () => useContext(DataContext);
+export const DATA_CONTEXT_TOKEN = new InjectionToken<typeof DataContext>('DATA_CONTEXT_TOKEN');
+export const useRouteData = () =>
+  useDependencyContext(DATA_CONTEXT_TOKEN) ?? defaultActivatedRoute.data;
 
 export const QueryContext = createContext<Readonly<RouteQuery>>(defaultActivatedRoute.query);
-export const useRouteQuery = () => useContext(QueryContext);
+export const QUERY_CONTEXT_TOKEN = new InjectionToken<typeof QueryContext>('QUERY_CONTEXT_TOKEN');
+export const useRouteQuery = () =>
+  useDependencyContext(QUERY_CONTEXT_TOKEN) ?? defaultActivatedRoute.query;
 
 export const ParamContext = createContext<Readonly<RouteParams>>(defaultActivatedRoute.params);
-export const useRouteParams = () => useContext(ParamContext);
+export const PARAM_CONTEXT_TOKEN = new InjectionToken<typeof ParamContext>('PARAM_CONTEXT_TOKEN');
+export const useRouteParams = () =>
+  useDependencyContext(PARAM_CONTEXT_TOKEN) ?? defaultActivatedRoute.params;
 
 export const PathContext = createContext<string | undefined>(undefined);
-export const useRoutePath = () => useContext(PathContext);
+export const PATH_CONTEXT_TOKEN = new InjectionToken<typeof PathContext>('PATH_CONTEXT_TOKEN');
+export const useRoutePath = () => useDependencyContext(PATH_CONTEXT_TOKEN);
 
 export const ActivatedRouteContext = createContext<Readonly<ActivatedRoute>>(defaultActivatedRoute);
-export const useActivatedRoute = () => useContext(ActivatedRouteContext);
+export const ACTIVATED_ROUTE_CONTEXT_TOKEN = new InjectionToken<typeof ActivatedRouteContext>(
+  'ACTIVATED_ROUTE_CONTEXT_TOKEN'
+);
+export const useActivatedRoute = () =>
+  useDependencyContext(ACTIVATED_ROUTE_CONTEXT_TOKEN) ?? defaultActivatedRoute;
 
 export const ActivatedRouteProvider: React.FC<Partial<ActivatedRoute>> = ({
   children,
@@ -40,18 +59,18 @@ export const ActivatedRouteProvider: React.FC<Partial<ActivatedRoute>> = ({
   );
 
   return (
-    <PathContext.Provider value={activatedRoute.path}>
-      <LoadingContext.Provider value={activatedRoute.loading}>
-        <QueryContext.Provider value={activatedRoute.query}>
-          <ParamContext.Provider value={activatedRoute.params}>
-            <DataContext.Provider value={activatedRoute.data}>
-              <ActivatedRouteContext.Provider value={activatedRoute}>
+    <InjectedContextProvider token={PATH_CONTEXT_TOKEN} value={activatedRoute.path}>
+      <InjectedContextProvider token={LOADING_CONTEXT_TOKEN} value={activatedRoute.loading}>
+        <InjectedContextProvider token={QUERY_CONTEXT_TOKEN} value={activatedRoute.query}>
+          <InjectedContextProvider token={PARAM_CONTEXT_TOKEN} value={activatedRoute.params}>
+            <InjectedContextProvider token={DATA_CONTEXT_TOKEN} value={activatedRoute.data}>
+              <InjectedContextProvider token={ACTIVATED_ROUTE_CONTEXT_TOKEN} value={activatedRoute}>
                 {children}
-              </ActivatedRouteContext.Provider>
-            </DataContext.Provider>
-          </ParamContext.Provider>
-        </QueryContext.Provider>
-      </LoadingContext.Provider>
-    </PathContext.Provider>
+              </InjectedContextProvider>
+            </InjectedContextProvider>
+          </InjectedContextProvider>
+        </InjectedContextProvider>
+      </InjectedContextProvider>
+    </InjectedContextProvider>
   );
 };

--- a/packages/fsapp/src/beta-app/router/context/button-context.web.tsx
+++ b/packages/fsapp/src/beta-app/router/context/button-context.web.tsx
@@ -1,14 +1,22 @@
-import { createContext, Fragment, useContext } from 'react';
+import { createContext, Fragment } from 'react';
+import { InjectionToken } from '@brandingbrand/fslinker';
+import { useDependencyContext } from '../../lib/use-dependency';
 
-export interface IButtonContext {
+export interface ButtonService {
   onPress(buttonId: string, callback: () => void): () => void;
   onPress(buttonId: string, componentId: string, callback: () => void): () => void;
 }
 
-export const ButtonContext = createContext<IButtonContext>({
+const DEFAULT_BUTTON_SERVICE: ButtonService = {
   onPress: () => () => undefined
-});
-export const useButtons = () => useContext(ButtonContext);
+};
+
+export const ButtonContext = createContext<ButtonService>(DEFAULT_BUTTON_SERVICE);
+export const BUTTON_CONTEXT_TOKEN = new InjectionToken<typeof ButtonContext>(
+  'BUTTON_CONTEXT_TOKEN'
+);
+export const useButtons = () =>
+  useDependencyContext(BUTTON_CONTEXT_TOKEN) ?? DEFAULT_BUTTON_SERVICE;
 
 export const ButtonProvider = Fragment;
 

--- a/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
+++ b/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
@@ -1,9 +1,20 @@
 import type { FSRouterHistory } from '../history';
 
-import { createContext, useContext } from 'react';
+import React, { createContext, FC } from 'react';
+import { InjectionToken } from '@brandingbrand/fslinker';
 
 import { dummyHistory } from '../history/history.dummy';
+import { InjectedContextProvider, useDependencyContext } from '../../lib/use-dependency';
 
 export const NavigatorContext = createContext<FSRouterHistory>(dummyHistory);
-export const NavigatorProvider = NavigatorContext.Provider;
-export const useNavigator = () => useContext(NavigatorContext);
+export const NAVIGATOR_CONTEXT_TOKEN = new InjectionToken<typeof NavigatorContext>(
+  'NAVIGATOR_CONTEXT_TOKEN'
+);
+export const useNavigator = () => useDependencyContext(NAVIGATOR_CONTEXT_TOKEN) ?? dummyHistory;
+
+export interface NavigatorProviderProps {
+  value: FSRouterHistory;
+}
+export const NavigatorProvider: FC<NavigatorProviderProps> = ({ value, children }) => (
+  <InjectedContextProvider token={NAVIGATOR_CONTEXT_TOKEN} value={value} children={children} />
+);

--- a/packages/fsapp/src/beta-app/router/index.ts
+++ b/packages/fsapp/src/beta-app/router/index.ts
@@ -1,4 +1,4 @@
-export { FSRouter } from './router';
+export { FSRouter, NAVIGATOR_TOKEN } from './router';
 export {
   NavigatorContext,
   useNavigator,

--- a/packages/fsapp/src/beta-app/router/index.ts
+++ b/packages/fsapp/src/beta-app/router/index.ts
@@ -16,7 +16,15 @@ export {
   useRouteQuery,
   ButtonContext,
   useButtons,
-  useButtonEffect
+  useButtonEffect,
+  ACTIVATED_ROUTE_CONTEXT_TOKEN,
+  BUTTON_CONTEXT_TOKEN,
+  DATA_CONTEXT_TOKEN,
+  LOADING_CONTEXT_TOKEN,
+  NAVIGATOR_CONTEXT_TOKEN,
+  PARAM_CONTEXT_TOKEN,
+  PATH_CONTEXT_TOKEN,
+  QUERY_CONTEXT_TOKEN
 } from './context';
 export { ScreenProps, makeScreen } from './make-screen';
 

--- a/packages/fsapp/src/beta-app/router/router.base.ts
+++ b/packages/fsapp/src/beta-app/router/router.base.ts
@@ -9,7 +9,7 @@ import type {
 
 import { Linking } from 'react-native';
 
-import { Injector } from '@brandingbrand/fslinker';
+import { InjectionToken, Injector } from '@brandingbrand/fslinker';
 
 import { MODAL_CONTEXT_TOKEN, ModalContext } from '../modal';
 import {
@@ -32,6 +32,8 @@ import {
 } from './context';
 import { getPath, resolveRoutes } from './utils';
 
+export const NAVIGATOR_TOKEN = new InjectionToken<FSRouterHistory>('NAVIGATOR');
+
 export abstract class FSRouterBase implements FSRouter {
   public static async register<T extends FSRouterBase>(
     this: FSRouterConstructor<T>,
@@ -51,6 +53,7 @@ export abstract class FSRouterBase implements FSRouter {
     Injector.provide({ provide: NAVIGATOR_CONTEXT_TOKEN, useValue: NavigatorContext });
     Injector.provide({ provide: MODAL_CONTEXT_TOKEN, useValue: ModalContext });
     Injector.provide({ provide: BUTTON_CONTEXT_TOKEN, useValue: ButtonContext });
+    Injector.provide({ provide: NAVIGATOR_TOKEN, useValue: history });
   }
 
   public async open(url: string): Promise<void> {

--- a/packages/fsapp/src/beta-app/router/router.base.ts
+++ b/packages/fsapp/src/beta-app/router/router.base.ts
@@ -9,6 +9,27 @@ import type {
 
 import { Linking } from 'react-native';
 
+import { Injector } from '@brandingbrand/fslinker';
+
+import { MODAL_CONTEXT_TOKEN, ModalContext } from '../modal';
+import {
+  ACTIVATED_ROUTE_CONTEXT_TOKEN,
+  ActivatedRouteContext,
+  BUTTON_CONTEXT_TOKEN,
+  ButtonContext,
+  DATA_CONTEXT_TOKEN,
+  DataContext,
+  LOADING_CONTEXT_TOKEN,
+  LoadingContext,
+  NAVIGATOR_CONTEXT_TOKEN,
+  NavigatorContext,
+  PARAM_CONTEXT_TOKEN,
+  ParamContext,
+  PATH_CONTEXT_TOKEN,
+  PathContext,
+  QUERY_CONTEXT_TOKEN,
+  QueryContext
+} from './context';
 import { getPath, resolveRoutes } from './utils';
 
 export abstract class FSRouterBase implements FSRouter {
@@ -20,7 +41,17 @@ export abstract class FSRouterBase implements FSRouter {
     return new this(mergedRoutes, options);
   }
 
-  constructor(public readonly routes: Routes, protected readonly history: FSRouterHistory) {}
+  constructor(public readonly routes: Routes, protected readonly history: FSRouterHistory) {
+    Injector.provide({ provide: LOADING_CONTEXT_TOKEN, useValue: LoadingContext });
+    Injector.provide({ provide: DATA_CONTEXT_TOKEN, useValue: DataContext });
+    Injector.provide({ provide: QUERY_CONTEXT_TOKEN, useValue: QueryContext });
+    Injector.provide({ provide: PARAM_CONTEXT_TOKEN, useValue: ParamContext });
+    Injector.provide({ provide: PATH_CONTEXT_TOKEN, useValue: PathContext });
+    Injector.provide({ provide: ACTIVATED_ROUTE_CONTEXT_TOKEN, useValue: ActivatedRouteContext });
+    Injector.provide({ provide: NAVIGATOR_CONTEXT_TOKEN, useValue: NavigatorContext });
+    Injector.provide({ provide: MODAL_CONTEXT_TOKEN, useValue: ModalContext });
+    Injector.provide({ provide: BUTTON_CONTEXT_TOKEN, useValue: ButtonContext });
+  }
 
   public async open(url: string): Promise<void> {
     const supported = await Linking.canOpenURL(url);

--- a/packages/fsapp/src/beta-app/router/router.tsx
+++ b/packages/fsapp/src/beta-app/router/router.tsx
@@ -28,6 +28,8 @@ import {
 import { FSRouterBase } from './router.base';
 import { trackView } from './utils';
 
+export { NAVIGATOR_TOKEN } from './router.base';
+
 // This is a hack. I am not happy about having to do this hack.
 // But it is required for Android. If no components are registered
 // Synchronously then errors are thrown and touch responses are eaten.

--- a/packages/fsapp/src/beta-app/router/router.web.tsx
+++ b/packages/fsapp/src/beta-app/router/router.web.tsx
@@ -14,9 +14,11 @@ import { Router } from 'react-router';
 import { Redirect, Route as Screen, Switch } from 'react-router-dom';
 import pathToRegexp from 'path-to-regexp';
 
+import { Injector } from '@brandingbrand/fslinker';
+
 import { buildPath, lazyComponent, StaticImplements } from '../utils';
 import { VersionOverlay } from '../development';
-import { WebShellProvider } from '../shell.web';
+import { WEB_SHELL_CONTEXT_TOKEN, WebShellContext, WebShellProvider } from '../shell.web';
 import { ModalProvider } from '../modal';
 
 import { ActivatedRouteProvider, defaultActivatedRoute, NavigatorProvider } from './context';
@@ -28,6 +30,7 @@ import { trackView } from './utils';
 export class FSRouter extends FSRouterBase {
   constructor(routes: Routes, private readonly options: RouterConfig & InternalRouterConfig) {
     super(routes, new History(routes));
+    Injector.provide({ provide: WEB_SHELL_CONTEXT_TOKEN, useValue: WebShellContext });
     this.registerRoutes();
   }
 

--- a/packages/fsapp/src/beta-app/router/router.web.tsx
+++ b/packages/fsapp/src/beta-app/router/router.web.tsx
@@ -26,6 +26,8 @@ import { FSRouterBase } from './router.base';
 import { History } from './history';
 import { trackView } from './utils';
 
+export { NAVIGATOR_TOKEN } from './router.base';
+
 @StaticImplements<FSRouterConstructor>()
 export class FSRouter extends FSRouterBase {
   constructor(routes: Routes, private readonly options: RouterConfig & InternalRouterConfig) {

--- a/packages/fsapp/src/beta-app/shell.web/index.ts
+++ b/packages/fsapp/src/beta-app/shell.web/index.ts
@@ -1,4 +1,9 @@
-export { WebShellContext, WebShellProvider, useWebShell } from './shell.context';
+export {
+  WebShellContext,
+  WEB_SHELL_CONTEXT_TOKEN,
+  WebShellProvider,
+  useWebShell
+} from './shell.context';
 export { makeDrawer } from './make-drawer';
 export type {
   WebShell,

--- a/packages/fslinker/README.md
+++ b/packages/fslinker/README.md
@@ -1,0 +1,116 @@
+# `fslinker`
+
+> Simple Dependency Injection
+
+## Description
+
+This library provides an easy way to provide and consume dependencies with static references.
+It is important that static references are used so that dependencies can be consumed even when
+used in externally bundled code.
+
+### The Problem
+
+Let's say a you had a dependency like a React Context like so
+
+```ts
+export const SomeContext = createContext('defaultValue');
+```
+
+If you used this context in a bundle the reference to `SomeContext` would be encapsulated in that bundle.
+If you then tried to make another bundle also using `SomeContext` it would get a new `SomeContext` even
+if the first bundle is already loaded on the page.
+
+This would work fine so long as the expected behavior is that the two bundles operate independently
+however if setting the context in one bundle was expected to affect the other then it would not behave
+as expected.
+
+### The Solution
+
+In order to preserve the same reference across bundles you can store the reference on the global object
+and then check if it exist and reuse that same value if it already exist. This library handles this
+for you by maintain a `GlobalInjectorCache` which will use the global object to store and reuse the
+previously defined references.
+
+## Example
+
+### Basic Usage
+
+```ts
+// Define a token to reference the value. Note that the `uniqueKey`
+// should be unique
+export const SOME_TOKEN = new InjectionToken<number>('SOME_TOKEN');
+
+// Then provide the value for the token.
+// Note that this should only occur once.
+Injector.provide({ provide: SOME_TOKEN, useValue: 9 });
+
+
+// Then you can get the value back anywhere in your application.
+const theValue = Injector.get(SOME_TOKEN); // 9
+```
+
+### Factory Usage
+
+```ts
+// Just like before, define a token
+export const SOME_TOKEN = new InjectionToken<number>('SOME_TOKEN');
+
+// when providing the value you can then use a function
+// which will be executed when creating the provider
+Injector.provide({ provide: SOME_TOKEN, useFactory: () => 5 + 5 });
+
+
+// and then you can use the calculated value
+const theValue = Injector.get(SOME_TOKEN); // 10
+```
+
+This pattern is more useful when you are providing a value
+that depends on other provided values.
+
+```ts
+export const OTHER_TOKEN = new InjectionToken<number>('OTHER_TOKEN');
+export const SOME_TOKEN = new InjectionToken<number>('SOME_TOKEN');
+
+Injector.provide({ provide: OTHER_TOKEN, useValue: 12 });
+
+// You can use `deps` to define a list of InjectionTokens or values
+// that will be passed in to the factory function when creating the value
+Injector.provide({ provide: SOME_TOKEN, useFactory: other => other * 10, deps: [OTHER_TOKEN] });
+
+const theValue = Injector.get(SOME_TOKEN); // 120
+```
+
+### Class Usage
+
+With classes there are some decorators which take care of a lot of the work for you.
+
+```ts
+// Declare Tokens
+export const OTHER_TOKEN = new InjectionToken<OtherService>('OTHER_TOKEN');
+export const SOME_TOKEN = new InjectionToken<SomeService>('SOME_TOKEN');
+
+// `@Injectable()` will automatically run `Injector.provide()` for you.
+@Injectable(OTHER_TOKEN)
+export class OtherService {
+  public doSomething(): void {
+    return;
+  }
+}
+
+
+@Injectable(SOME_TOKEN)
+export class SomeService {
+  // Using `@Inject()` will use the Injector to get the dependency.
+  constructor(@Inject(OTHER_TOKEN) protected readonly other: OtherService) {}
+
+  public init(): void {
+    this.other.doSomething();
+  }
+}
+
+
+// Getting a provided service will give you the singleton instance
+// that was constructed when the dependency was provided.
+const someService = Injector.get(SOME_TOKEN);
+someService.init();
+```

--- a/packages/fslinker/__tests__/class.spec.ts
+++ b/packages/fslinker/__tests__/class.spec.ts
@@ -1,0 +1,107 @@
+// tslint:disable: max-classes-per-file
+import { Inject, Injectable, InjectionToken, Injector, LocalInjectorCache } from '../src';
+
+describe('injected class', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    injector = new Injector(new LocalInjectorCache());
+  });
+
+  it('should not throw an error when injecting a class', () => {
+    class Example {}
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    expect(() => injector.provide({ provide: token, useClass: Example })).not.toThrow();
+  });
+
+  it('should provide an instance of an injected class', () => {
+    class Example {}
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    injector.provide({ provide: token, useClass: Example });
+
+    const instance = injector.get(token);
+    expect(instance).toBeInstanceOf(Example);
+  });
+
+  it('should inject defined deps', () => {
+    class Dependency {}
+    class Example {
+      constructor(public readonly dep: Dependency) {}
+    }
+
+    const dependencyToken = new InjectionToken<Dependency>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    injector.provide({ provide: dependencyToken, useClass: Dependency });
+    injector.provide({ provide: token, useClass: Example, deps: [dependencyToken] });
+
+    const instance = injector.get(token);
+    expect(instance?.dep).toBeInstanceOf(Dependency);
+  });
+
+  it('should throw if an incorrect number of dependencies is provided', () => {
+    class Dependency {}
+    class Example {
+      constructor(public readonly dep: Dependency) {}
+    }
+
+    const dependencyToken = new InjectionToken<Dependency>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    injector.provide({ provide: dependencyToken, useClass: Dependency });
+    expect(() =>
+      injector.provide({
+        provide: token,
+        useClass: Example,
+        // @ts-expect-error
+        deps: [dependencyToken, dependencyToken]
+      })
+    ).toThrow(TypeError);
+  });
+
+  it('should throw if a dependency is missing', () => {
+    class Dependency {}
+    class Example {
+      constructor(public readonly dep: Dependency) {}
+    }
+
+    const dependencyToken = new InjectionToken<Dependency>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    expect(() =>
+      injector.provide({
+        provide: token,
+        useClass: Example,
+        deps: [dependencyToken]
+      })
+    ).toThrow(TypeError);
+  });
+
+  it('should automatically apply decorated dependencies', () => {
+    const dependencyToken = new InjectionToken<Dependency>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    class Dependency {}
+    class Example {
+      constructor(@Inject(dependencyToken) public readonly dep: Dependency) {}
+    }
+
+    injector.provide({ provide: dependencyToken, useClass: Dependency });
+    injector.provide({ provide: token, useClass: Example });
+
+    const instance = injector.get(token);
+    expect(instance?.dep).toBeInstanceOf(Dependency);
+  });
+
+  it('should automatically provide injectable classes', () => {
+    const token = new InjectionToken<Example>('CLASS_TOKEN');
+
+    @Injectable(token, injector)
+    class Example {}
+
+    const instance = injector.get(token);
+    expect(instance).toBeInstanceOf(Example);
+  });
+});

--- a/packages/fslinker/__tests__/factory.spec.ts
+++ b/packages/fslinker/__tests__/factory.spec.ts
@@ -1,0 +1,68 @@
+import { InjectionToken, Injector, LocalInjectorCache } from '../src';
+
+
+describe('injected factory', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    injector = new Injector(new LocalInjectorCache());
+  });
+
+  it('should not throw an error when injecting a factory', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    expect(() => injector.provide({ provide: token, useFactory: () => 9 })).not.toThrow();
+  });
+
+  it('should provide the returned value of the factory', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    injector.provide({ provide: token, useFactory: () => 10 + 20 });
+
+    const value = injector.get(token);
+    expect(value).toBe(30);
+  });
+
+  it('should inject dependencies', () => {
+    const dependencyToken = new InjectionToken<number>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+
+    injector.provide({
+      provide: dependencyToken,
+      useValue: 20
+    });
+    injector.provide({
+      provide: token,
+      useFactory: (dependency: number) => dependency * 10,
+      deps: [dependencyToken]
+    });
+
+    const value = injector.get(token);
+    expect(value).toBe(200);
+  });
+
+  it('should throw if the incorrect number of dependencies is provided', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+
+    expect(() =>
+      injector.provide({
+        provide: token,
+        useFactory: (dependency: number) => dependency * 10,
+        // @ts-expect-error
+        deps: []
+      })
+    ).toThrowError(TypeError);
+  });
+
+  it('should throw if a dependency is not provided', () => {
+    const dependencyToken = new InjectionToken<number>('DEPENDENCY_TOKEN');
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+
+    expect(() =>
+      injector.provide({
+        provide: token,
+        useFactory: (dependency: number) => dependency * 10,
+        deps: [dependencyToken]
+      })
+    ).toThrowError(TypeError);
+  });
+});
+

--- a/packages/fslinker/__tests__/global.spec.ts
+++ b/packages/fslinker/__tests__/global.spec.ts
@@ -12,4 +12,14 @@ describe('global cache', () => {
     const value = Injector.get(token);
     expect(value).toBe(9);
   });
+
+  it('should throw in an invalid provider is provided', () => {
+    const token = new InjectionToken<number>('some_token');
+
+    // @ts-expect-error
+    expect(() => Injector.provide({ provide: token })).toThrow(TypeError);
+
+    // @ts-expect-error
+    expect(() => Injector.provide({ useValue: 9 })).toThrow(TypeError);
+  });
 });

--- a/packages/fslinker/__tests__/global.spec.ts
+++ b/packages/fslinker/__tests__/global.spec.ts
@@ -1,0 +1,15 @@
+import { InjectionToken, Injector } from '../src';
+
+describe('global cache', () => {
+  beforeEach(() => {
+    Injector.reset();
+  });
+
+  it('should maintain injected providers', () => {
+    const token = new InjectionToken<number>('some_token');
+    Injector.provide({ provide: token, useValue: 9 });
+
+    const value = Injector.get(token);
+    expect(value).toBe(9);
+  });
+});

--- a/packages/fslinker/__tests__/value.spec.ts
+++ b/packages/fslinker/__tests__/value.spec.ts
@@ -1,0 +1,56 @@
+import { InjectionToken, Injector, LocalInjectorCache } from '../src';
+
+describe('injected value', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    injector = new Injector(new LocalInjectorCache());
+  });
+
+  it('should not throw an error when injecting a value', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    expect(() => injector.provide({ provide: token, useValue: 9 })).not.toThrow();
+  });
+
+  it('should return the provided value', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    injector.provide({ provide: token, useValue: 9 });
+
+    const value = injector.get(token);
+    expect(value).toBe(9);
+  });
+
+  it('should throw when providing a duplicate token', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    injector.provide({ provide: token, useValue: 9 });
+
+    expect(() => injector.provide({ provide: token, useValue: 9 })).toThrowError(/duplicate/i);
+  });
+
+  it('should maintain references', () => {
+    const token = new InjectionToken<never[]>('ARRAY_TOKEN');
+    const array: never[] = [];
+    injector.provide({ provide: token, useValue: array });
+
+    const value = injector.get(token);
+    expect(value).toBe(array);
+  });
+
+  it('should maintain references for duplicated tokens', () => {
+    const originalToken = new InjectionToken<never[]>('ARRAY_TOKEN');
+    const array: never[] = [];
+    injector.provide({ provide: originalToken, useValue: array });
+
+    const duplicateToken = new InjectionToken<number>('ARRAY_TOKEN');
+    const value = injector.get(duplicateToken);
+
+    expect(value).toBe(array);
+  });
+
+  it('should return undefined for unprovided values', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+    const value = injector.get(token);
+
+    expect(value).toBeUndefined();
+  });
+});

--- a/packages/fslinker/__tests__/value.spec.ts
+++ b/packages/fslinker/__tests__/value.spec.ts
@@ -53,4 +53,10 @@ describe('injected value', () => {
 
     expect(value).toBeUndefined();
   });
+
+  it('should throw if a required dependency is missing', () => {
+    const token = new InjectionToken<number>('NUMBER_TOKEN');
+
+    expect(() => injector.require(token)).toThrow(TypeError);
+  });
 });

--- a/packages/fslinker/package.json
+++ b/packages/fslinker/package.json
@@ -7,8 +7,8 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
-    "prepare": "tsc",
-    "tsc:watch": "tsc -w --preserveWatchOutput"
+    "prepare": "tsc -p ./tsconfig.lib.json",
+    "tsc:watch": "tsc -p ./tsconfig.lib.json -w --preserveWatchOutput"
   },
   "dependencies": {},
   "publishConfig": {

--- a/packages/fslinker/package.json
+++ b/packages/fslinker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@brandingbrand/fslinker",
+  "sideEffects": false,
+  "version": "11.0.1-alpha.9",
+  "description": "Dependency Injection",
+  "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "prepare": "tsc",
+    "tsc:watch": "tsc -w --preserveWatchOutput"
+  },
+  "dependencies": {},
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "gitHead": "6261ffc8c139f8986f531ccca430900d75570ccc"
+}

--- a/packages/fslinker/src/cache/cache.ts
+++ b/packages/fslinker/src/cache/cache.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '../providers';
+
+export abstract class InjectorCache {
+  abstract get<T>(token: InjectionToken<T>): T | undefined;
+  abstract provide<T>(token: InjectionToken<T>, value: T): void;
+  abstract reset(): void;
+}

--- a/packages/fslinker/src/cache/global-cache.ts
+++ b/packages/fslinker/src/cache/global-cache.ts
@@ -1,0 +1,61 @@
+import { InjectionToken } from '../providers';
+import { InjectorCache } from './cache';
+
+// In order for the linker to be deterministic and used
+// across bundles the key needs to be a statically known
+// value that can be referenced in each bundle independently
+// as such a private symbol would not be suitable.
+const GLOBAL_CACHE_KEY = '__FLAGSHIP_LINKER_GLOBAL_CACHE__';
+
+declare global {
+  interface Window {
+    [GLOBAL_CACHE_KEY]: Map<string, unknown>;
+  }
+
+  namespace NodeJS {
+    interface Global {
+      [GLOBAL_CACHE_KEY]: Map<string, unknown>;
+    }
+  }
+}
+
+export class GlobalInjectorCache extends InjectorCache {
+  private readonly globalMap: Map<string, unknown>;
+
+  constructor() {
+    super();
+
+    const globalObject = typeof global !== undefined ? global : window;
+
+    if (globalObject === undefined) {
+      throw new TypeError(
+        `${GlobalInjectorCache.name}: Unsupported environment, the global object could not be found`
+      );
+    }
+
+    if (globalObject[GLOBAL_CACHE_KEY] === undefined) {
+      globalObject[GLOBAL_CACHE_KEY] = new Map();
+    }
+
+    this.globalMap = globalObject[GLOBAL_CACHE_KEY];
+  }
+
+  public get<T>(token: InjectionToken<T>): T | undefined {
+    return this.globalMap.get(token.uniqueKey) as T;
+  }
+
+  public provide<T>(token: InjectionToken<T>, value: T): void {
+    if (this.globalMap.has(token.uniqueKey)) {
+      throw new Error(
+        // tslint:disable-next-line: ter-max-len
+        `${GlobalInjectorCache.name}: Duplicate provider, token ${token.uniqueKey} is already provided`
+      );
+    }
+
+    this.globalMap.set(token.uniqueKey, value);
+  }
+
+  public reset(): void {
+    this.globalMap.clear();
+  }
+}

--- a/packages/fslinker/src/cache/index.ts
+++ b/packages/fslinker/src/cache/index.ts
@@ -1,0 +1,3 @@
+export * from './cache';
+export * from './global-cache';
+export * from './local-cache';

--- a/packages/fslinker/src/cache/local-cache.ts
+++ b/packages/fslinker/src/cache/local-cache.ts
@@ -1,0 +1,27 @@
+import { InjectionToken } from '../providers';
+import { InjectorCache } from './cache';
+import { GlobalInjectorCache } from './global-cache';
+
+export class LocalInjectorCache extends InjectorCache {
+  private readonly globalFallback: InjectorCache = new GlobalInjectorCache();
+  private readonly map: Map<string, unknown> = new Map();
+
+  public get<T>(token: InjectionToken<T>): T | undefined {
+    return (this.map.get(token.uniqueKey) as T) ?? this.globalFallback.get(token);
+  }
+
+  public provide<T>(token: InjectionToken<T>, value: T): void {
+    if (this.map.has(token.uniqueKey)) {
+      throw new Error(
+        // tslint:disable-next-line: ter-max-len
+        `${LocalInjectorCache.name}: Duplicate provider, token ${token.uniqueKey} is already provided`
+      );
+    }
+
+    this.map.set(token.uniqueKey, value);
+  }
+
+  public reset(): void {
+    this.map.clear();
+  }
+}

--- a/packages/fslinker/src/index.ts
+++ b/packages/fslinker/src/index.ts
@@ -5,8 +5,11 @@ export { InjectorCache, GlobalInjectorCache, LocalInjectorCache } from './cache'
 export {
   InjectionToken,
   ValueProvider,
-  ClassProvider,
-  FactoryProvider,
+  InjectedClassProvider,
+  InjectedFactoryProvider,
   Provider,
-  StaticFactoryProvider
+  BasicFactoryProvider,
+  BasicClassProvider,
+  ClassProvider,
+  FactoryProvider
 } from './providers';

--- a/packages/fslinker/src/index.ts
+++ b/packages/fslinker/src/index.ts
@@ -1,0 +1,12 @@
+export { Injector } from './injector';
+export { Inject, getDependencies } from './inject';
+export { Injectable } from './injectable';
+export { InjectorCache, GlobalInjectorCache, LocalInjectorCache } from './cache';
+export {
+  InjectionToken,
+  ValueProvider,
+  ClassProvider,
+  FactoryProvider,
+  Provider,
+  StaticFactoryProvider
+} from './providers';

--- a/packages/fslinker/src/inject.ts
+++ b/packages/fslinker/src/inject.ts
@@ -1,0 +1,26 @@
+import { InjectionToken, OfToken } from './providers';
+
+const DEPENDENCIES_SYMBOL = Symbol('DEPENDENCIES_SYMBOL');
+
+interface InjectedClass<D extends unknown[], T = unknown> {
+  [DEPENDENCIES_SYMBOL]?: InjectionToken[];
+  new (...deps: D): T;
+}
+
+export const Inject =
+  (token: InjectionToken) =>
+  <D extends unknown[], T = unknown>(
+    target: InjectedClass<D, T>,
+    _key: string | symbol,
+    index: number
+  ) => {
+    const prevDependencies = target[DEPENDENCIES_SYMBOL] ?? [];
+
+    prevDependencies[index] = token;
+
+    target[DEPENDENCIES_SYMBOL] = prevDependencies;
+  };
+
+export const getDependencies = <D extends unknown[], T = unknown>(target: InjectedClass<D, T>) => {
+  return (target[DEPENDENCIES_SYMBOL] ?? []) as OfToken<D>;
+};

--- a/packages/fslinker/src/injectable.ts
+++ b/packages/fslinker/src/injectable.ts
@@ -1,0 +1,8 @@
+import { Injector } from './injector';
+import { InjectionToken } from './providers';
+
+export const Injectable =
+  <T, C extends new (...dependencies: any[]) => T>(token: InjectionToken<T>, injector?: Injector) =>
+  (target: C) => {
+    (injector ?? Injector).provide({ provide: token, useClass: target });
+  };

--- a/packages/fslinker/src/injector.ts
+++ b/packages/fslinker/src/injector.ts
@@ -1,10 +1,24 @@
-import { InjectionToken, Provider } from './providers';
+import {
+  BasicClassProvider,
+  BasicFactoryProvider,
+  ClassProvider,
+  FactoryProvider,
+  InjectedClassProvider,
+  InjectedFactoryProvider,
+  InjectionToken,
+  Provider,
+  ValueProvider
+} from './providers';
 import { GlobalInjectorCache, InjectorCache } from './cache';
 import { getDependencies } from './inject';
 
 export class Injector {
   public static get<T>(token: InjectionToken<T>): T | undefined {
     return this.injector.get(token);
+  }
+
+  public static require<T>(token: InjectionToken<T>): T extends undefined ? never : T {
+    return this.injector.require(token);
   }
 
   public static provide<D extends unknown[], T>(provider: Provider<D, T>): void {
@@ -23,92 +37,112 @@ export class Injector {
     return this.cache.get(token);
   }
 
+  public require<T>(token: InjectionToken<T>): T extends undefined ? never : T {
+    const dependency = this.cache.get(token);
+    if (dependency === undefined) {
+      throw new TypeError(`${Injector.name}: Required ${token.uniqueKey} is undefined`);
+    }
+
+    return dependency as T extends undefined ? never : T;
+  }
+
   public provide<D extends unknown[], T>(provider: Provider<D, T>): void {
+    if (!('provide' in provider)) {
+      throw new TypeError(
+        // tslint:disable-next-line: ter-max-len
+        `${Injector.name}: Expected provider to specify a provide token, but none was provided`
+      );
+    }
+
     if ('useValue' in provider) {
-      this.cache.provide(provider.provide, provider.useValue);
-    }
-
-    if ('useFactory' in provider) {
-      if ('deps' in provider) {
-        const deps = provider.deps.map(depOrToken => {
-          if (depOrToken instanceof InjectionToken) {
-            const dep = this.get(depOrToken);
-            if (!dep) {
-              throw new TypeError(
-                // tslint:disable-next-line: ter-max-len
-                `${Injector.name}: Token ${depOrToken.uniqueKey} could not be found but is required by ${provider.provide.uniqueKey}`
-              );
-            }
-
-            return dep;
-          }
-
-          return depOrToken;
-        }) as Parameters<typeof provider['useFactory']>;
-
-        if (deps.length !== provider.useFactory.length) {
-          // tslint:disable-next-line: ter-max-len
-          throw new TypeError(`${Injector.name}: ${provider.useFactory.name} requires ${provider.useFactory.length} dependencies but recieved ${deps.length} dependencies`);
-        }
-
-        const value = provider.useFactory(...deps);
-        this.cache.provide(provider.provide, value);
-      } else {
-        const value = provider.useFactory();
-        this.cache.provide(provider.provide, value);
-      }
-    }
-
-    if ('useClass' in provider) {
-      if ('deps' in provider) {
-        const deps = provider.deps.map(depOrToken => {
-          if (depOrToken instanceof InjectionToken) {
-            const dep = this.get(depOrToken);
-            if (!dep) {
-              throw new TypeError(
-                // tslint:disable-next-line: ter-max-len
-                `${Injector.name}: Token ${depOrToken.uniqueKey} could not be found but is required by ${provider.provide.uniqueKey}`
-              );
-            }
-
-            return dep;
-          }
-
-          return depOrToken;
-        }) as ConstructorParameters<typeof provider['useClass']>;
-
-        if (deps.length !== provider.useClass.length) {
-          // tslint:disable-next-line: ter-max-len
-          throw new TypeError(`${Injector.name}: ${provider.useClass.name} requires ${provider.useClass.length} dependencies but recieved ${deps.length} dependencies`);
-        }
-
-        const value = new provider.useClass(...deps);
-        this.cache.provide(provider.provide, value);
-      } else {
-        const deps = getDependencies(provider.useClass).map(token => {
-          const dep = this.get(token);
-          if (!dep) {
-            throw new TypeError(
-              // tslint:disable-next-line: ter-max-len
-              `${Injector.name}: Token ${token.uniqueKey} could not be found but is required by ${provider.useClass.name}`
-            );
-          }
-
-          return dep;
-        }) as ConstructorParameters<typeof provider['useClass']>;
-
-        if (deps.length !== provider.useClass.length) {
-          // tslint:disable-next-line: ter-max-len
-          throw new TypeError(`${Injector.name}: ${provider.useClass.name} requires ${provider.useClass.length} dependencies but recieved ${deps.length} dependencies`);
-        }
-
-        const value = new provider.useClass(...deps);
-        this.cache.provide(provider.provide, value);
-      }
+      this.provideValue(provider);
+    } else if ('useFactory' in provider) {
+      this.provideFactory(provider);
+    } else if ('useClass' in provider) {
+      this.provideClass(provider);
+    } else {
+      throw new TypeError(
+        // tslint:disable-next-line: ter-max-len
+        `${Injector.name}: Expected provider to provide either a value, factory or class, but none was provided`
+      );
     }
   }
 
   public reset(): void {
     this.cache.reset();
+  }
+
+  private verifyDeps(target: Function, deps: unknown[]): void | never {
+    if (deps.length !== target.length) {
+      throw new TypeError(
+        // tslint:disable-next-line: ter-max-len
+        `${Injector.name}: ${target.name} requires ${target.length} dependencies but recieved ${deps.length} dependencies`
+      );
+    }
+  }
+
+  private requireDep<T>(depOrToken: T | InjectionToken<T>): T {
+    if (depOrToken instanceof InjectionToken) {
+      return this.require(depOrToken);
+    }
+
+    return depOrToken;
+  }
+
+  private provideValue<T>(provider: ValueProvider<T>): void {
+    this.cache.provide(provider.provide, provider.useValue);
+  }
+
+  private provideFactory<D extends unknown[], T>(provider: FactoryProvider<D, T>): void {
+    if ('deps' in provider) {
+      this.provideFactoryWithDeps(provider);
+    } else {
+      this.provideStaticFactory(provider);
+    }
+  }
+
+  private provideFactoryWithDeps<D extends unknown[], T>(
+    provider: InjectedFactoryProvider<D, T>
+  ): void {
+    const deps = provider.deps.map(depOrToken => this.requireDep(depOrToken));
+    this.verifyDeps(provider.useFactory, deps);
+
+    const value = provider.useFactory(...(deps as Parameters<typeof provider['useFactory']>));
+    this.cache.provide(provider.provide, value);
+  }
+
+  private provideStaticFactory<T>(provider: BasicFactoryProvider<T>): void {
+    const value = provider.useFactory();
+    this.cache.provide(provider.provide, value);
+  }
+
+  private provideClass<D extends unknown[], T>(provider: ClassProvider<D, T>): void {
+    if ('deps' in provider) {
+      this.provideClassWithDeps(provider);
+    } else {
+      this.provideStaticClass(provider);
+    }
+  }
+
+  private provideClassWithDeps<D extends unknown[], T>(
+    provider: InjectedClassProvider<D, T>
+  ): void {
+    const deps = provider.deps.map(depOrToken => this.requireDep(depOrToken));
+    this.verifyDeps(provider.useClass, deps);
+
+    const value = new provider.useClass(
+      ...(deps as ConstructorParameters<typeof provider['useClass']>)
+    );
+    this.cache.provide(provider.provide, value);
+  }
+
+  private provideStaticClass<D extends unknown[], T>(provider: BasicClassProvider<D, T>): void {
+    const deps = getDependencies(provider.useClass).map(token => this.require(token));
+    this.verifyDeps(provider.useClass, deps);
+
+    const value = new provider.useClass(
+      ...(deps as ConstructorParameters<typeof provider['useClass']>)
+    );
+    this.cache.provide(provider.provide, value);
   }
 }

--- a/packages/fslinker/src/injector.ts
+++ b/packages/fslinker/src/injector.ts
@@ -1,0 +1,114 @@
+import { InjectionToken, Provider } from './providers';
+import { GlobalInjectorCache, InjectorCache } from './cache';
+import { getDependencies } from './inject';
+
+export class Injector {
+  public static get<T>(token: InjectionToken<T>): T | undefined {
+    return this.injector.get(token);
+  }
+
+  public static provide<D extends unknown[], T>(provider: Provider<D, T>): void {
+    this.injector.provide(provider);
+  }
+
+  public static reset(): void {
+    this.injector.reset();
+  }
+
+  private static injector: Injector = new Injector(new GlobalInjectorCache());
+
+  constructor(private readonly cache: InjectorCache) {}
+
+  public get<T>(token: InjectionToken<T>): T | undefined {
+    return this.cache.get(token);
+  }
+
+  public provide<D extends unknown[], T>(provider: Provider<D, T>): void {
+    if ('useValue' in provider) {
+      this.cache.provide(provider.provide, provider.useValue);
+    }
+
+    if ('useFactory' in provider) {
+      if ('deps' in provider) {
+        const deps = provider.deps.map(depOrToken => {
+          if (depOrToken instanceof InjectionToken) {
+            const dep = this.get(depOrToken);
+            if (!dep) {
+              throw new TypeError(
+                // tslint:disable-next-line: ter-max-len
+                `${Injector.name}: Token ${depOrToken.uniqueKey} could not be found but is required by ${provider.provide.uniqueKey}`
+              );
+            }
+
+            return dep;
+          }
+
+          return depOrToken;
+        }) as Parameters<typeof provider['useFactory']>;
+
+        if (deps.length !== provider.useFactory.length) {
+          // tslint:disable-next-line: ter-max-len
+          throw new TypeError(`${Injector.name}: ${provider.useFactory.name} requires ${provider.useFactory.length} dependencies but recieved ${deps.length} dependencies`);
+        }
+
+        const value = provider.useFactory(...deps);
+        this.cache.provide(provider.provide, value);
+      } else {
+        const value = provider.useFactory();
+        this.cache.provide(provider.provide, value);
+      }
+    }
+
+    if ('useClass' in provider) {
+      if ('deps' in provider) {
+        const deps = provider.deps.map(depOrToken => {
+          if (depOrToken instanceof InjectionToken) {
+            const dep = this.get(depOrToken);
+            if (!dep) {
+              throw new TypeError(
+                // tslint:disable-next-line: ter-max-len
+                `${Injector.name}: Token ${depOrToken.uniqueKey} could not be found but is required by ${provider.provide.uniqueKey}`
+              );
+            }
+
+            return dep;
+          }
+
+          return depOrToken;
+        }) as ConstructorParameters<typeof provider['useClass']>;
+
+        if (deps.length !== provider.useClass.length) {
+          // tslint:disable-next-line: ter-max-len
+          throw new TypeError(`${Injector.name}: ${provider.useClass.name} requires ${provider.useClass.length} dependencies but recieved ${deps.length} dependencies`);
+        }
+
+        const value = new provider.useClass(...deps);
+        this.cache.provide(provider.provide, value);
+      } else {
+        const deps = getDependencies(provider.useClass).map(token => {
+          const dep = this.get(token);
+          if (!dep) {
+            throw new TypeError(
+              // tslint:disable-next-line: ter-max-len
+              `${Injector.name}: Token ${token.uniqueKey} could not be found but is required by ${provider.useClass.name}`
+            );
+          }
+
+          return dep;
+        }) as ConstructorParameters<typeof provider['useClass']>;
+
+        if (deps.length !== provider.useClass.length) {
+          // tslint:disable-next-line: ter-max-len
+          throw new TypeError(`${Injector.name}: ${provider.useClass.name} requires ${provider.useClass.length} dependencies but recieved ${deps.length} dependencies`);
+        }
+
+        const value = new provider.useClass(...deps);
+        this.cache.provide(provider.provide, value);
+      }
+    }
+  }
+
+  public reset(): void {
+    this.cache.reset();
+  }
+}

--- a/packages/fslinker/src/providers.ts
+++ b/packages/fslinker/src/providers.ts
@@ -4,11 +4,11 @@ export class InjectionToken<T = unknown> {
 }
 
 export type OfToken<A extends any[]> = {
-  [K in keyof A]: InjectionToken<A[K]>
+  [K in keyof A]: InjectionToken<A[K]>;
 };
 
 export type OrToken<A extends any[]> = {
-  [K in keyof A]: A[K] | InjectionToken<A[K]>
+  [K in keyof A]: A[K] | InjectionToken<A[K]>;
 };
 
 export interface ValueProvider<T = unknown> {
@@ -16,31 +16,37 @@ export interface ValueProvider<T = unknown> {
   useValue: T;
 }
 
-export interface StaticClassProvider<D extends unknown[], T = undefined> {
+export interface BasicClassProvider<D extends unknown[], T = undefined> {
   provide: InjectionToken<T>;
   useClass: new (...dependencies: D) => T;
 }
 
-export interface ClassProvider<D extends unknown[], T = undefined> {
+export interface InjectedClassProvider<D extends unknown[], T = undefined> {
   provide: InjectionToken<T>;
   useClass: new (...dependencies: D) => T;
   deps: OrToken<D>;
 }
 
-export interface StaticFactoryProvider<T = unknown> {
+export type ClassProvider<D extends unknown[], T = unknown> =
+  | BasicClassProvider<D, T>
+  | InjectedClassProvider<D, T>;
+
+export interface BasicFactoryProvider<T = unknown> {
   provide: InjectionToken<T>;
   useFactory: () => T;
 }
 
-export interface FactoryProvider<D extends unknown[], T = unknown> {
+export interface InjectedFactoryProvider<D extends unknown[], T = unknown> {
   provide: InjectionToken<T>;
   useFactory: (...dependencies: D) => T;
   deps: OrToken<D>;
 }
 
+export type FactoryProvider<D extends unknown[], T = unknown> =
+  | BasicFactoryProvider<T>
+  | InjectedFactoryProvider<D, T>;
+
 export type Provider<D extends unknown[], T = unknown> =
   | ValueProvider<T>
-  | StaticClassProvider<D, T>
   | ClassProvider<D, T>
-  | StaticFactoryProvider<T>
   | FactoryProvider<D, T>;

--- a/packages/fslinker/src/providers.ts
+++ b/packages/fslinker/src/providers.ts
@@ -1,0 +1,46 @@
+export class InjectionToken<T = unknown> {
+  protected readonly brand: T | undefined;
+  constructor(public readonly uniqueKey: string) {}
+}
+
+export type OfToken<A extends any[]> = {
+  [K in keyof A]: InjectionToken<A[K]>
+};
+
+export type OrToken<A extends any[]> = {
+  [K in keyof A]: A[K] | InjectionToken<A[K]>
+};
+
+export interface ValueProvider<T = unknown> {
+  provide: InjectionToken<T>;
+  useValue: T;
+}
+
+export interface StaticClassProvider<D extends unknown[], T = undefined> {
+  provide: InjectionToken<T>;
+  useClass: new (...dependencies: D) => T;
+}
+
+export interface ClassProvider<D extends unknown[], T = undefined> {
+  provide: InjectionToken<T>;
+  useClass: new (...dependencies: D) => T;
+  deps: OrToken<D>;
+}
+
+export interface StaticFactoryProvider<T = unknown> {
+  provide: InjectionToken<T>;
+  useFactory: () => T;
+}
+
+export interface FactoryProvider<D extends unknown[], T = unknown> {
+  provide: InjectionToken<T>;
+  useFactory: (...dependencies: D) => T;
+  deps: OrToken<D>;
+}
+
+export type Provider<D extends unknown[], T = unknown> =
+  | ValueProvider<T>
+  | StaticClassProvider<D, T>
+  | ClassProvider<D, T>
+  | StaticFactoryProvider<T>
+  | FactoryProvider<D, T>;

--- a/packages/fslinker/tsconfig.json
+++ b/packages/fslinker/tsconfig.json
@@ -1,12 +1,7 @@
 {
   "extends": "../../tsconfig/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
+    "composite": true
   },
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "dist/"
-  ]
+  "references": [{ "path": "./tsconfig.lib.json" }, { "path": "./tsconfig.spec.json" }]
 }

--- a/packages/fslinker/tsconfig.json
+++ b/packages/fslinker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "dist/"
+  ]
+}

--- a/packages/fslinker/tsconfig.lib.json
+++ b/packages/fslinker/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "dist/"
+  ]
+}

--- a/packages/fslinker/tsconfig.spec.json
+++ b/packages/fslinker/tsconfig.spec.json
@@ -1,12 +1,11 @@
 {
-  "extends": "../../tsconfig/tsconfig.base.json",
+  "extends": "../../tsconfig/tsconfig.jest.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "__tests__",
     "outDir": "dist"
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts",
     "dist/"
   ]
 }

--- a/packages/fslinker/tsconfig.spec.json
+++ b/packages/fslinker/tsconfig.spec.json
@@ -1,11 +1,14 @@
 {
-  "extends": "../../tsconfig/tsconfig.jest.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "__tests__",
-    "outDir": "dist"
+    "rootDir": ".",
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "lib": ["esnext"],
+    "types": ["jest"]
   },
+  "include": ["**/*.spec.ts", "**/*.test.ts", "src/**/*.ts"],
   "exclude": [
-    "**/*.test.ts",
     "dist/"
   ]
 }


### PR DESCRIPTION
## Description

This adds in a dependency injection library `fslinker`
This updates all context within `fsapp` to be statically referenced by the `fslinker` library
This assures that references will be maintained even when used across bundles
This adds in several `InjectionTokens` for things like the redux store, the API defined for the app, and the navigator, so that they can be injected anywhere regardless of context.