### PR TITLE
Initial FS12 Env Plugin Package

### DIFF
--- a/apps/react-native/package.json
+++ b/apps/react-native/package.json
@@ -29,6 +29,7 @@
     "@babel/runtime": "^7.12.5",
     "@brandingbrand/kernel-cli": "*",
     "@brandingbrand/kernel-component-dev": "*",
+    "@brandingbrand/kernel-plugin-env": "*",
     "@brandingbrand/kernel-plugin-app-icon": "*",
     "@brandingbrand/kernel-plugin-asset": "*",
     "@brandingbrand/kernel-plugin-native-navigation": "*",
@@ -113,6 +114,7 @@
   "kernel": {
     "plugins": [
       "@brandingbrand/kernel-plugin-asset",
+      "@brandingbrand/kernel-plugin-env",
       "@brandingbrand/kernel-plugin-permissions",
       "@brandingbrand/kernel-plugin-native-navigation",
       "@brandingbrand/kernel-plugin-app-icon",

--- a/packages/plugin-env/CHANGELOG.md
+++ b/packages/plugin-env/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @brandingbrand/kernel-plugin-env
+
+## 0.0.1
+
+### Patch Changes

--- a/packages/plugin-env/package.json
+++ b/packages/plugin-env/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@brandingbrand/kernel-plugin-env",
+  "version": "0.0.1",
+  "description": "",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.module.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "microbundle --target node --compress --format cjs,esm --tsconfig tsconfig.build.json --no-sourcemap",
+    "dev": "microbundle watch --target node --compress --format cjs,esm --tsconfig tsconfig.build.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@brandingbrand/kernel-core": "*"
+  }
+}

--- a/packages/plugin-env/src/index.ts
+++ b/packages/plugin-env/src/index.ts
@@ -1,0 +1,35 @@
+import { fsk, path } from "@brandingbrand/kernel-core";
+
+const ios = async (options: any) => {
+  const env = options?.env ?? 'dev';
+  const modulePath = path.project.resolve(
+    "node_modules",
+    "@brandingbrand/kernel-component-env",
+    "ios",
+    "Env.m"
+  );
+
+  fsk.update(
+    modulePath,
+    /(NSString \*initialEnvName =).*/,
+    `$1 @"${env}";`
+  )
+};
+
+const android = async (options: any) => {
+  const env = options?.env ?? 'dev';
+  const modulePath = path.project.resolve(
+    "node_modules",
+    "@brandingbrand/kernel-component-env",
+    "android/src/main/java/com/env",
+    "EnvModule.java"
+  );
+
+  fsk.update(
+    modulePath,
+    /(final String initialEnvName =).*/,
+    `$1 "${env}";`
+  )
+};
+
+export { ios, android };

--- a/packages/plugin-env/tsconfig.build.json
+++ b/packages/plugin-env/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@tsconfig/node16/tsconfig.json",
+  "exclude": ["test"]
+}


### PR DESCRIPTION
On init, this plugin substitutes the `initialEnvName` value in the native bridges with the one provided via command line arguments in the command line arguments.  If one is not supplied the default is 'dev'.