### PR TITLE
fix(flagship): stop forcing lowercasing when renaming packages

### DIFF
--- a/packages/flagship/src/lib/rename.ts
+++ b/packages/flagship/src/lib/rename.ts
@@ -52,7 +52,7 @@ export function pkgDirectory(oldPkg: string, newPkg: string, ...pathComponents: 
 
     // Rename matching paths
     results.forEach(oldPath => {
-      const newPath = oldPath.replace(oldPathPart, newPathPart).toLowerCase();
+      const newPath = oldPath.replace(oldPathPart, newPathPart);
       fs.moveSync(oldPath, newPath);
     });
 


### PR DESCRIPTION
We were unnecessarily forcing the path to lowercase when renaming packages. This would break on case sensitive filesystems if you had a capital letter in the path containing your project.

Fixes #1778