### PR TITLE
fix(fsapp): FS-3176 - nested scrolling causing unpainted divs

### DIFF
--- a/packages/fsapp/src/beta-app/development/version-overlay.component.tsx
+++ b/packages/fsapp/src/beta-app/development/version-overlay.component.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity } from 'react-native';
 
 import { useApp } from '../app/context';
 import { useModals } from '../modal';
@@ -36,9 +36,9 @@ export const VersionOverlay: FC = ({ children }) => {
   }
 
   return (
-    <View style={styles.screenContainer}>
+    <>
       {children}
       <Version />
-    </View>
+    </>
   );
 };

--- a/packages/fsapp/src/beta-app/development/version-overlay.styles.tsx
+++ b/packages/fsapp/src/beta-app/development/version-overlay.styles.tsx
@@ -1,10 +1,6 @@
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
-  screenContainer: {
-    flex: 1,
-    flexBasis: 'auto'
-  },
   devNoteContainer: {
     position: 'absolute',
     bottom: 0,

--- a/packages/fsapp/src/beta-app/development/version-overlay.styles.web.tsx
+++ b/packages/fsapp/src/beta-app/development/version-overlay.styles.web.tsx
@@ -1,10 +1,6 @@
 import { CreateWebStyles } from '../utils';
 
 export const styles = CreateWebStyles({
-  screenContainer: {
-    flex: 1,
-    flexBasis: 'auto'
-  },
   devNoteContainer: {
     position: 'fixed',
     bottom: 0,

--- a/packages/fsapp/src/beta-app/router/router.web.tsx
+++ b/packages/fsapp/src/beta-app/router/router.web.tsx
@@ -189,15 +189,15 @@ export class FSRouter extends FSRouterBase {
     return (
       <NavigatorProvider value={this.history}>
         <ModalProvider>
-          <VersionOverlay>
-            <WebShellProvider {...this.options.shell}>
+          <WebShellProvider {...this.options.shell}>
+            <VersionOverlay>
               <Router history={this.history}>
                 <Switch>
                   {this.routes.map(route => this.constructScreen(route, loading, routeDetails))}
                 </Switch>
               </Router>
-            </WebShellProvider>
-          </VersionOverlay>
+            </VersionOverlay>
+          </WebShellProvider>
         </ModalProvider>
       </NavigatorProvider>
     );

--- a/packages/fsapp/src/beta-app/shell.web/shell.context.tsx
+++ b/packages/fsapp/src/beta-app/shell.web/shell.context.tsx
@@ -1,7 +1,7 @@
 import type { DrawerComponentType, ShellConfig, WebShell } from './types';
 
 import React, { createContext, FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, TouchableWithoutFeedback, View, ViewStyle } from 'react-native';
+import { TouchableWithoutFeedback, View, ViewStyle } from 'react-native';
 
 import { InjectionToken } from '@brandingbrand/fslinker';
 
@@ -43,25 +43,23 @@ const styles = CreateWebStyles({
     overflowX: 'hidden'
   },
   appDrawerDefault: {
-    flex: 1,
+    flexGrow: 1,
     flexBasis: 'auto'
   },
   container: {
     width: '100%',
-    flex: 1,
+    flexGrow: 1,
     flexBasis: 'auto',
     transitionProperty: 'margin-left'
   },
   containerOverlay: {
     backgroundColor: 'black',
     opacity: 0,
-    position: 'fixed',
-    height: '100%',
-    width: 0,
+    position: 'absolute',
     transitionProperty: 'opacity'
   },
   containerOverlayActive: {
-    width: '100%'
+    inset: 0
   }
 });
 
@@ -128,8 +126,8 @@ export const WebShellProvider: FC<ShellConfig> = ({
       <View
         style={[styles.appDrawerDefault, (activateLeft || activateRight) && styles.appDrawerOpen]}
       >
-        <ScrollView
-          contentContainerStyle={[
+        <View
+          style={[
             styles.container,
             leftDrawerOpen && LeftDrawer?.options?.slideShell && { marginLeft: leftWidth },
             rightDrawerOpen &&
@@ -160,7 +158,7 @@ export const WebShellProvider: FC<ShellConfig> = ({
               ]}
             />
           </TouchableWithoutFeedback>
-        </ScrollView>
+        </View>
 
         {LeftDrawer && (
           <DrawerContainer


### PR DESCRIPTION
Ticket: https://brandingbrand.atlassian.net/browse/FS-3176

## Description

This fixes some weird chrome specific rendering bugs with scroll views
This removes unneeded scroll views and uses `flexGrow` instead of `flex` for some other views
This uses `inset` instead of `height` to make the overlay cover the whole screen
