### PR TITLE
feat: update web carousel dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "marked": "^0.7.0",
     "websocket-extensions": "^0.1.4",
     "react-dev-utils": "^11.0.0",
-    "immer": "^8.0.1"
+    "immer": "^9.0.6"
   },
   "workspaces": [
     "packages/*"

--- a/packages/fscomponents/package.json
+++ b/packages/fscomponents/package.json
@@ -42,6 +42,7 @@
     "react-native-webview": "^11.6.4",
     "react-player": "^1.15.2",
     "sweetalert": "^2.1.0",
+    "swiper": "^6.5.1",
     "yup": "^0.29.0"
   },
   "devDependencies": {

--- a/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
+++ b/packages/fscomponents/src/components/Carousel/Carousel.web.tsx
@@ -1,10 +1,13 @@
+// tslint:disable no-submodule-imports
+
 import React, { Component } from 'react';
 
-// @ts-ignore TODO: Update react-id-swiper to support typing
-import Swiper from 'react-id-swiper';
-import 'swiper/css/swiper.css' // tslint:disable-line
+// TODO: Update react-id-swiper to support typing
+import ReactIdSwiper from 'react-id-swiper/lib/ReactIdSwiper.custom';
+import 'swiper/swiper-bundle.css'; // tslint:disable-line
 import { View } from 'react-native';
 import { CarouselProps } from './CarouselProps';
+import { Navigation, Pagination, Swiper } from 'swiper/swiper.esm';
 
 let SWIPER_ID = 0;
 
@@ -37,8 +40,10 @@ export class Carousel extends Component<CarouselProps> {
     return (
       <View style={style}>
         <div id={`web-swiper-${this.id}`}>
-          <Swiper
+          <ReactIdSwiper
             loop={loop}
+            Swiper={Swiper}
+            modules={[Navigation, Pagination]}
             pagination={_showsPagination ? {
               el: `.swiper-pagination`,
               clickable: true
@@ -52,7 +57,7 @@ export class Carousel extends Component<CarouselProps> {
                 </div>
               );
             })}
-          </Swiper>
+          </ReactIdSwiper>
         </div>
         {/* swiper library doesn't have style props that let use to
           style inner component like dots and pagination, it's expecting

--- a/packages/fscomponents/src/components/__stories__/Carousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/Carousel.story.tsx
@@ -36,7 +36,7 @@ const style = StyleSheet.create({
 
 const imageSlide = (
   <Image
-    source={{ uri: 'https://placehold.it/375x150' }}
+    source={{ uri: 'https://via.placeholder.com/375x150' }}
     style={object('slideImageStyle', style.slideImage)}
   />
 );

--- a/packages/fscomponents/src/components/typings.d.ts
+++ b/packages/fscomponents/src/components/typings.d.ts
@@ -1,0 +1,2 @@
+declare module 'swiper/swiper.esm';
+

--- a/packages/fsweb/package.json
+++ b/packages/fsweb/package.json
@@ -51,7 +51,7 @@
     "react-native-web-modal": "^1.0.1",
     "react-native-web-webview": "^0.2.8",
     "style-loader": "^1.0.0",
-    "swiper": "^5.0.0",
+    "swiper": "^6.5.1",
     "terser-webpack-plugin": "^1.4.2",
     "ts-loader": "^6.0.0",
     "webpack": "^4.41.2",

--- a/packages/pirateship/src/screens.tsx
+++ b/packages/pirateship/src/screens.tsx
@@ -33,6 +33,7 @@ import ImageWithOverlaySample from './screens/ImageWithOverlaySample';
 import CartCountSample from './screens/CartCountSample';
 import { EngagementComp } from './lib/engagement';
 import WebviewSample from './screens/WebviewSample';
+import CarouselSample from './screens/CarouselSample';
 
 export default {
   Shop,
@@ -66,5 +67,6 @@ export default {
   ImageWithOverlaySample,
   CartCountSample,
   EngagementComp,
-  WebviewSample
+  WebviewSample,
+  CarouselSample
 } as any;

--- a/packages/pirateship/src/screens/CarouselSample.tsx
+++ b/packages/pirateship/src/screens/CarouselSample.tsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { Options } from 'react-native-navigation';
+import PSScreenWrapper from '../components/PSScreenWrapper';
+import { ScreenProps } from '../lib/commonTypes';
+import { navBarTabLanding } from '../styles/Navigation';
+import { Carousel } from '@brandingbrand/fscomponents';
+import { Image, View } from 'react-native';
+
+const placeholder = require('../../assets/images/placeholder-100x100.png');
+
+class CartCountSample extends Component<ScreenProps> {
+  static options: Options = navBarTabLanding;
+
+  render(): JSX.Element {
+    return (
+      <PSScreenWrapper
+        hideGlobalBanner={true}
+        navigator={this.props.navigator}
+        scroll={false}
+      >
+        <Carousel height={100} showsPagination={true} showsButtons={true}>
+          <View style={{flex: 1}}><Image source={placeholder} /></View>
+          <View style={{flex: 1}}><Image source={placeholder} /></View>
+          <View style={{flex: 1}}><Image source={placeholder} /></View>
+        </Carousel>
+      </PSScreenWrapper>
+    );
+  }
+}
+
+export default CartCountSample;

--- a/packages/pirateship/src/screens/Development.tsx
+++ b/packages/pirateship/src/screens/Development.tsx
@@ -18,7 +18,8 @@ const screens: LayoutComponent[] = [
   { options: { topBar: { title: { text: 'Image With Overlay' }}}, name: 'ImageWithOverlaySample' },
   { options: { topBar: { title: { text: 'Cart Count' }}}, name: 'CartCountSample'},
   { options: { topBar: { title: { text: 'PS Half Modal' }}}, name: 'EmailSignUp' },
-  { options: { topBar: { title: { text: 'Webview' }}}, name: 'WebviewSample' }
+  { options: { topBar: { title: { text: 'Webview' }}}, name: 'WebviewSample' },
+  { options: { topBar: { title: { text: 'Carousel' }}}, name: 'CarouselSample' }
 ];
 
 export interface DevelopmentScreenState {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7479,12 +7479,12 @@ dom-walk@^0.1.0:
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
 
-dom7@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/dom7/-/dom7-2.1.5.tgz#a79411017800b31d8400070cdaebbfc92c1f6377"
-  integrity sha512-xnhwVgyOh3eD++/XGtH+5qBwYTgCm0aW91GFgPJ3XG+jlsRLyJivnbP0QmUBFhI+Oaz9FV0s7cxgXHezwOEBYA==
+dom7@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dom7/-/dom7-3.0.0.tgz#b861ce5d67a6becd7aaa3ad02942ff14b1240331"
+  integrity sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==
   dependencies:
-    ssr-window "^2.0.0"
+    ssr-window "^3.0.0-alpha.1"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -9739,10 +9739,10 @@ image-size@^0.6.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
   integrity sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==
 
-immer@8.0.1, immer@^8.0.1:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
-  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
+immer@8.0.1, immer@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -16288,10 +16288,10 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssr-window@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-2.0.0.tgz#98c301aef99523317f8d69618f0010791096efc4"
-  integrity sha512-NXzN+/HPObKAx191H3zKlYomE5WrVIkoCB5IaSdvKokxTpjBdWfr0RaP+1Z5KOfDT0ZVz+2tdtiBkhsEQ9p+0A==
+ssr-window@^3.0.0, ssr-window@^3.0.0-alpha.1:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-3.0.0.tgz#fd5b82801638943e0cc704c4691801435af7ac37"
+  integrity sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA==
 
 ssri@^6.0.0, ssri@^6.0.1:
   version "6.0.2"
@@ -16666,13 +16666,13 @@ sweetalert@^2.1.0:
     es6-object-assign "^1.1.0"
     promise-polyfill "^6.0.2"
 
-swiper@^5.0.0:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-5.4.5.tgz#a350f654bf68426dbb651793824925512d223c0f"
-  integrity sha512-7QjA0XpdOmiMoClfaZ2lYN6ICHcMm72LXiY+NF4fQLFidigameaofvpjEEiTQuw3xm5eksG5hzkaRsjQX57vtA==
+swiper@^6.5.1:
+  version "6.8.4"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.8.4.tgz#938fed4144f4d7952fbf9c44e5832d133a4de794"
+  integrity sha512-O+buF9Q+sMA0H7luMS8R59hCaJKlpo8PXhQ6ZYu6Rn2v9OsFd4d1jmrv14QvxtQpKAvL/ZiovEeANI/uDGet7g==
   dependencies:
-    dom7 "^2.1.5"
-    ssr-window "^2.0.0"
+    dom7 "^3.0.0"
+    ssr-window "^3.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This updates the Swiper dependency to fix a security issue. The fixed version is a breaking change from the previous (v5 to v6) which in turn broke our custom implementation which uses react-id-swiper in conjunction with Swiper. (The pagination buttons were no longer displaying.)

I refactored the web carousel code to use the "custom build" solution described in the react-id-swiper readme and it solved the problem: https://www.npmjs.com/package/react-id-swiper#custom-build-swiper

This also adds a new screen to the dev menu to test carousels.

There are two ways to test this:

1. Run `yarn dev:storybook` and play with the Carousel stories
2. Run PirateShip web (`yarn ship:compile-web`), go to the develop menu, and then go to the Carousel sample screen