### PR TITLE
fix: snaps carousel back to first image when autoscrolling

### DIFF
--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -265,11 +265,10 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
       if (scrollViewElement instanceof HTMLElement && !animating) {
         setAnimating(true);
         await animatedScrollTo(scrollViewElement, nextIndex * pageWidth, animated ? 200 : 0)
-          .then(() => setAnimating(false))
           .catch(e => {
-            setAnimating(false);
             console.warn('animatedScrollTo error', e);
-          });
+          })
+          .finally(() => setAnimating(false))
         // Hacky fix for a hacky Safari release. This fixes a scroll issue
         // on iOS 14.
         setTimeout(() => {
@@ -285,7 +284,7 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
     const animationOptions =
       nextIndex !== 0 &&
       options &&
-      'animated' in options ? options : {animated: false};
+      'animated' in options ? options : {animated: true};
 
     await goTo(nextIndex, animationOptions);
   }, [goTo, currentIndex, numberOfPages]);

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -268,7 +268,7 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
           .catch(e => {
             console.warn('animatedScrollTo error', e);
           })
-          .finally(() => setAnimating(false))
+          .finally(() => setAnimating(false));
         // Hacky fix for a hacky Safari release. This fixes a scroll issue
         // on iOS 14.
         setTimeout(() => {

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -281,9 +281,13 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
   );
 
   const goToNext = useCallback(async (options?: GoToOptions | GestureResponderEvent) => {
-    const nextIndex = currentIndex + 1 > numberOfPages - 1 ? numberOfPages - 1 : currentIndex + 1;
+    const nextIndex = currentIndex + 1 > numberOfPages - 1 ? 0 : currentIndex + 1;
+    const animationOptions =
+      nextIndex !== 0 &&
+      options &&
+      'animated' in options ? options : {animated: false};
 
-    await goTo(nextIndex, options && 'animated' in options ? options : undefined);
+    await goTo(nextIndex, animationOptions);
   }, [goTo, currentIndex, numberOfPages]);
 
   const goToPrev = useCallback(async (options?: GoToOptions | GestureResponderEvent) => {
@@ -309,7 +313,6 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
   useEffect(() => {
     if (autoplay && numberOfPages > 0 && !animating && shouldPlay) {
       autoplayTimeout.current = setTimeout(async () => {
-        const nextIndex = currentIndex + 1;
         const options = {
           animated: true
         };
@@ -317,12 +320,7 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
         if (autoplayTimeoutDuration <= 300) {
           options.animated = false;
         }
-
-        if (nextIndex < numberOfPages) {
-          await goToNext(options);
-        } else {
-          await goToPrev(options);
-        }
+        await goToNext(options);
       }, autoplayTimeoutDuration);
       return () => {
         if (autoplayTimeout.current) {

--- a/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
+++ b/packages/fscomponents/src/components/MultiCarousel/MultiCarousel.web.tsx
@@ -281,12 +281,7 @@ export const MultiCarousel = <ItemT, >(props: MultiCarouselProps<ItemT>) => {
 
   const goToNext = useCallback(async (options?: GoToOptions | GestureResponderEvent) => {
     const nextIndex = currentIndex + 1 > numberOfPages - 1 ? 0 : currentIndex + 1;
-    const animationOptions =
-      nextIndex !== 0 &&
-      options &&
-      'animated' in options ? options : {animated: true};
-
-    await goTo(nextIndex, animationOptions);
+    await goTo(nextIndex, options && 'animated' in options ? options : undefined);
   }, [goTo, currentIndex, numberOfPages]);
 
   const goToPrev = useCallback(async (options?: GoToOptions | GestureResponderEvent) => {

--- a/packages/fscomponents/src/components/__stories__/MultiCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/MultiCarousel.story.tsx
@@ -88,13 +88,23 @@ storiesOf('MultiCarousel', module)
       showArrow={boolean('arrow?', true)}
     />
   ))
-  .add('Image Carousel', () => (
+  .add('Image Carousel Autoplay', () => (
     <MultiCarousel
       data={imageItems}
       renderItem={renderImage}
       itemsPerPage={number('itemsPerPage', 1)}
       autoplay={true}
-      autoplayTimeoutDuration={3000}
+      autoplayTimeoutDuration={1000}
+      showArrow={boolean('arrow?', true)}
+    />
+  ))
+  .add('Image Carousel No Autoplay', () => (
+    <MultiCarousel
+      data={imageItems}
+      renderItem={renderImage}
+      itemsPerPage={number('itemsPerPage', 1)}
+      autoplay={false}
+      autoplayTimeoutDuration={1000}
       showArrow={boolean('arrow?', true)}
     />
   ));

--- a/packages/fscomponents/src/components/__stories__/MultiCarousel.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/MultiCarousel.story.tsx
@@ -8,13 +8,35 @@ import {
   boolean, number, object
 // tslint:disable-next-line no-implicit-dependencies
 } from '@storybook/addon-knobs';
-import { ListRenderItem, StyleSheet } from 'react-native';
+import {
+  Image,
+  ListRenderItem,
+  StyleSheet,
+  View
+} from 'react-native';
 
-const productItems = [...Array(10)].map((a, i) => ({
+const productItems = [...Array(9)].map((a, i) => ({
   id: i,
   title: `Product ${i + 1}`,
-  image: 'https://placehold.it/100x100'
+  image: `https://via.placeholder.com/100/${i}F${i}F${i}F`
 }));
+
+const imageItems = [...Array(3)].map((a, i) => ({
+  id: i,
+  title: '',
+  image: `https://via.placeholder.com/300/${i}F${i}F${i}F`
+}));
+
+
+const imageStyle = StyleSheet.create({
+  image: {
+    width: 300,
+    height: 300
+  },
+  container: {
+    alignItems: 'center'
+  }
+});
 
 const style = StyleSheet.create({
   imageStyle: {
@@ -45,6 +67,17 @@ const renderItem: ListRenderItem<typeof productItems[number]> = ({ item }) => {
   );
 };
 
+const renderImage: ListRenderItem<typeof imageItems[number]> = ({ item }) => {
+  return (
+    <View style={imageStyle.container}>
+      <Image
+        source={{uri: item.image}}
+        style={imageStyle.image}
+      />
+    </View>
+  );
+};
+
 // TODO: Update MultiCarousel to support prop switching
 storiesOf('MultiCarousel', module)
   .add('basic usage', () => (
@@ -52,6 +85,16 @@ storiesOf('MultiCarousel', module)
       data={productItems}
       renderItem={renderItem}
       itemsPerPage={number('itemsPerPage', 3)}
+      showArrow={boolean('arrow?', true)}
+    />
+  ))
+  .add('Image Carousel', () => (
+    <MultiCarousel
+      data={imageItems}
+      renderItem={renderImage}
+      itemsPerPage={number('itemsPerPage', 1)}
+      autoplay={true}
+      autoplayTimeoutDuration={3000}
       showArrow={boolean('arrow?', true)}
     />
   ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5857,7 +5857,7 @@ autobind-decorator@^2.4.0:
   resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
   integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
 
-autoprefixer@^9.8.6:
+autoprefixer@^9.1.5, autoprefixer@^9.8.6:
   version "9.8.8"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.8.tgz#fd4bd4595385fa6f06599de749a4d5f7a474957a"
   integrity sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==


### PR DESCRIPTION
In this PR
=========
Amends carousel behavior to snap back to first item when autoscrolling and reaches the end
Adds Storybook to demo the behavior

https://www.screencast.com/t/GM6UfK168m