### PR TITLE
Initial FS12 environment package

### DIFF
--- a/packages/component-env/CHANGELOG.md
+++ b/packages/component-env/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @brandingbrand/kernel-component-env
+
+## 0.0.1
+

--- a/packages/component-env/android/build.gradle
+++ b/packages/component-env/android/build.gradle
@@ -1,0 +1,74 @@
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath "com.android.tools.build:gradle:7.2.1"
+  }
+}
+
+def isNewArchitectureEnabled() {
+  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+}
+
+apply plugin: "com.android.library"
+
+if (isNewArchitectureEnabled()) {
+  apply plugin: "com.facebook.react"
+}
+
+def getExtOrDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["Env_" + name]
+}
+
+def getExtOrIntegerDefault(name) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["Env_" + name]).toInteger()
+}
+
+android {
+  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+
+  defaultConfig {
+    minSdkVersion getExtOrIntegerDefault("minSdkVersion")
+    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+  }
+  buildTypes {
+    release {
+      minifyEnabled false
+    }
+  }
+
+  lintOptions {
+    disable "GradleCompatible"
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+
+}
+
+repositories {
+  mavenCentral()
+  google()
+}
+
+
+dependencies {
+  // For < 0.71, this will be from the local maven repo
+  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
+  //noinspection GradleDynamicVersion
+  implementation "com.facebook.react:react-native"
+}
+
+if (isNewArchitectureEnabled()) {
+  react {
+    jsRootDir = file("../src/")
+    libraryName = "Env"
+    codegenJavaPackageName = "com.env"
+  }
+}

--- a/packages/component-env/android/gradle.properties
+++ b/packages/component-env/android/gradle.properties
@@ -1,0 +1,5 @@
+Env_kotlinVersion=1.7.0
+Env_minSdkVersion=21
+Env_targetSdkVersion=31
+Env_compileSdkVersion=31
+Env_ndkversion=21.4.7075529

--- a/packages/component-env/android/src/main/AndroidManifest.xml
+++ b/packages/component-env/android/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.env">
+
+</manifest>

--- a/packages/component-env/android/src/main/java/com/env/EnvModule.java
+++ b/packages/component-env/android/src/main/java/com/env/EnvModule.java
@@ -1,0 +1,50 @@
+package com.env;
+
+import androidx.annotation.NonNull;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvModule extends ReactContextBaseJavaModule {
+  private SharedPreferences sharedPref;
+  public static final String NAME = "Env";
+
+  public EnvModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    sharedPref = reactContext.getSharedPreferences("__ENV_NAME_STORE", Context.MODE_PRIVATE);
+  }
+
+  @Override
+  @NonNull
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Map<String, Object> getConstants() {
+    final String initialEnvName = "dev"; // [Env initialEnvName]
+
+    return new HashMap<String, Object>() {{
+        put("envName", sharedPref.getString("envName", initialEnvName));
+    }};
+  }
+
+  @SuppressLint("ApplySharedPref")
+  @ReactMethod
+  public void setEnv(String name, Promise promise) {
+    final SharedPreferences.Editor editor = sharedPref.edit();
+    editor.putString("envName", name);
+    editor.commit();
+
+    promise.resolve(null);
+  }
+}

--- a/packages/component-env/android/src/main/java/com/env/EnvPackage.java
+++ b/packages/component-env/android/src/main/java/com/env/EnvPackage.java
@@ -1,0 +1,28 @@
+package com.env;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class EnvPackage implements ReactPackage {
+  @NonNull
+  @Override
+  public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new EnvModule(reactContext));
+    return modules;
+  }
+
+  @NonNull
+  @Override
+  public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+}

--- a/packages/component-env/env.podspec
+++ b/packages/component-env/env.podspec
@@ -1,0 +1,35 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
+Pod::Spec.new do |s|
+  s.name         = "env"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+
+  s.platforms    = { :ios => "11.0" }
+  s.source       = { :git => "https://github.com/brandingbrand/flagship.git", :tag => "#{s.version}" }
+
+  s.source_files = "ios/**/*.{h,m,mm}"
+
+  s.dependency "React-Core"
+
+  # Don't install the dependencies when we run `pod install` in the old architecture.
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+    s.pod_target_xcconfig    = {
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+    }
+    s.dependency "React-Codegen"
+    s.dependency "RCT-Folly"
+    s.dependency "RCTRequired"
+    s.dependency "RCTTypeSafety"
+    s.dependency "ReactCommon/turbomodule/core"
+  end
+end

--- a/packages/component-env/ios/Env.h
+++ b/packages/component-env/ios/Env.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Env : NSObject
+
+@end

--- a/packages/component-env/ios/Env.m
+++ b/packages/component-env/ios/Env.m
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface Env : NSObject <RCTBridgeModule>
+@end
+
+
+@implementation Env
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
+- (NSDictionary *)constantsToExport {
+  NSString *initialEnvName =  @"dev"; // [Env initialEnvName]
+  NSString *envName = [[NSUserDefaults standardUserDefaults]
+                       objectForKey:@"envName"];
+  return @{
+    @"envName": envName ?: initialEnvName
+  };
+}
+
+RCT_EXPORT_METHOD(setEnv:(nonnull NSString *)name
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  [[NSUserDefaults standardUserDefaults] setObject:(name ?: @"") forKey:@"envName"];
+  [[NSUserDefaults standardUserDefaults] synchronize];
+  resolve(nil);
+}
+
+@end

--- a/packages/component-env/ios/Foo.h
+++ b/packages/component-env/ios/Foo.h
@@ -1,0 +1,12 @@
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import "RNFooSpec.h"
+
+@interface Foo : NSObject <NativeFooSpec>
+#else
+#import <React/RCTBridgeModule.h>
+
+@interface Foo : NSObject <RCTBridgeModule>
+#endif
+
+@end

--- a/packages/component-env/ios/Foo.mm
+++ b/packages/component-env/ios/Foo.mm
@@ -1,0 +1,27 @@
+#import "Foo.h"
+
+@implementation Foo
+RCT_EXPORT_MODULE()
+
+// Example method
+// See // https://reactnative.dev/docs/native-modules-ios
+RCT_REMAP_METHOD(multiply,
+                 multiplyWithA:(double)a withB:(double)b
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSNumber *result = @(a * b);
+
+    resolve(result);
+}
+
+// Don't compile this code when we build for the old architecture.
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeFooSpecJSI>(params);
+}
+#endif
+
+@end

--- a/packages/component-env/package.json
+++ b/packages/component-env/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@brandingbrand/kernel-component-env",
+  "version": "0.0.1",
+  "description": "Project environment persistence and switching",
+  "homepage": "https://github.com/brandingbrand",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.tsx",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "android",
+    "ios",
+    "env.podspec",
+    "!android/build",
+    "!ios/build"
+  ],
+  "scripts": {
+    "build": "microbundle --target node --jsx 'React.createElement' --compress --format cjs,esm --tsconfig tsconfig.build.json --no-sourcemap",
+    "dev": "microbundle watch --target node --jsx 'React.createElement' --compress --format cjs,esm --tsconfig tsconfig.build.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@brandingbrand/kernel-core": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.21",
+    "@types/react-native": "^0.70.6"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/packages/component-env/src/index.tsx
+++ b/packages/component-env/src/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { NativeModules, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
+
+const styles = StyleSheet.create({
+  row: {
+    borderBottomColor: '#eee',
+    borderBottomWidth: 1,
+    padding: 15,
+    paddingHorizontal: 10
+  },
+  configView: { padding: 10 },
+})
+
+interface Props {
+  restart: () => void;
+}
+
+export const EnvironmentSwitcher: React.FC<Props> = (props) => {
+  const onPress = (e: string) => {
+    env.current = e;
+    props.restart();
+  }
+
+  // TODO: Pull these from env index once that is available
+  const envs = ['dev', 'prod'];
+
+  return (
+    <View style={styles.configView}>
+      {envs.map((e, i) => (
+        <TouchableHighlight
+          key={e}
+          onPress={() => onPress(e)}
+          style={styles.row}
+          underlayColor='#eee'
+        >
+          <Text>{`${e} ${env.current === e ? '[active]' : ''}`}</Text>
+        </TouchableHighlight>
+      ))}
+    </View>
+  )
+}
+
+export const env = {
+  get current(): string {
+    return NativeModules.Env.envName;
+  },
+
+  set current(value: string) {
+    NativeModules.Env.setEnv(value);
+  }
+}

--- a/packages/component-env/test/index.test.ts
+++ b/packages/component-env/test/index.test.ts
@@ -1,0 +1,9 @@
+describe("component-dev", () => {
+  it("ios", () => {
+    expect("").toMatch("");
+  });
+
+  it("android", () => {
+    expect("").toMatch("");
+  });
+});

--- a/packages/component-env/tsconfig.build.json
+++ b/packages/component-env/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "exclude": ["test"]
+}

--- a/packages/component-env/tsconfig.json
+++ b/packages/component-env/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "esModuleInterop": true,
+    "target": "ES5"
+  }
+}


### PR DESCRIPTION
Adds a new package to the mono repro @brandingbrand/kernel-component-env that provides access to the currently active environment via a native bridge and provides a dev menu component that allows for switching the active environment.  A few callouts:

- I've hardcoded an env list ['dev', 'prod'] that is used in the env component currently.  When the env index is exposed in later work, I will create this list from that.
- Initial dev environment in our native modules is hardcoded as 'dev'.  I will be working on a plugin next that will replace this line with the environment that is provided in the init command
- This PR just contains the changes for the env package. Once the PRs for the dev menu and component and plugin are merged I'll be able to fully integrate this.  

Demo:

https://user-images.githubusercontent.com/2643572/210882699-75fa4272-5dce-47b4-8a0e-033f9034b968.mov
