### PR TITLE
types(Product.ts): Adds extendedSizing key to Product type

### DIFF
--- a/packages/fscommerce/src/Commerce/types/Product.ts
+++ b/packages/fscommerce/src/Commerce/types/Product.ts
@@ -218,5 +218,5 @@ export interface Product extends BaseProduct {
    *
    * @example ['NC17', 'NC68']
    */
-  extendedSizs?: string[];
+  extendedSizes?: string[];
 }

--- a/packages/fscommerce/src/Commerce/types/Product.ts
+++ b/packages/fscommerce/src/Commerce/types/Product.ts
@@ -212,4 +212,11 @@ export interface Product extends BaseProduct {
    * @example '165139'
    */
   reviewId?: string;
+
+  /**
+   * List of identifiers of extended sized versions of the original product
+   *
+   * @example ['NC17', 'NC68']
+   */
+  extendedSizs?: string[];
 }


### PR DESCRIPTION
## Changes
- Adds extendedSizing key to Product type

## Reason for Change
Need this key to return a valid Product type from Submarine's fssalesforce DemandwareNormalizer

# Related
- [MAD-2382 PR](https://github.com/brandingbrand/madewell.rn/pull/1026)
- [Submarine PR 813](https://github.com/brandingbrand/submarine/pull/813)