### PR TITLE
feat: AS-297 Make refine header optional

### DIFF
--- a/packages/fscomponents/src/components/FilterList/FilterListDrilldown.tsx
+++ b/packages/fscomponents/src/components/FilterList/FilterListDrilldown.tsx
@@ -88,6 +88,7 @@ export interface FilterListDrilldownProps {
   secondLevelShowApply?: boolean;
   secondLevelShowClose?: boolean;
   optionsFooterStyles?: StyleProp<ViewStyle>;
+  showDrillDownHeader?: boolean;
 }
 
 const S = StyleSheet.create({
@@ -533,7 +534,12 @@ export class FilterListDrilldown extends PureComponent<
             display: this.state.secondLevelItem ? 'none' : 'flex'
           }}
         >
-          {this.renderDrilldownHeader()}
+          {
+            // Default to true
+            this.props.showDrillDownHeader === undefined || this.props.showDrillDownHeader ?
+              this.renderDrilldownHeader() :
+              null
+          }
           <FlatList
             data={this.props.items}
             renderItem={this.renderFilterItem}

--- a/packages/fscomponents/src/components/__stories__/FilterListDrilldown.story.tsx
+++ b/packages/fscomponents/src/components/__stories__/FilterListDrilldown.story.tsx
@@ -57,6 +57,7 @@ storiesOf('FilterListDrilldown', module)
       onReset={action('FilterList onReset')}
       singleFilterIds={['sort']}
       onClose={boolean('Show Close', true) ? action('FilterList onClose') : undefined}
+      showDrillDownHeader={boolean('Show Drill Down Header', true)}
       showUnselected={boolean('Show Unselected', false)}
       showSelectedCount={boolean('Show Selected Count', false)}
       secondLevelShowApply={boolean('Show Second Level Apply', false)}


### PR DESCRIPTION
This PR adds a new props to the `FilterListDrilldown` to allow for hiding the refine bar. 

new props defaults to `true` and it's named `showDrillDownHeader` (Optional- boolean).
