### PR TITLE
chore: add convenience scripts for publishing alpha versions

### DIFF
--- a/scripts/getNextAlphaVersion.js
+++ b/scripts/getNextAlphaVersion.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/*
+  This script parses the lerna.json file to determine the next alpha version. For example, if the
+  current published version is 11.1.0-alpha.12, it will output 11.1.0-alpha.13.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+const lernaConfigPath = path.resolve(__dirname, '..', 'lerna.json');
+const lernaConfig = fs.readFileSync(lernaConfigPath, { encoding: 'utf-8' });
+
+const currentVersionMatches = lernaConfig.match(/(\d+\.\d+\.\d+\-alpha\.)(\d+)/);
+
+if (!currentVersionMatches) {
+  throw new Error('Current version does not match expected alpha pattern A.B.C-alpha.D');
+}
+
+const currentMainVersion = currentVersionMatches[1];
+const currentAlphaVersion = currentVersionMatches[2];
+
+const nextAlphaNumber = parseInt(currentAlphaVersion, 10) + 1;
+const nextAlphaVersion = currentMainVersion + nextAlphaNumber;
+
+console.log(nextAlphaVersion);

--- a/scripts/publishAlpha.sh
+++ b/scripts/publishAlpha.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script is intended to assist in publishing alpha versions of Flagship with Lerna. If no
+# version is specified, it will parse the lerna.json file to determine the next version. For
+# example, if the current version is 11.1.0-alpha.14, the next published version would be
+# 11.1.0-alpha.15.
+#
+# By default, the script will invoke Lerna CLI in interactive mode so the user can manually confirm
+# the next version. To include this script in automation, provide the --yes argument which tells
+# Lerna to not prompt the user.
+#
+# Usage:
+#
+# Automatically determine the next version:
+# ./scripts/publishAlpha.sh [optional lerna flags]
+#
+# Manually specify the next version:
+# ./scripts/publishAlpha.sh [version] [optional lerna flags]
+
+set -e
+
+if [[ "$1" =~ ^[0-9] ]]; then
+  NEXT_VERSION="$1"
+else
+  NEXT_VERSION=$(node ./scripts/getNextAlphaVersion.js)
+fi
+
+if [[ "$1" =~ ^[0-9] ]]; then
+  # If user manually provided the version as the first argument, unset $1 so that we can pass the
+  # remaining arguments to the lerna publish command
+  shift 1
+fi
+
+echo "lerna publish $NEXT_VERSION --dist-tag=canary --allow-branch=develop --exact $@"
+
+lerna publish $NEXT_VERSION --dist-tag=canary --allow-branch=develop --exact "$@"


### PR DESCRIPTION
This adds a bash script to aide in publishing alpha versions. If no version is specified, it will parse the lerna.json file to determine the next alpha version. If a version is specified, it will use said version. In either case it will invoke Lerna with the default flags we want for publishing alpha versions (dist-tag, allow-branch, and exact).