### PR TITLE
chore: ignore vim's temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ packages/pirateship/env/env.js
 
 # Incremental Builds
 **/*.tsbuildinfo
+
+# Vim
+*.swp
+*.swo


### PR DESCRIPTION
In this PR
========
Adds Vim's tmp files to git ignore so they are not accidentally committed.