### PR TITLE
Feat: Changes dependency management for router 

### DIFF
--- a/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
+++ b/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
@@ -14,7 +14,7 @@ export const NAVIGATOR_CONTEXT_TOKEN = new InjectionToken<typeof NavigatorContex
 );
 
 export const useNavigator = () => {
-  const ref = React.useRef<FSRouterHistory>(dummyHistory)
+  const ref = React.useRef<FSRouterHistory>();
 
   if (!ref.current) {
     ref.current = Injector.require(NAVIGATOR_TOKEN);

--- a/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
+++ b/packages/fsapp/src/beta-app/router/context/navigator.context.tsx
@@ -1,16 +1,27 @@
 import type { FSRouterHistory } from '../history';
 
 import React, { createContext, FC } from 'react';
-import { InjectionToken } from '@brandingbrand/fslinker';
+import { InjectionToken, Injector } from '@brandingbrand/fslinker';
 
 import { dummyHistory } from '../history/history.dummy';
-import { InjectedContextProvider, useDependencyContext } from '../../lib/use-dependency';
+import { InjectedContextProvider } from '../../lib/use-dependency';
+
+export const NAVIGATOR_TOKEN = new InjectionToken<FSRouterHistory>('NAVIGATOR');
 
 export const NavigatorContext = createContext<FSRouterHistory>(dummyHistory);
 export const NAVIGATOR_CONTEXT_TOKEN = new InjectionToken<typeof NavigatorContext>(
   'NAVIGATOR_CONTEXT_TOKEN'
 );
-export const useNavigator = () => useDependencyContext(NAVIGATOR_CONTEXT_TOKEN) ?? dummyHistory;
+
+export const useNavigator = () => {
+  const ref = React.useRef<FSRouterHistory>(dummyHistory)
+
+  if (!ref.current) {
+    ref.current = Injector.require(NAVIGATOR_TOKEN);
+  }
+
+  return ref.current;
+};
 
 export interface NavigatorProviderProps {
   value: FSRouterHistory;

--- a/packages/fsapp/src/beta-app/router/router.base.ts
+++ b/packages/fsapp/src/beta-app/router/router.base.ts
@@ -9,7 +9,7 @@ import type {
 
 import { Linking } from 'react-native';
 
-import { InjectionToken, Injector } from '@brandingbrand/fslinker';
+import { Injector } from '@brandingbrand/fslinker';
 
 import { MODAL_CONTEXT_TOKEN, ModalContext } from '../modal';
 import {
@@ -28,11 +28,10 @@ import {
   PATH_CONTEXT_TOKEN,
   PathContext,
   QUERY_CONTEXT_TOKEN,
-  QueryContext
+  QueryContext,
+  NAVIGATOR_TOKEN
 } from './context';
 import { getPath, resolveRoutes } from './utils';
-
-export const NAVIGATOR_TOKEN = new InjectionToken<FSRouterHistory>('NAVIGATOR');
 
 export abstract class FSRouterBase implements FSRouter {
   public static async register<T extends FSRouterBase>(

--- a/packages/fsapp/src/beta-app/router/router.base.ts
+++ b/packages/fsapp/src/beta-app/router/router.base.ts
@@ -22,14 +22,14 @@ import {
   LOADING_CONTEXT_TOKEN,
   LoadingContext,
   NAVIGATOR_CONTEXT_TOKEN,
+  NAVIGATOR_TOKEN,
   NavigatorContext,
   PARAM_CONTEXT_TOKEN,
   ParamContext,
   PATH_CONTEXT_TOKEN,
   PathContext,
   QUERY_CONTEXT_TOKEN,
-  QueryContext,
-  NAVIGATOR_TOKEN
+  QueryContext
 } from './context';
 import { getPath, resolveRoutes } from './utils';
 

--- a/packages/fsapp/src/beta-app/router/router.tsx
+++ b/packages/fsapp/src/beta-app/router/router.tsx
@@ -28,7 +28,7 @@ import {
 import { FSRouterBase } from './router.base';
 import { trackView } from './utils';
 
-export { NAVIGATOR_TOKEN } from './router.base';
+export { NAVIGATOR_TOKEN } from './context/navigator.context';
 
 // This is a hack. I am not happy about having to do this hack.
 // But it is required for Android. If no components are registered

--- a/packages/fsapp/src/beta-app/router/router.web.tsx
+++ b/packages/fsapp/src/beta-app/router/router.web.tsx
@@ -26,7 +26,7 @@ import { FSRouterBase } from './router.base';
 import { History } from './history';
 import { trackView } from './utils';
 
-export { NAVIGATOR_TOKEN } from './router.base';
+export { NAVIGATOR_TOKEN } from './context/navigator.context';
 
 @StaticImplements<FSRouterConstructor>()
 export class FSRouter extends FSRouterBase {


### PR DESCRIPTION
⚠️ **Breaking Change** ⚠️ 

Remove `useDependencyContext` in favor of a direct dependency injection method. This resolves a bug with multiple instances of the router being spawned within apps.