### PR TITLE
fix(fs12): remove ios and android dirs init

### DIFF
--- a/packages/core/src/executors/init/platform/clean.ts
+++ b/packages/core/src/executors/init/platform/clean.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { fs, logger, path, rimraf } from "../../../utils";
+
+import type { Config } from "../../../types/types";
+import type { CleanOptions } from "../../../types/options";
+
+export const execute = (options: CleanOptions, config: Config) => ({
+  ios: async () => {
+    logger.logInfo("removing ios dir");
+
+    if (await fs.pathExists(path.project.resolve("ios"))) {
+      await rimraf.async(path.project.resolve("ios"), {});
+    }
+  },
+  android: async () => {
+    logger.logInfo("removing android dir");
+
+    if (await fs.pathExists(path.project.resolve("android"))) {
+      await rimraf.async(path.project.resolve("android"), {});
+    }
+  },
+});

--- a/packages/core/src/executors/init/platform/index.ts
+++ b/packages/core/src/executors/init/platform/index.ts
@@ -1,3 +1,4 @@
+import * as clean from "./clean";
 import * as plist from "./plist";
 import * as styles from "./styles";
 import * as config from "./config";
@@ -8,6 +9,7 @@ import * as manifest from "./manifest";
 import * as cocoapods from "./cocoapods";
 
 export const executors = [
+  clean,
   template,
   config,
   manifest,


### PR DESCRIPTION
Built on https://github.com/brandingbrand/flagship/pull/2524.

The purpose for this PR was to remove the ios and android directories if they exist on init command which will fix a bug when a file already exists. We could change 2 lines of code to force overwriting but it increases build time and asset generation for ios gets corrupted.