### PR TITLE
fix: context fix for engagement components

### DIFF
--- a/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
+++ b/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
@@ -85,7 +85,7 @@ class RenderImageTextItem extends Component<RenderItemProps & { context: any }, 
     if (!link) {
       return;
     }
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link

--- a/packages/fsengagement/src/inboxblocks/IconTextBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/IconTextBlock.tsx
@@ -74,7 +74,7 @@ class IconTextBlock extends Component<IconTextProps & { context: any }> {
     if (!link) {
       return;
     }
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link

--- a/packages/fsengagement/src/inboxblocks/ImageWithOverlay.tsx
+++ b/packages/fsengagement/src/inboxblocks/ImageWithOverlay.tsx
@@ -106,7 +106,7 @@ class ImageWithOverlay extends Component<ImageBlockProps & { context: any }, Ima
     return result;
   }
   onPress = (link: string) => () => {
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link


### PR DESCRIPTION
In a previous PR we began passing context into class components as a prop but I forgot to change the usage to pull from props instead of the old context.