### PR TITLE
fix(fsapp): return if out of range

### DIFF
--- a/packages/fsapp/src/beta-app/router/history/history.ts
+++ b/packages/fsapp/src/beta-app/router/history/history.ts
@@ -181,9 +181,13 @@ export class History implements FSRouterHistory {
   @queueMethod
   public async pop(): Promise<void> {
     const stack = this.stack?.children ?? [];
+    const previousStack = stack[stack.length - 2];
+    if (!previousStack) {
+      return;
+    }
     const newLocation = {
       stack: this.activeStack,
-      ...stack[stack.length - 2]
+      ...previousStack
     };
 
     await this.updateLocation(newLocation, 'POP');


### PR DESCRIPTION
**Description**
- This fixes an issue found recently on an app where if the user if able to tap/click the pop button multiple times, it then breaks any further navigation such as from categories.
- This simply returns if the navigation is out of range

**Testing**
In an Android simulator, navigate to a PIP
Click rapidly, twice on a pop trigger
Observe link triggers on categories always work now