### PR TITLE
fix: issue with promises resolving before heard

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/history.ts
+++ b/packages/fsapp/src/beta-app/router/history/history.ts
@@ -353,6 +353,7 @@ export class History implements FSRouterHistory {
       this.store.unshift();
     }
 
+    const nextLoad = this.nextLoad;
     try {
       if (this.activeStack !== location.stack) {
         await this.switchStack(location.stack);
@@ -422,7 +423,7 @@ export class History implements FSRouterHistory {
         default:
       }
     } finally {
-      await this.nextLoad;
+      await nextLoad;
       this.setLoading(false);
     }
   }


### PR DESCRIPTION
- On Android, we had an order of operations issue where promises would resolve before they were being listened for.
- This fixes Android routing
- ⚠️ Without this fix, Android routing will be totally broken