### PR TITLE
fix(fsengagement): fix RenderImageTextItem deeplinks

### DIFF
--- a/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
+++ b/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
@@ -1,10 +1,8 @@
 /* tslint:disable */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { useContext, useState  } from 'react';
 import {
   Dimensions,
   Image,
-  LayoutChangeEvent,
   StyleProp,
   Text,
   TextStyle,
@@ -13,6 +11,7 @@ import {
 } from 'react-native';
 import styles from './SliderEntry.style';
 
+import { EngagementContext } from '../lib/contexts';
 export interface RenderItemProps {
   data?: any;
   parallax?: any;
@@ -35,176 +34,151 @@ export interface RenderItemProps {
 export interface TextValue {
   value: string;
 }
-export interface RenderItemState {
-  viewHeight: number;
-  viewHeightChanged: boolean;
-}
 
 const { height: viewportHeight } = Dimensions.get('window');
 
-export default class RenderImageTextItem extends Component<RenderItemProps, RenderItemState> {
-  static contextTypes: any = {
-    handleAction: PropTypes.func
-  };
-  constructor(props: RenderItemProps) {
-    super(props);
-    this.state = {
-      viewHeight: 0,
-      viewHeightChanged: false
-    };
-  }
-  get image(): any {
-    const { data: { source }, options } = this.props;
-    const imagePadding = {
+const RenderImageTextItem = (props:RenderItemProps):JSX.Element => {
+
+  const [viewHeight, setViewHeight] = useState(0);
+  const [viewHeightChanged, setViewHeightChanged] = useState(false);
+  const { handleAction } = useContext(EngagementContext);
+
+  const {
+    data: {
+      source,
+      ratio,
+      showText,
+      text,
+      header,
+      additional,
+      eyebrow
+    },
+    even,
+    grid,
+    itemWidth,
+    horizPadding = 0,
+    verticalSpacing = 0,
+    options,
+    overallHeight = 0,
+    totalItemWidth = 0,
+    numColumns = 2,
+    eyebrowStyle,
+    headerStyle,
+    textStyle,
+    additionalStyle,
+    noMargin,
+  } = props;
+
+  const imagePadding = {
       margin: options.imagePadding || 0
-    };
+  };
 
-    return (
-      <Image
-        source={source}
-        style={[styles.image, imagePadding]}
-      />
-    );
-  }
-
-  _onLayout = (event: LayoutChangeEvent) => {
-    var { height } = event.nativeEvent.layout;
-
-    if (!this.state.viewHeightChanged &&
-      this.state.viewHeight !== height &&
-      Math.abs(this.state.viewHeight - height) > 1) {
-      this.setState({
-        viewHeight: height,
-        viewHeightChanged: true
-      })
-    }
-  }
-  onPress = () => {
-    const { data: { link } } = this.props;
-    if (!link) {
-      return;
-    }
-    const { handleAction } = this.context;
-    handleAction({
-      type: 'deep-link',
-      value: link
-    });
-  }
-  render() {
-    const {
-      data: {
-        ratio,
-        showText,
-        text,
-        header,
-        additional,
-        eyebrow
-      },
-      even,
-      grid,
-      itemWidth,
-      horizPadding = 0,
-      verticalSpacing = 0,
-      options,
-      overallHeight = 0,
-      totalItemWidth = 0,
-      numColumns = 2,
-      eyebrowStyle,
-      headerStyle,
-      textStyle,
-      additionalStyle,
-      noMargin
-    } = this.props;
-
-    let itemStyle: any = {};
-    let imageStyle: any = {};
-    const textPadding = options.textPadding || {};
-    if (grid) {
-      if (ratio && itemWidth) {
-        itemStyle = {
-          width: noMargin ? totalItemWidth - (itemWidth * (numColumns - 1)) : itemWidth,
-          marginRight: noMargin ? 0 : horizPadding,
-          paddingHorizontal: 0,
-          marginBottom: verticalSpacing
-        };
-      } else {
-        itemStyle = {
-          width: itemWidth,
-          height: viewportHeight * .36,
-          marginRight: even ? horizPadding : 0,
-          marginBottom: verticalSpacing
-        };
+  const handleOnLayout:any = (event:any) => {
+      let { height } = event.nativeEvent.layout;
+      if (!viewHeightChanged &&
+          viewHeight !== height &&
+          Math.abs(viewHeight - height) > 1) {
+          setViewHeightChanged(true);
+          setViewHeight(height);
       }
+  };
+  const handleOnPress = ():void => {
+    const { data: { link } } = props;
+    if (!link) {
+        return;
+    }
+    handleAction({
+        type: 'deep-link',
+        value: link
+    });
+  };
 
-      imageStyle = {
-        width: '100%',
-        height: (itemWidth / parseFloat(ratio))
+  let itemStyle: any = {};
+  let imageStyle: any = {};
+  const textPadding = options.textPadding || {};
+  if (grid) {
+    if (ratio && itemWidth) {
+      itemStyle = {
+        width: noMargin ? totalItemWidth - (itemWidth * (numColumns - 1)) : itemWidth,
+        marginRight: noMargin ? 0 : horizPadding,
+        paddingHorizontal: 0,
+        marginBottom: verticalSpacing
       };
     } else {
-      if (ratio && itemWidth) {
-        itemStyle = {
-          width: itemWidth,
-          paddingRight: horizPadding
-        };
-      } else {
-        itemStyle = {
-          width: itemWidth,
-          height: viewportHeight * .36
-        };
-      }
-      imageStyle = {
-        width: '100%',
-        height: ((itemWidth - parseInt(options.itemHorizontalPaddingPercent,10)) / parseFloat(ratio))
+      itemStyle = {
+        width: itemWidth,
+        height: viewportHeight * .36,
+        marginRight: even ? horizPadding : 0,
+        marginBottom: verticalSpacing
       };
     }
 
-    var textbg: any = {};
-    if (options.backgroundColor) {
-      textbg.backgroundColor = options.backgroundColor;
+    imageStyle = {
+      width: '100%',
+      height: (itemWidth / parseFloat(ratio))
+    };
+  } else {
+    if (ratio && itemWidth) {
+      itemStyle = {
+        width: itemWidth,
+        paddingRight: horizPadding
+      };
+    } else {
+      itemStyle = {
+        width: itemWidth,
+        height: viewportHeight * .36
+      };
     }
+    imageStyle = {
+      width: '100%',
+      height: ((itemWidth - parseInt(options.itemHorizontalPaddingPercent,10)) / parseFloat(ratio))
+    };
+  }
 
-    if (grid) {
-      return (
+  let textbg: any = {};
+  if (options.backgroundColor) {
+    textbg.backgroundColor = options.backgroundColor;
+  }
+
+  return (
+    <>
+      {grid ?
         <TouchableOpacity
-          activeOpacity={.8}
-          onPress={this.onPress}
-          style={itemStyle}
-          onLayout={this._onLayout}
-        >
-          <View style={imageStyle}>
-            <View style={[styles.imageContainerNoCard, even ? {} : {}]}>
-              {this.image}
-            </View>
-          </View>
-
-          {showText &&
-            <View
-            style={[{ height: this.state.viewHeight - ((itemWidth) / parseFloat(ratio)) }, textbg]}
-            >
-              <View style={[textPadding, { justifyContent: 'center' }]}>
-                {!!(eyebrow && eyebrow.value) &&
-                  <Text style={[eyebrowStyle, { textAlign: options.textAlign }]}>{eyebrow.value}</Text>}
-                {!!(header && header.value) &&
-                  <Text style={[headerStyle, { textAlign: options.textAlign }]}>{header.value}</Text>}
-                {!!(text && text.value) &&
-                  <Text style={[textStyle, { textAlign: options.textAlign }]}>{text.value}</Text>}
-              </View>
-            </View>}
-
-        </TouchableOpacity>
-      );
-    }
-
-    return (
-      <TouchableOpacity
         activeOpacity={.8}
-        onPress={this.onPress}
+        onPress={handleOnPress}
         style={itemStyle}
-
+        onLayout={handleOnLayout}
       >
         <View style={imageStyle}>
           <View style={[styles.imageContainerNoCard, even ? {} : {}]}>
-            {this.image}
+            <Image source={source} style={[styles.image, imagePadding]}/>
+          </View>
+        </View>
+
+        {showText &&
+          <View
+          style={[{ height: viewHeight - ((itemWidth) / parseFloat(ratio)) }, textbg]}
+          >
+            <View style={[textPadding, { justifyContent: 'center' }]}>
+              {!!(eyebrow && eyebrow.value) &&
+                <Text style={[eyebrowStyle, { textAlign: options.textAlign }]}>{eyebrow.value}</Text>}
+              {!!(header && header.value) &&
+                <Text style={[headerStyle, { textAlign: options.textAlign }]}>{header.value}</Text>}
+              {!!(text && text.value) &&
+                <Text style={[textStyle, { textAlign: options.textAlign }]}>{text.value}</Text>}
+            </View>
+          </View>
+        }
+
+      </TouchableOpacity>
+      : <TouchableOpacity
+        activeOpacity={.8}
+        onPress={handleOnPress}
+        style={itemStyle}
+      >
+        <View style={imageStyle}>
+          <View style={[styles.imageContainerNoCard, even ? {} : {}]}>
+            <Image source={source} style={[styles.image, imagePadding]}/>
           </View>
         </View>
 
@@ -222,9 +196,15 @@ export default class RenderImageTextItem extends Component<RenderItemProps, Rend
               {!!(additional && additional.value) &&
                 <Text style={[additionalStyle, { textAlign: options.textAlign }]}>{additional.value}</Text>}
             </View>
-          </View>}
+          </View>
+        }
 
-      </TouchableOpacity>
-    );
-  }
+        </TouchableOpacity>
+      }
+    </>
+  );
 }
+
+export default RenderImageTextItem;
+
+//# sourceMappingURL=RenderImageTextItem.js.map


### PR DESCRIPTION
Im just going to copy this from are related PR I made on another project since it describes what I did pretty well.

> ## Description
> 
> `RenderImageTextItem` couldn't access `EngagementContext` which meant that `handleAction` was undefined and calling it when the user tapped the image would fail. `RenderImageTextItem` should have had access to the context since its supposed to be a child of `EngagementComp` but I couldn't find as a descendant anywhere in the code. To get around that I went ahead and converted `RenderImageTextItem` from a class component to a functional component so that I could give it access to the right context using the `useContext()` hook. Everything seems to be working after the conversion but if `RenderImageTextItem` was a class component for a reason and switching it causes problems that I'm not aware of please let me know so I can figure out a different fix.