### PR TITLE
feat(title): no-ticket - added title to product index type

### DIFF
--- a/packages/fscommerce/src/Commerce/types/ProductIndex.ts
+++ b/packages/fscommerce/src/Commerce/types/ProductIndex.ts
@@ -88,7 +88,7 @@ export interface ProductIndex<T extends Product = Product> extends Partial<Pagea
    *
    * @example 'Shoes'
    */
-  title: string;
+  title?: string;
   /**
    * A unique identifier for the product index category, used for vehicle filter
    *


### PR DESCRIPTION
### No Ticket

### Description
- we currently don't have a way to pull in the title for pips in shopify apps
- we need to pull in the title in fsshopify product index normalizer.
- we are currently using the type FSCommerceTypes.ProductIndex
- This change will allow us to pull in the pip title from the shopify data returned in the API response.
- i will be updating submarine > fsshopify > src > normalizers > productindex.ts once this is merged 