### PR TITLE
fix(fsapp): default modal type

### DIFF
--- a/packages/fsapp/src/beta-app/modal/make-modal.ts
+++ b/packages/fsapp/src/beta-app/modal/make-modal.ts
@@ -5,7 +5,7 @@ import type { TopBarStyle } from '../router/types';
 
 import { uniqueId } from 'lodash-es';
 
-export const makeModal = <T = void, P = void>(
+export const makeModal = <T = void, P = {}>(
   component: ComponentType<ModalComponentProps<T> & P>,
   options?: ModalOptions,
   topBarOptions?: TopBarStyle


### PR DESCRIPTION
## Description

This updates the default generics for makeModal() that that it matches the defaults ModalComponentType.
This way makeModal does not require any arguments to pass into interfaces which require a deafult ModalComponentType.
