### PR TITLE
fix(fsapp): stuck router after external navigation

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/history.web.ts
+++ b/packages/fsapp/src/beta-app/router/history/history.web.ts
@@ -86,15 +86,16 @@ export class History implements FSRouterHistory {
         window.location.href = to;
       } else {
         this.browserHistory.push(to, state);
+        await this.nextLoad;
       }
     } else {
       if (to?.pathname && /^\w+:\/\//.exec(to.pathname)) {
         window.location.href = to.pathname;
       } else if (to) {
         this.browserHistory.push(to);
+        await this.nextLoad;
       }
     }
-    await this.nextLoad;
   }
 
   public replace(path: string, state?: unknown): Promise<void>;


### PR DESCRIPTION
## Description

This handles an edge case of external navigations failing or the fsapp being left in memory.
It prevents the router from being stuck in thse cases
