### PR TITLE
feat(flagship): cache files in-memory during init

### DIFF
--- a/packages/flagship/package.json
+++ b/packages/flagship/package.json
@@ -13,6 +13,7 @@
     "flagship": "flagship.js"
   },
   "dependencies": {
+    "@brandingbrand/fsfoundation": "^11.5.0",
     "fs-extra": "^8.0.0",
     "glob": "^7.1.2",
     "jsc-android": "241213.x.x",

--- a/packages/flagship/src/helpers.ts
+++ b/packages/flagship/src/helpers.ts
@@ -1,5 +1,3 @@
-const fs = require('fs-extra');
-
 export const colors = {
   Reset: '\x1b[0m',
   Bright: '\x1b[1m',
@@ -28,23 +26,6 @@ export const colors = {
   BgWhite: '\x1b[47m'
 };
 
-export function addPod(file: string, podLine: string): void {
-  const fileContent = fs.readFileSync(file, { encoding: 'utf8' });
-  if (fileContent.indexOf(podLine) > -1) {
-    return;
-  }
-
-  fs.writeFileSync(
-    file,
-    fileContent.replace(
-      '# Add new pods below this line',
-      `\t${podLine}\n# Add new pods below this line`
-    )
-  );
-
-  logInfo(`Podfile updated\n${podLine}`);
-}
-
 export function logInfo(...messages: string[]): void {
   logWithType('info', [].slice.call(messages, 0));
 }
@@ -57,20 +38,6 @@ export function logWarn(...messages: string[]): void {
   return logWithType('warn', [].slice.call(messages, 0));
 }
 
-export function updateFile(file: string, oldText: string, newText: string): void {
-  const fileContent = fs.readFileSync(file, { encoding: 'utf8' });
-  fs.writeFileSync(file, fileContent.replace(oldText, newText));
-
-  logInfo(`file updated\n${file}`);
-}
-
-export function appendFile(file: string, text: string): void {
-  const fileContent = fs.readFileSync(file, { encoding: 'utf8' });
-  fs.writeFileSync(file, fileContent + text);
-
-  logInfo(`file appended\n${file}`);
-}
-
 export function getCmdOption(argv: string[]): (a: string) => string | undefined {
   return (optionName: string): string | undefined => {
     const optionArgv = argv
@@ -79,11 +46,6 @@ export function getCmdOption(argv: string[]): (a: string) => string | undefined 
 
     return optionArgv && optionArgv.split('=')[1] || undefined;
   };
-}
-
-export function doesKeywordExist(fileName: string, keyword: string): boolean {
-  const fileContent = fs.readFileSync(fileName, { encoding: 'utf8' });
-  return fileContent.indexOf(keyword) > -1;
 }
 
 function logWithType(type: string, args: string[]): void {

--- a/packages/flagship/src/lib/__tests__/android.test.ts
+++ b/packages/flagship/src/lib/__tests__/android.test.ts
@@ -1,5 +1,5 @@
 const android = require(`../android`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/cocoapods.test.ts
+++ b/packages/flagship/src/lib/__tests__/cocoapods.test.ts
@@ -1,6 +1,6 @@
 const childProcess = require('child_process');
 const cocoapods = require(`../cocoapods`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 const os = require(`../os`);
 

--- a/packages/flagship/src/lib/__tests__/deeplink.test.ts
+++ b/packages/flagship/src/lib/__tests__/deeplink.test.ts
@@ -1,5 +1,5 @@
 import * as deeplink from '../deeplinking';
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/env.test.ts
+++ b/packages/flagship/src/lib/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import * as env from '../env';
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);
 const tempRootDir = nodePath.join(__dirname, `__env_test`);

--- a/packages/flagship/src/lib/__tests__/fastlane.test.ts
+++ b/packages/flagship/src/lib/__tests__/fastlane.test.ts
@@ -1,5 +1,5 @@
 const fastlane = require(`../fastlane`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/fs.test.ts
+++ b/packages/flagship/src/lib/__tests__/fs.test.ts
@@ -30,19 +30,27 @@ test(`update`, () => {
   fs.update(nodePath.join(tempRootDir, `ios/Podfile`),
     `target 'MOCKAPP' do`, `target 'TESTAPP' do`);
 
-  const body = fsExtra.readFileSync(nodePath.join(tempRootDir, `ios/Podfile`)).toString();
+  const body = fs.readFileSync(nodePath.join(tempRootDir, `ios/Podfile`)).toString();
 
   expect(body).toMatch(`target 'TESTAPP' do`);
 });
 
 test(`keyword does exist`, () => {
-  expect(fs.doesKeywordExist(nodePath.join(tempRootDir, `ios/Podfile`), `target 'MOCKAPP' do`))
-    .toBeTruthy();
+  expect(
+    fs.doesKeywordExist(
+      nodePath.join(tempRootDir, 'ios/Podfile'),
+      'Add new pods below this line'
+    )
+  ).toBeTruthy();
 });
 
 test(`keyword doesn't exist`, () => {
-  expect(fs.doesKeywordExist(nodePath.join(tempRootDir, `ios/Podfile`), `target 'TESTAPP' do`))
-    .toBeFalsy();
+  expect(
+    fs.doesKeywordExist(
+      nodePath.join(tempRootDir, 'ios/Podfile'),
+      'this string has no business in our podfile'
+    )
+  ).toBeFalsy();
 });
 
 // Force to be treated as a module

--- a/packages/flagship/src/lib/__tests__/ios.test.ts
+++ b/packages/flagship/src/lib/__tests__/ios.test.ts
@@ -1,5 +1,5 @@
 const ios = require(`../ios`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/native-constants.test.ts
+++ b/packages/flagship/src/lib/__tests__/native-constants.test.ts
@@ -1,5 +1,5 @@
 const nativeConstants = require(`../native-constants`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/path.test.ts
+++ b/packages/flagship/src/lib/__tests__/path.test.ts
@@ -1,5 +1,5 @@
 const path = require(`../path`);
-const fs = require(`fs-extra`);
+const fs = require('../fs');
 const nodePath = require(`path`);
 
 const mockProjectDir = nodePath.join(__dirname, '..', '..', '..', '__tests__', `mock_project`);

--- a/packages/flagship/src/lib/__tests__/rename.test.ts
+++ b/packages/flagship/src/lib/__tests__/rename.test.ts
@@ -1,5 +1,5 @@
 const rename = require('../rename');
-const fs = require('fs-extra');
+const fs = require('../fs');
 const path = require('path');
 const { trueCasePathSync } =
   require('true-case-path'); // tslint:disable-line:no-implicit-dependencies

--- a/packages/flagship/src/lib/cocoapods.ts
+++ b/packages/flagship/src/lib/cocoapods.ts
@@ -41,7 +41,7 @@ export function add(pods: string[], podfilePath: string = path.ios.podfilePath()
   if (!pods.length) {
     return;
   }
-  const podfileContents = fs.readFileSync(podfilePath, { encoding: 'utf8' });
+  const podfileContents = fs.readFileSync(podfilePath);
 
   // Filter out any pods that are already declared in the podfile
   // TODO: This should support a version check
@@ -66,7 +66,7 @@ export function add(pods: string[], podfilePath: string = path.ios.podfilePath()
 export function sources(sources: string[]): void {
   if (sources.length > 0) {
     helpers.logInfo('adding additional pod sources: ' + sources.join(', '));
-    let podfileContents = fs.readFileSync(path.ios.podfilePath(), 'utf8');
+    let podfileContents = fs.readFileSync(path.ios.podfilePath());
     podfileContents = podfileContents.replace('# ADDITIONAL_POD_SOURCES',
       sources.map(s => `source '${s}'`).join('\n'));
     fs.writeFileSync(path.ios.podfilePath(), podfileContents);

--- a/packages/flagship/src/lib/fs.ts
+++ b/packages/flagship/src/lib/fs.ts
@@ -1,35 +1,25 @@
-import {
-  copySync,
-  ensureDirSync,
-  ensureSymlinkSync,
-  moveSync,
-  pathExistsSync,
-  readdirSync,
-  readFileSync,
-  removeSync,
-  renameSync,
-  writeFileSync
-} from 'fs-extra';
-export {
-  copySync,
-  removeSync,
-  readFileSync,
-  writeFileSync,
-  readdirSync,
-  ensureDirSync,
-  renameSync,
-  pathExistsSync,
-  ensureSymlinkSync,
-  moveSync
-};
+import { Dictionary } from '@brandingbrand/fsfoundation';
 
+import * as fs from 'fs-extra';
 import * as helpers from '../helpers';
 import * as path from './path';
+
+export {
+  ensureDirSync,
+  ensureFileSync,
+  ensureSymlinkSync,
+  pathExistsSync,
+  readdirSync
+} from 'fs-extra';
+
+let fileQueue: Dictionary<{ body: string; dirty?: (code: number) => void }> = {};
+
 
 /**
  * Clones a named resource from within FLAGSHIP into the project.
  *
  * @param {...string} resource A list of path components to the resource to copy.
+ * @returns {void}
  */
 export function clone(...resource: string[]): void {
   const source = path.flagship.resolve(...resource);
@@ -40,27 +30,43 @@ export function clone(...resource: string[]): void {
     `${helpers.colors.Dim}${destination}${helpers.colors.Reset}`
   );
 
-  copySync(source, destination);
+  if (fileQueue[source]) {
+    writeFileSync(destination, fileQueue[source].body);
+  } else {
+    copySync(source, destination);
+  }
 }
 
 /**
- * Updates a file, replacing a given string with a new one.
+ * Copy a file or directory. The directory can have contents.
  *
- * @param {string} path The path to the file to update.
- * @param {string} oldText The old text to replace.
- * @param {string} newText The replacement text.
+ *  @param {string} src Note that if src is a directory it will copy everything inside of this
+ *  directory, not the entire directory itself.
+ *  @param {string} dest Note that if src is a file, dest cannot be a directory.
+ *  @param {Object} options fs-extra copySync options.
+ *  @returns {void}
  */
-export function update(path: string, oldText: string | RegExp, newText: string): void {
-  // TODO: This should use a streaming buffer
+export function copySync(src: string, dest: string, options?: Object): void {
+  // TODO: Use fs-extra type definition for options instead of Object
+  src = path.resolve(src);
 
-  if (!doesKeywordExist(path, oldText)) {
-    return helpers.logError(`Couldn't find ${oldText} in ${path}`);
+  if (fs.existsSync(src)) {
+    const stat = fs.lstatSync(src);
+
+    if (stat.isDirectory()) {
+      // TODO: Traverse the directory and see if we have any cached files and move them instead of
+      // flushing the cache.
+      flushSync();
+      return fs.copySync(src, dest, options);
+    } else if (stat.isFile()) {
+      if (fileQueue[src]) {
+        return writeFileSync(dest, fileQueue[src].body);
+      }
+    }
   }
 
-  const fileContent = readFileSync(path, { encoding: 'utf8' });
-
-  helpers.logInfo(`updating ${helpers.colors.Dim}${path}${helpers.colors.Reset}`);
-  writeFileSync(path, fileContent.replace(oldText, newText));
+  // Source doesn't exist or isn't in the queue
+  return fs.copySync(src, dest, options);
 }
 
 /**
@@ -71,11 +77,190 @@ export function update(path: string, oldText: string | RegExp, newText: string):
  * @returns {boolean} True if the keyword exists in the file.
  */
 export function doesKeywordExist(path: string, keyword: string | RegExp): boolean {
-  // TODO: This should use a streaming buffer
-  const fileContent = readFileSync(path, { encoding: 'utf8' });
+  const fileContent = readFileSync(path);
   if (typeof keyword === 'string') {
     return fileContent.indexOf(keyword) > -1;
   } else {
     return keyword.test(fileContent);
+  }
+}
+
+/**
+ * Returns whether or not the given path exists.
+ *
+ * @param {string} src The path to check whether or not it exists.
+ * @returns {boolean} Whether or not the path exists.
+ */
+export function existsSync(src: string): boolean {
+  src = path.resolve(src);
+
+  return !!fileQueue[src] || fs.existsSync(src);
+}
+
+/**
+ * Flushes all pending writes in the write queue and purges the cache. This will bring the
+ * filesystem into a consistent state with the deferred actions so it should be invoked minimally,
+ * but before anything that interacts with the filesystem outside of this library is allowed to
+ * execute.
+ * @returns {void}
+ */
+export function flushSync(): void {
+  for (const name in fileQueue) {
+    if (fileQueue.hasOwnProperty(name)) {
+      const file = fileQueue[name];
+
+      if (file.dirty) {
+        fs.writeFileSync(name, file.body);
+
+        process.removeListener('beforeExit', file.dirty);
+        delete file.dirty;
+      }
+    }
+  }
+
+  fileQueue = {};
+}
+
+/**
+ * Moves a file or directory, even across devices.
+ *
+ * @param {string} src The file or directory to move
+ * @param {string} dest The destination for the file or directory
+ * @returns {void}
+ */
+export function moveSync(src: string, dest: string): void {
+  src = path.resolve(src);
+  dest = path.resolve(dest);
+
+  if (fs.existsSync(src)) {
+    const stat = fs.lstatSync(src);
+
+    if (stat.isDirectory()) {
+      // TODO: Traverse the directory and see if we have any cached files and move them instead of
+      // flushing the cache
+      flushSync();
+      return fs.moveSync(src, dest);
+    } else if (stat.isFile()) {
+      const file = fileQueue[src];
+
+      if (file) {
+        writeFileSync(dest, file.body);
+
+        if (file.dirty) {
+          process.removeListener('beforeExit', file.dirty);
+          delete fileQueue[src];
+        }
+
+        fs.removeSync(src);
+        return;
+      }
+    }
+  }
+
+  // Source doesn't exist or isn't in the queue
+  return fs.moveSync(src, dest);
+}
+
+/**
+ * Synchronously reads in the file at the given path and caches the contents in-memory.
+ *
+ * @param {string} src The path of the file to read.
+ * @returns {string} The contents of the file.
+ */
+export function readFileSync(src: string): string {
+  const name = path.resolve(src);
+
+  return fileQueue[name]?.body || (fileQueue[name] = {
+    body: fs.readFileSync(name, { encoding: 'utf8' })
+  }).body;
+}
+
+/**
+ * Synchronously removes a file from a given path.
+ *
+ * @param {string} src The path to remove.
+ * @returns {void}
+ */
+export function removeSync(src: string): void {
+  const name = path.resolve(src);
+  let file = fileQueue[name];
+
+  if (file) {
+    if (file.dirty) {
+      process.removeListener('beforeExit', file.dirty);
+    }
+
+    delete fileQueue[name];
+  } else {
+    // Check if this is a parent directory of any cached files
+    for (const cached in fileQueue) {
+      if (cached.startsWith(name)) {
+        file = fileQueue[cached];
+
+        if (file.dirty) {
+          process.removeListener('beforeExit', file.dirty);
+        }
+
+        delete fileQueue[cached];
+      }
+    }
+  }
+
+  fs.removeSync(src);
+}
+
+/**
+ * Updates a file, replacing a given string with a new one.
+ *
+ * @param {string} path The path to the file to update.
+ * @param {string} oldText The old text to replace.
+ * @param {string} newText The replacement text.
+ * @returns {void}
+ */
+export function update(path: string, oldText: string | RegExp, newText: string): void {
+  if (!doesKeywordExist(path, oldText)) {
+    return helpers.logError(`Couldn't find ${oldText} in ${path}`);
+  }
+
+  const fileContent = readFileSync(path);
+
+  helpers.logInfo(`updating ${helpers.colors.Dim}${path}${helpers.colors.Reset}`);
+  writeFileSync(path, fileContent.replace(oldText, newText));
+}
+
+/**
+ * Updates the cached version of given file and schedules the file to be written to disk before
+ * the process exits.
+ *
+ * @param {string} dest The path of the file to write.
+ * @param {string} body The new body of the file.
+ * @returns {void}
+ */
+export function writeFileSync(dest: string, body: string): void {
+  const name = path.resolve(dest);
+  let file = fileQueue[name];
+
+  if (!file) {
+    file = (fileQueue[name] = { body });
+  } else {
+    file.body = body;
+  }
+
+  if (!file.dirty) {
+    file.dirty = code => {
+      // Only commit the file to disk if the process is exiting successfully.
+      if (0 === code) {
+        fs.writeFile(name, file.body, (err: Error) => {
+          if (err) {
+            helpers.logError(`Error saving file ${name}`, err.toString());
+          }
+
+          delete file.dirty;
+        });
+      }
+    };
+
+    // Schedule the file to be written before the process closes.
+    process.once('beforeExit', file.dirty);
   }
 }

--- a/packages/flagship/src/lib/modules/android/react-native-camera.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-camera.ts
@@ -8,7 +8,7 @@ import {
 export function postLink(configuration: Config): void {
   // Add dependencies to /android/app/build.gradle and replace compile command with implementation
   // command due to Gradle 3 changes
-  let gradleAppBuild = fs.readFileSync(path.android.gradlePath(), { encoding: 'utf8' });
+  let gradleAppBuild = fs.readFileSync(path.android.gradlePath());
 
   gradleAppBuild = gradleAppBuild.replace(
     'defaultConfig {',
@@ -21,7 +21,7 @@ export function postLink(configuration: Config): void {
 
   // Disable aapt2 because it's not causes issues with our image assets. Add
   // android.enableAapt2=false to gradle.properties
-  let gradleProps = fs.readFileSync(path.android.gradlePropertiesPath(), { encoding: 'utf8' });
+  let gradleProps = fs.readFileSync(path.android.gradlePropertiesPath());
   gradleProps += '\nandroid.enableAapt2=false\n';
   fs.writeFileSync(path.android.gradlePropertiesPath(), gradleProps);
   logInfo('disabled aapt2 in gradle.properties');

--- a/packages/flagship/src/lib/modules/android/react-native-code-push.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-code-push.ts
@@ -66,7 +66,7 @@ export function postLink(configuration: Config): void {
   const codePushGradlePath =
     'apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"';
   const gradlePath = path.android.gradlePath();
-  const gradleContent = fs.readFileSync(gradlePath, { encoding: 'utf8' });
+  const gradleContent = fs.readFileSync(gradlePath);
   if (gradleContent.indexOf(codePushGradlePath) < 0) {
     logInfo(`patching codepush into build.gradle`);
     fs.writeFileSync(

--- a/packages/flagship/src/lib/modules/android/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-firebase.ts
@@ -24,7 +24,7 @@ export function postLink(configuration: Config): void {
 
   // Disable aapt2 because it's not compatible with the Firebase install. Add
   // android.enableAapt2=false to gradle.properties
-  let gradleProps = fs.readFileSync(path.android.gradlePropertiesPath(), { encoding: 'utf8' });
+  let gradleProps = fs.readFileSync(path.android.gradlePropertiesPath());
   gradleProps += '\nandroid.enableAapt2=false\n';
   fs.writeFileSync(path.android.gradlePropertiesPath(), gradleProps);
   logInfo('disabled aapt2 in gradle.properties');
@@ -35,7 +35,7 @@ export function postLink(configuration: Config): void {
     implementation 'com.google.firebase:firebase-core:16.0.1'
       `;
 
-  let gradleAppBuild = fs.readFileSync(path.android.gradlePath(), { encoding: 'utf8' });
+  let gradleAppBuild = fs.readFileSync(path.android.gradlePath());
 
   gradleAppBuild = gradleAppBuild.replace(
     /(com.google.android.gms:play-services-base:.+)/,
@@ -51,7 +51,7 @@ export function postLink(configuration: Config): void {
   logInfo('updated ./android/app/build.gradle');
 
   // Add dependencies to /android/build.gradle and update gradle version to 3.1.3
-  let gradleBuild = fs.readFileSync(path.resolve('android', 'build.gradle'), { encoding: 'utf8' });
+  let gradleBuild = fs.readFileSync(path.resolve('android', 'build.gradle'));
   const servicesDep = `classpath 'com.google.gms:google-services:4.0.1'`;
 
   if (gradleBuild.indexOf(servicesDep) > -1) {
@@ -74,10 +74,7 @@ export function postLink(configuration: Config): void {
   logInfo('updated ./android/build.gradle');
 
   // Update MainApplication.java
-  let mainApplication = fs.readFileSync(
-    path.android.mainApplicationPath(configuration),
-    { encoding: 'utf8' }
-  );
+  let mainApplication = fs.readFileSync(path.android.mainApplicationPath(configuration));
 
   mainApplication = mainApplication.replace(
     /(import io.invertase.firebase.RNFirebasePackage;)/,

--- a/packages/flagship/src/lib/modules/android/react-native-sensitive-info.ts
+++ b/packages/flagship/src/lib/modules/android/react-native-sensitive-info.ts
@@ -13,7 +13,7 @@ export function postLink(configuration: Config): void {
   logInfo('patching Android for react-native-sensitive-info');
   const mainApplicationPath = path.android.mainApplicationPath(configuration);
 
-  let mainApplication = fs.readFileSync(mainApplicationPath, { encoding: 'utf8' });
+  let mainApplication = fs.readFileSync(mainApplicationPath);
 
   if (mainApplication.indexOf('RNSensitiveInfoPackage') > -1) {
     logInfo('react-native-sensitive-info is already linked in MainApplication.java');
@@ -31,6 +31,6 @@ export function postLink(configuration: Config): void {
     '$1\n                new RNSensitiveInfoPackage(),'
   );
 
-  fs.writeFileSync(mainApplicationPath, mainApplication, { encoding: 'utf8' });
+  fs.writeFileSync(mainApplicationPath, mainApplication);
   logInfo('finished patching Android for react-native-sensitive-info');
 }

--- a/packages/flagship/src/lib/modules/ios/react-native-adobe-analytics.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-adobe-analytics.ts
@@ -21,7 +21,7 @@ export function preLink(config: Config): void {
   logInfo('Sucessfully copied ADBMobileConfig.json to iOS folder');
 
   // Add Adobe Mobile SDK Podfile
-  const podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
+  const podfile = fs.readFileSync(path.ios.podfilePath());
   const adobeSdk = `pod 'AdobeMobileSDK', '~> 4.14.1'`;
 
   if (podfile.indexOf(adobeSdk) === -1) {

--- a/packages/flagship/src/lib/modules/ios/react-native-firebase.ts
+++ b/packages/flagship/src/lib/modules/ios/react-native-firebase.ts
@@ -24,10 +24,7 @@ export function preLink(configuration: Config): void {
   );
   logInfo('copied GoogleService-Info.plist to ./ios/');
 
-  let appDelegate = fs.readFileSync(
-    path.ios.appDelegatePath(configuration),
-    { encoding: 'utf-8' }
-  );
+  let appDelegate = fs.readFileSync(path.ios.appDelegatePath(configuration));
 
   // Update AppDelegate.m with Firebase import and initialization
   const firebaseImport = '#import <Firebase.h>';
@@ -44,7 +41,7 @@ export function preLink(configuration: Config): void {
   }
 
   // Add Firebase pod to Podfile
-  const podfile = fs.readFileSync(path.ios.podfilePath(), { encoding: 'utf-8' });
+  const podfile = fs.readFileSync(path.ios.podfilePath());
   const firebasePod = `pod 'Firebase/Core', '6.13.0'`;
 
   if (podfile.indexOf(firebasePod) === -1) {

--- a/packages/flagship/src/lib/rename.ts
+++ b/packages/flagship/src/lib/rename.ts
@@ -18,6 +18,10 @@ import {
 export function source(oldName: string, newName: string, ...pathComponents: string[]): void {
   const directory = path.project.resolve(...pathComponents);
 
+  // Since we're using a 3rd party library to do the replace glob, ensure our disc is in sync
+  // with our in-memory cache.
+  fs.flushSync();
+
   try {
     replace.sync({
       files: directory + '/**/*',
@@ -106,7 +110,7 @@ export function files(oldName: string, newName: string, ...pathComponents: strin
         .replace(oldName.toLocaleLowerCase(), newName.toLocaleLowerCase());
       newPath = newPath.join('/');
 
-      fs.renameSync(oldPath, newPath);
+      fs.moveSync(oldPath, newPath);
     });
   } catch (err) {
     logError('renaming project files', err);


### PR DESCRIPTION
When a Flagship project inits, it can read and write the same file to disk multiple times.

This change caches the contents of files read in-memory and commits them to disk when the init process exits.