### PR TITLE
chore(pirateship): remove unused react-native-safe-area

### DIFF
--- a/packages/pirateship/package.json
+++ b/packages/pirateship/package.json
@@ -59,7 +59,6 @@
     "react-native-htmlview": "^0.15.0",
     "react-native-localize": "^1.3.0",
     "react-native-navigation": "^6.0.0",
-    "react-native-safe-area": "^0.5.0",
     "react-native-sensitive-info": "^5.5.0",
     "react-native-svg": "^10.0.0",
     "react-native-touch-id": "~4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,7 +4047,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.8", "@types/react@^16.9.11":
+"@types/react@*", "@types/react@^16.9.11":
   version "16.9.55"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.55.tgz#47078587f5bfe028a23b6b46c7b94ac0d436acff"
   integrity sha512-6KLe6lkILeRwyyy7yG9rULKJ0sXplUsl98MGoCfpteXf9sPWFWWMknDcsvubcpaTdBuxtsLF6HDUwdApZL/xIg==
@@ -14755,13 +14755,6 @@ react-native-ratings@^7.2.0:
   dependencies:
     lodash "^4.17.15"
     prop-types "^15.7.2"
-
-react-native-safe-area@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area/-/react-native-safe-area-0.5.1.tgz#b0263f5fcd1341c74dee0e5f0b296da965242a14"
-  integrity sha512-gBLv93P90sM6hk5HzUwTXzFuSDazTpg2ONi5iL9pnUsUfwdw2L9SKgjgVroxX10leGB9+0zz6/ycV+mItqr8OQ==
-  dependencies:
-    "@types/react" "^16.8.8"
 
 react-native-sensitive-info@^5.5.0:
   version "5.5.8"


### PR DESCRIPTION
react-native-safe-area is not used in Flagship. This change removes the dependency.