### PR TITLE
fix(flagship): deep linking on android

### DIFF
--- a/packages/flagship/android/app/src/main/AndroidManifest.xml
+++ b/packages/flagship/android/app/src/main/AndroidManifest.xml
@@ -25,9 +25,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="default-bb-rn-url-scheme" android:host="__URL_HOST_PATH__" />
-                <!-- deep link intents -->
             </intent-filter>
 
+            <!-- deep link intents -->
         </activity>
 
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/packages/flagship/src/lib/android.ts
+++ b/packages/flagship/src/lib/android.ts
@@ -364,9 +364,13 @@ export function urlScheme(configuration: FlagshipTypes.Config): void {
  */
 export function urlSchemeHost(config: FlagshipTypes.AndroidConfig): void {
   if (config.manifest) {
-    const host = config.manifest.urlSchemeHost || '';
-    helpers.logInfo(`setting Android URL scheme host path to ${host}`);
-    fs.update(path.android.manifestPath(), '__URL_HOST_PATH__', host);
+    if (config.manifest.urlSchemeHost !== null) {
+      const host = config.manifest.urlSchemeHost ?? '';
+      helpers.logInfo(`setting Android URL scheme host path to ${host}`);
+      fs.update(path.android.manifestPath(), '__URL_HOST_PATH__', host);
+    } else {
+      fs.update(path.android.manifestPath(), 'android:host="__URL_HOST_PATH__"', '');
+    }
   }
 }
 

--- a/packages/flagship/src/lib/deeplinking.ts
+++ b/packages/flagship/src/lib/deeplinking.ts
@@ -20,10 +20,15 @@ export function addDeeplinkHosts(associatedDomains: string[]): void {
     }
 
     return `
+    <intent-filter android:autoVerify="true">
+      <action android:name="android.intent.action.VIEW" />
+      <category android:name="android.intent.category.DEFAULT" />
+      <category android:name="android.intent.category.BROWSABLE" />
       <data android:scheme="http"
         android:host="${hostname}" />
       <data android:scheme="https"
-        android:host="${hostname}" />`;
+        android:host="${hostname}" />
+    </intent-filter>`;
   });
 
   // update android's manifest


### PR DESCRIPTION
## Description

This fixes the intent filters for deep linking on android.
This allows for linking like

```
app://some/path
```
and
```
https://somewebsite.com/some/path
```
within the same app.
