### PR TITLE
fix(fsengagement): context fix for class components in v10

### DIFF
--- a/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
+++ b/packages/fsengagement/src/carousel/RenderImageTextItem.tsx
@@ -1,5 +1,5 @@
 /* tslint:disable */
-import React, { Component } from 'react';
+import React, { Component, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dimensions,
@@ -12,6 +12,7 @@ import {
   View
 } from 'react-native';
 import styles from './SliderEntry.style';
+import { EngagementContext } from '../lib/contexts';
 
 export interface RenderItemProps {
   data?: any;
@@ -42,11 +43,11 @@ export interface RenderItemState {
 
 const { height: viewportHeight } = Dimensions.get('window');
 
-export default class RenderImageTextItem extends Component<RenderItemProps, RenderItemState> {
+class RenderImageTextItem extends Component<RenderItemProps & { context: any }, RenderItemState> {
   static contextTypes: any = {
     handleAction: PropTypes.func
   };
-  constructor(props: RenderItemProps) {
+  constructor(props: RenderItemProps & { context: any }) {
     super(props);
     this.state = {
       viewHeight: 0,
@@ -84,7 +85,7 @@ export default class RenderImageTextItem extends Component<RenderItemProps, Rend
     if (!link) {
       return;
     }
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link
@@ -228,3 +229,8 @@ export default class RenderImageTextItem extends Component<RenderItemProps, Rend
     );
   }
 }
+
+export default (props: RenderItemProps) => {
+  const context = useContext(EngagementContext);
+  return <RenderImageTextItem {...props} context={context} />;
+};

--- a/packages/fsengagement/src/inboxblocks/IconTextBlock.tsx
+++ b/packages/fsengagement/src/inboxblocks/IconTextBlock.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useContext } from 'react';
 import {
   Image,
   ImageStyle,
@@ -13,6 +13,7 @@ import { TextBlock } from './TextBlock';
 import { ImageBlock } from './ImageBlock';
 import { CTABlock } from './CTABlock';
 import DividerBlock from './DividerBlock';
+import { EngagementContext } from '../lib/contexts';
 
 const images = {
   rightArrow: require('../../assets/images/rightArrow.png'),
@@ -65,7 +66,7 @@ export interface IconTextProps {
 }
 export type ArrowTypes = 'rightArrow' | 'rightBlockArrow' | 'rightCategoryArrow';
 
-export default class IconTextBlock extends Component<IconTextProps> {
+class IconTextBlock extends Component<IconTextProps & { context: any }> {
   static contextTypes: any = {
     handleAction: PropTypes.func
   };
@@ -73,7 +74,7 @@ export default class IconTextBlock extends Component<IconTextProps> {
     if (!link) {
       return;
     }
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link
@@ -158,3 +159,8 @@ export default class IconTextBlock extends Component<IconTextProps> {
     );
   }
 }
+
+export default (props: IconTextProps) => {
+  const context = useContext(EngagementContext);
+  return <IconTextBlock {...props} context={context} />;
+};

--- a/packages/fsengagement/src/inboxblocks/ImageWithOverlay.tsx
+++ b/packages/fsengagement/src/inboxblocks/ImageWithOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dimensions,
@@ -12,6 +12,7 @@ import {
   ViewStyle
 } from 'react-native';
 import { TextBlock } from './TextBlock';
+import { EngagementContext } from '../lib/contexts';
 export interface ImageBlockProps {
   source: ImageURISource;
   resizeMode?: any;
@@ -31,7 +32,7 @@ export interface ImageBlockState {
   height?: number;
 }
 
-export default class ImageWithOverlay extends Component<ImageBlockProps, ImageBlockState> {
+class ImageWithOverlay extends Component<ImageBlockProps & { context: any }, ImageBlockState> {
   static contextTypes: any = {
     handleAction: PropTypes.func
   };
@@ -105,7 +106,7 @@ export default class ImageWithOverlay extends Component<ImageBlockProps, ImageBl
     return result;
   }
   onPress = (link: string) => () => {
-    const { handleAction } = this.context;
+    const { handleAction } = this.props.context;
     handleAction({
       type: 'deep-link',
       value: link
@@ -232,3 +233,8 @@ export default class ImageWithOverlay extends Component<ImageBlockProps, ImageBl
     );
   }
 }
+
+export default (props: ImageBlockProps) => {
+  const context = useContext(EngagementContext);
+  return <ImageWithOverlay {...props} context={context} />;
+};


### PR DESCRIPTION
Fixes some class components that are not able to use context directly so we have to inject context into them.  This applies the following prs that were made to develop: https://github.com/brandingbrand/flagship/pull/2252 and https://github.com/brandingbrand/flagship/pull/2255