### PR TITLE
chore(fs12): react-native xcode 14.3 support

### DIFF
--- a/apps/react-native/package.json
+++ b/apps/react-native/package.json
@@ -79,7 +79,7 @@
     "metro-config": "0.72.3",
     "react": "18.1.0",
     "react-dom": "18.1.0",
-    "react-native": "0.70.6",
+    "react-native": "0.70.8",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^7.30.2"
   },
@@ -88,7 +88,7 @@
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-cookies/cookies": "^6.2.1",
     "react": "18.1.0",
-    "react-native": "0.70.6",
+    "react-native": "0.70.8",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^7.30.2",
     "react-native-permissions": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "metro-config": "0.72.3",
     "react": "18.1.0",
     "react-dom": "18.1.0",
-    "react-native": "0.70.6",
+    "react-native": "0.70.8",
     "react-native-device-info": "^10.3.0",
     "react-native-navigation": "^7.30.2",
     "xcode": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11832,10 +11832,10 @@ react-native-web-modal@^1.0.1:
   resolved "https://registry.yarnpkg.com/react-native-web-modal/-/react-native-web-modal-1.0.1.tgz#d0e1d5fa020c88edb9258409054bec73a7726ea1"
   integrity sha512-dFb6EAsayRQxS7GLsXVJn1G44xvU6/3cemoKx1Wgfiu/9DlPcqR30xCloJ3OBuwyoM+FTkWaoeK3JiibYzcCqA==
 
-react-native@0.70.6, react-native@^0.63.5:
-  version "0.70.6"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.70.6.tgz#d692f8b51baffc28e1a8bc5190cdb779de937aa8"
-  integrity sha512-xtQdImPHnwgraEx3HIZFOF+D1hJ9bC5mfpIdUGoMHRws6OmvHAjmFpO6qfdnaQ29vwbmZRq7yf14sbury74R/w==
+react-native@0.70.8, react-native@^0.63.5:
+  version "0.70.8"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.70.8.tgz#aa9aae8e6291589908db74fe69e0ec1d9a9c5490"
+  integrity sha512-O3ONJed9W/VEEVWsbZcwyMDhnEvw7v9l9enqWqgbSGLzHfh6HeIGMCNmjz+kRsHnC7AiF47fupWfgYX7hNnhoQ==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "9.3.2"


### PR DESCRIPTION
No additional changes: https://react-native-community.github.io/upgrade-helper/?from=0.70.6&to=0.70.8.