### PR TITLE
fix(flagship): updating android template files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,50 +28,29 @@ jobs:
     sudo: true
     dist: trusty
     os: linux
-    # android emulator setup based on https://github.com/brianegan/flutter_architecture_samples
-    # from comment in https://github.com/googlemaps/android-maps-utils/issues/371#issuecomment-498921876
+    language: android
+    jdk: openjdk8
+    android:
+      components:
+        # Adds Android API 22 and emulator image to android image
+        # https://docs.travis-ci.com/user/languages/android/#how-to-install-android-sdk-components
+        - android-22
+        - extra
+        - sys-img-armeabi-v7a-android-22
     before_install:
-      - ANDROID_SDK_TOOLS=4333796 # android-28
-      - ANDROID_PLATFORM_SDK=28
-      - ANDROID_BUILD_TOOLS=28.0.3
-      - sudo apt-get install -y --no-install-recommends lib32stdc++6 libstdc++6 > /dev/null
-      # Install the Android SDK Dependency.
-      - export ANDROID_HOME=/opt/android-sdk-linux
-      - cd /opt
-      - wget -q https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_TOOLS.zip -O android-sdk-tools.zip
-      - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
-      - rm android-sdk-tools.zip
-      - cd -
-      - PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-      # Silence warning.
-      - mkdir -p ~/.android
-      - touch ~/.android/repositories.cfg
-      # Accept licenses before installing components, no need to echo y for each component
-      - yes | sdkmanager --licenses
-      # Platform and build tools (including flutter requirements)
-      - sdkmanager "emulator" "tools" "platform-tools" "platforms;android-${ANDROID_PLATFORM_SDK}" "build-tools;${ANDROID_BUILD_TOOLS}" > /dev/null
-      - sdkmanager --list | head -15
-
-      # Download a pinned version of the emulator since upgrades can cause issues
-      - ${ANDROID_HOME}/emulator/emulator -version
-      - emulator_version=5264690 #29.0.9.0 (build_id 5537588) ==> 28.0.23.0 (build_id 5264690)
-      - curl -fo emulator.zip "https://dl.google.com/android/repository/emulator-linux-$emulator_version.zip"
-      - rm -rf "${ANDROID_HOME}/emulator"
-      - unzip -q emulator.zip -d "${ANDROID_HOME}"
-      - rm -f emulator.zip
-      - ${ANDROID_HOME}/emulator/emulator -version
-
-      # install older platform and build tools (for emulator)
-      - sdkmanager "build-tools;25.0.2" "platforms;android-25" > /dev/null
-      # Create and start emulator.
-      - EMULATOR_API_LEVEL=22
-      - ANDROID_ABI="default;armeabi-v7a"
-      - sdkmanager "system-images;android-$EMULATOR_API_LEVEL;$ANDROID_ABI" > /dev/null
-      - sdkmanager --list | head -15
-      - echo no | avdmanager create avd --force -n test -k "system-images;android-$EMULATOR_API_LEVEL;$ANDROID_ABI"
-      - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window -gpu swiftshader &
-      - ./scripts/android-wait-for-emulator.sh
+      - rvm install 2.6.0
+      - touch $HOME/.android/repositories.cfg
+      - yes | sdkmanager "platforms;android-31"
+      - yes | sdkmanager "build-tools;33.0.0"
+      - yes | sdkmanager "ndk-bundle"
+      - cp $ANDROID_HOME/build-tools/33.0.0/d8 $ANDROID_HOME/build-tools/33.0.0/dx
+      - cp $ANDROID_HOME/build-tools/33.0.0/lib/d8.jar $ANDROID_HOME/build-tools/33.0.0/lib/dx.jar
+      - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -c 100M
+      - emulator -avd test -no-audio -no-window &
+      - android-wait-for-emulator
+      - adb shell input keyevent 82 &
     script:
+      - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
       - yarn prepare
       - yarn ship:init
       - yarn ship:compile-android

--- a/packages/flagship/android/build.gradle
+++ b/packages/flagship/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 19
         compileSdkVersion = 31
         targetSdkVersion = 31
@@ -19,7 +19,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:4.2.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -38,8 +38,8 @@ subprojects {
     afterEvaluate {
         project -> if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 30
-                buildToolsVersion "30.0.2"
+                compileSdkVersion 31
+                buildToolsVersion "33.0.0"
             }
         }
     }

--- a/packages/flagship/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/flagship/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Jira Ticket
[FCR-3189](https://brandingbrand.atlassian.net/browse/FCR-3189)
[FCR-3190](https://brandingbrand.atlassian.net/browse/FCR-3190)
## Description
- Fixing missed config issue in build.gradle templates
- Bumping gradle wrapper version to 4.2.0
- Updating gradle to 6.9.1
- 
## Testing Instructions
1. Init pirateship
2. Navigate to the project android folder after init and generate a debugBuild -> `./gradlew assembleDebug`
3. Navigate to `app/build/outputs/apk/debug ` and verify .apk config is built to Android 12 API 31 with` aapt dump badging app-debug.apk `

## Testing
## Pirateship  .apk badging
```
package: name='com.brandingbrand.reactnative.and.pirateship' 
versionCode='10019000' 
versionName='10.19.0' 
platformBuildVersionName='12' 
platformBuildVersionCode='31' 
compileSdkVersion='31' 
compileSdkVersionCodename='12'
sdkVersion:'19'
targetSdkVersion:'31'

```