### PR TITLE
feat(fs12): info plist parser

### DIFF
--- a/apps/react-native/.kernelrc/env/env.prod.ts
+++ b/apps/react-native/.kernelrc/env/env.prod.ts
@@ -19,6 +19,9 @@ const prod: ENV = {
           },
         },
       },
+      urlScheme: {
+        scheme: 'kernel',
+      },
     },
     signing: {
       distCertType: 'iPhone Distribution',

--- a/packages/core/src/executors/init/platform/plist.ts
+++ b/packages/core/src/executors/init/platform/plist.ts
@@ -1,43 +1,27 @@
-import plist from "simple-plist";
-import deepmerge from "deepmerge";
-import type { PlistJsObj } from "simple-plist";
-
-import { path } from "../../../utils";
+import { setPlist, setUrlScheme } from "../../../utils/ios/info-plist";
 
 import type { Config } from "../../../types/types";
 import type { InitOptions } from "../../../types/options";
 
 export const execute = (options: InitOptions, config: Config) => {
-  const asyncReadFile = async (path: string) => {
-    return new Promise<PlistJsObj>((res, rej) => {
-      plist.readFile<PlistJsObj>(path, (err, data) => {
-        if (err) return rej(err);
-
-        if (data) return res(data);
-      });
-    });
-  };
-
-  const asyncWriteFile = async (path: string, obj: PlistJsObj) => {
-    return new Promise<void>((res, rej) => {
-      plist.writeFile(path, obj, (err, data) => {
-        if (err) return rej(err);
-
-        res(data);
-      });
-    });
-  };
-
   return {
     ios: async () => {
       if (!config.ios.plist) return;
 
-      const data = await asyncReadFile(path.ios.infoPlistPath(config));
+      const { urlScheme, ...restPlist } = config.ios.plist;
 
-      await asyncWriteFile(
-        path.ios.infoPlistPath(config),
-        deepmerge.all([data, config.ios.plist])
-      );
+      if (urlScheme) {
+        await setUrlScheme(
+          urlScheme.host
+            ? `${urlScheme.scheme}://${urlScheme.host}`
+            : urlScheme.scheme,
+          config
+        );
+      }
+
+      if (restPlist) {
+        await setPlist(restPlist, config);
+      }
     },
     android: async () => {
       //

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from "./executors";
 export * from "./utils";
 export * from "./types/types";
 export * as android from "./types/android";
+export * as ios from "./types/ios";

--- a/packages/core/src/types/ios/InfoPlist.ts
+++ b/packages/core/src/types/ios/InfoPlist.ts
@@ -1,0 +1,42 @@
+export type URLScheme = {
+  CFBundleURLName?: string;
+  CFBundleURLSchemes: string[];
+};
+
+export type InterfaceOrientation =
+  | "UIInterfaceOrientationPortrait"
+  | "UIInterfaceOrientationPortraitUpsideDown"
+  | "UIInterfaceOrientationLandscapeLeft"
+  | "UIInterfaceOrientationLandscapeRight";
+
+export type InterfaceStyle = "Light" | "Dark" | "Automatic";
+
+export type AppTransportSecurity = {
+  NSExceptionDomains?: {
+    [key: string]: {
+      NSIncludesSubdomains?: boolean;
+      NSExceptionAllowsInsecureHTTPLoads?: boolean;
+      NSExceptionMinimumTLSVersion?: string;
+      NSExceptionRequiresForwardSecrecy?: boolean;
+    };
+  };
+};
+
+export type InfoPlist = Record<string, unknown> & {
+  UIStatusBarHidden?: boolean;
+  UIStatusBarStyle?: string;
+  UILaunchStoryboardName?: string | "LaunchScreen";
+  CFBundleShortVersionString?: string;
+  CFBundleVersion?: string;
+  CFBundleDisplayName?: string;
+  CFBundleIdentifier?: string;
+  CFBundleName?: string;
+  CFBundleURLTypes?: URLScheme[];
+  CFBundleDevelopmentRegion?: string;
+  ITSAppUsesNonExemptEncryption?: boolean;
+  UIBackgroundModes?: string[];
+  UISupportedInterfaceOrientations?: InterfaceOrientation[];
+  UIUserInterfaceStyle?: InterfaceStyle;
+  UIRequiresFullScreen?: boolean;
+  NSAppTransportSecurity?: AppTransportSecurity;
+};

--- a/packages/core/src/types/ios/index.ts
+++ b/packages/core/src/types/ios/index.ts
@@ -1,0 +1,1 @@
+export * as InfoPlistType from "./InfoPlist";

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -1,3 +1,4 @@
+import type { InfoPlistType } from "./ios";
 import type { AndroidManifestType, StringsType, StylesType } from "./android";
 
 export interface Config<T = unknown> {
@@ -38,7 +39,7 @@ export interface IOS {
   /**
    * Additional Plist values
    */
-  plist?: Record<string, unknown>;
+  plist?: Plist & InfoPlistType.InfoPlist;
   /**
    * Signing configuration
    */
@@ -51,6 +52,10 @@ export interface IOS {
    * App version Info
    */
   versioning?: IOSVersion;
+}
+
+export interface Plist {
+  urlScheme?: UrlScheme;
 }
 
 export enum TargetedDevices {

--- a/packages/core/src/utils/ios/index.ts
+++ b/packages/core/src/utils/ios/index.ts
@@ -1,0 +1,2 @@
+export * as plist from "./plist";
+export * as infoPlist from "./info-plist";

--- a/packages/core/src/utils/ios/info-plist.ts
+++ b/packages/core/src/utils/ios/info-plist.ts
@@ -1,0 +1,28 @@
+import * as path from "../path";
+import { withPlist } from "./plist";
+
+import type { Config } from "../../types/types";
+import { InfoPlistType } from "../../types/ios";
+import deepmerge from "deepmerge";
+
+export const withInfoPlist = (
+  callback: (plist: InfoPlistType.InfoPlist) => InfoPlistType.InfoPlist,
+  config: Config
+) =>
+  withPlist<InfoPlistType.InfoPlist>(path.ios.infoPlistPath(config), callback);
+
+export const setUrlScheme = (urlScheme: string, config: Config) =>
+  withInfoPlist((plist) => {
+    if (plist.CFBundleURLTypes?.[0]) {
+      plist.CFBundleURLTypes[0].CFBundleURLSchemes.push(urlScheme);
+    } else {
+      plist.CFBundleURLTypes = [{ CFBundleURLSchemes: [urlScheme] }];
+    }
+
+    return plist;
+  }, config);
+
+export const setPlist = (data: Record<string, unknown>, config: Config) =>
+  withInfoPlist((plist) => {
+    return deepmerge.all<InfoPlistType.InfoPlist>([plist, data]);
+  }, config);

--- a/packages/core/src/utils/ios/plist.ts
+++ b/packages/core/src/utils/ios/plist.ts
@@ -1,0 +1,29 @@
+import plist, { PlistJsObj } from "simple-plist";
+
+const asyncReadFile = async <T>(path: string) => {
+  return new Promise<T>((res, rej) => {
+    plist.readFile<T>(path, (err, data) => {
+      if (err) return rej(err);
+
+      if (data) return res(data);
+    });
+  });
+};
+
+const asyncWriteFile = async (path: string, obj: PlistJsObj) => {
+  return new Promise<void>((res, rej) => {
+    plist.writeFile(path, obj, (err, data) => {
+      if (err) return rej(err);
+
+      res(data);
+    });
+  });
+};
+
+export const withPlist = async <T>(path: string, callback: (plist: T) => T) => {
+  const plist = await asyncReadFile<T>(path);
+
+  const res = callback(plist);
+
+  await asyncWriteFile(path, res as PlistJsObj);
+};


### PR DESCRIPTION
Built on https://github.com/brandingbrand/flagship/pull/2525.

We want to encourage parsing parceable files over utilizing ejs for complex transformations. Ejs is good to use for simple plug-n-chug but not for complex assignments. This change adds functionality to parse plist files.