### PR TITLE
fix(fslinker): update global typing to support node 16

### DIFF
--- a/packages/fslinker/src/cache/global-cache.ts
+++ b/packages/fslinker/src/cache/global-cache.ts
@@ -8,15 +8,8 @@ import { InjectorCache, InMemoryCache } from './cache';
 const GLOBAL_CACHE_KEY = '__FLAGSHIP_LINKER_GLOBAL_CACHE__';
 
 declare global {
-  interface Window {
-    [GLOBAL_CACHE_KEY]: Map<string, unknown>;
-  }
-
-  namespace NodeJS {
-    interface Global {
-      [GLOBAL_CACHE_KEY]: Map<string, unknown>;
-    }
-  }
+  // tslint:disable-next-line: no-var-keyword
+  export var __FLAGSHIP_LINKER_GLOBAL_CACHE__: Map<string, unknown>;
 }
 
 export class GlobalInjectorCache extends InMemoryCache implements InjectorCache {


### PR DESCRIPTION
The DefinitelyTyped definition of the global object for Node 16 removed NodeJS.Global as an exported type for the global object, which causes this file to fail to compile.

This change explicitly declares `__FLAGSHIP_LINKER_GLOBAL_CACHE__` as existing in the global scope so we can compile for Node 14 and 16.