### PR TITLE
feat: target android api 30 and add aab support [v10.x]

### DIFF
--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 19
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         supportLibVersion = "28.0.0"
         kotlinVersion = "1.3.72"
         RNNKotlinVersion = kotlinVersion
@@ -38,8 +38,8 @@ subprojects {
     afterEvaluate {
         project -> if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 28
-                buildToolsVersion "28.0.3"
+                compileSdkVersion 30
+                buildToolsVersion "30.0.2"
             }
         }
     }

--- a/packages/flagship/android/fastlane/Fastfile
+++ b/packages/flagship/android/fastlane/Fastfile
@@ -7,7 +7,20 @@ lane :appcenter do
   appcenter_upload(
     #PROJECT_MODIFY_FLAG_appcenter_api_token
     owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
-    app_name: "INJECTED_FROM_CONFIG" #PROJECT_MODIFY_FLAG_appcenter_app_name_android
+    app_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_app_name_android
+    destination_type: "group"
+  )
+end
+
+lane :appcenter_bundle do
+  # build the release variant
+  gradle(task: "bundleRelease")
+
+  appcenter_upload(
+    #PROJECT_MODIFY_FLAG_appcenter_api_token
+    owner_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_owner_name
+    app_name: "INJECTED_FROM_CONFIG", #PROJECT_MODIFY_FLAG_appcenter_app_name_android
+    destination_type: "store"
   )
 end
 

--- a/packages/flagship/src/lib/fastlane.ts
+++ b/packages/flagship/src/lib/fastlane.ts
@@ -74,7 +74,7 @@ export function configure(path: string, configuration: Config): void {
       fs.update(
         path,
         /.+#PROJECT_MODIFY_FLAG_appcenter_app_name_android/g,
-        `app_name: "${distribute.appNameAndroid}" #PROJECT_MODIFY_FLAG_appcenter_app_name_android`
+        `app_name: "${distribute.appNameAndroid}", #PROJECT_MODIFY_FLAG_appcenter_app_name_android`
       );
     }
   }

--- a/packages/pirateship/env/common.js
+++ b/packages/pirateship/env/common.js
@@ -31,6 +31,13 @@ module.exports = {
   apiHost: 'https://api.example.com',
   publicVersionNumber: '1.0.0',
   require: [],
+  appCenter: {
+    organization: 'branding-brand',
+    distribute: {
+      appNameIOS: 'test-ios',
+      appNameAndroid: 'test-android'
+    }
+  },
   appIds: {
     android: 'com.brandingbrand.reactnative.and.pirateship',
     ios: 'com.brandingbrand.reactnative.pirateship',


### PR DESCRIPTION
BREAKING CHANGE: This updates the Android base project to target API level 30. Per Google's documentation, app updates will no longer be accepted unless they target level 30 as of November 2021. As such, this is being included as a feature release instead of a new breaking version.

This PR also introduces a new Fastlane lane to build Android App Bundles (AABs) called appcenter_bundle.