### PR TITLE
fix(fs12): extend android permissions with types

### DIFF
--- a/packages/plugin-permissions/src/types.ts
+++ b/packages/plugin-permissions/src/types.ts
@@ -3,7 +3,9 @@ import type { Plugin } from "@brandingbrand/code-core";
 import { ios, android } from "./utils";
 
 export type IOSPermission = keyof typeof ios.permissions;
-export type AndroidPermission = typeof android.permissions[number];
+export type AndroidPermission =
+  | typeof android.permissions[number]
+  | (string & {});
 
 export interface IOSPermissionType {
   permission: IOSPermission;

--- a/packages/plugin-permissions/test/index.test.ts
+++ b/packages/plugin-permissions/test/index.test.ts
@@ -55,7 +55,11 @@ describe("plugin-permissions", () => {
     await android({
       codePluginPermissions: {
         plugin: {
-          android: ["ACCESS_FINE_LOCATION", "ACCESS_COARSE_LOCATION"],
+          android: [
+            "ACCESS_FINE_LOCATION",
+            "ACCESS_COARSE_LOCATION",
+            "BIND_CARRIER_SERVICES",
+          ],
         },
       },
     });
@@ -69,6 +73,9 @@ describe("plugin-permissions", () => {
     );
     expect(manifest).toMatch(
       '<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>'
+    );
+    expect(manifest).toMatch(
+      '<uses-permission android:name="android.permission.BIND_CARRIER_SERVICES"/>'
     );
   });
 });


### PR DESCRIPTION
There are a lot of extraneous Android permissions, https://developer.android.com/reference/android/Manifest.permission, that aren't necessarily typed in https://github.com/zoontek/react-native-permissions/blob/master/src/permissions.android.ts - we support what is out-of-the-box from `react-native-permissions` since this is the purpose of the plugin. We extend the permissions type to accept any permission as well.