### PR TITLE
fix(core): android template release directory

### DIFF
--- a/packages/core/assets/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.java
+++ b/packages/core/assets/template/android/app/src/release/java/com/helloworld/ReactNativeFlipper.java
@@ -4,9 +4,11 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package <%- android.packageName %>;
+
 import android.content.Context;
 import com.facebook.react.ReactInstanceManager;
+
 /**
  * Class responsible of loading Flipper inside your React Native application. This is the release
  * flavor of it so it's empty as we don't want to load Flipper.

--- a/packages/core/src/executors/init/platform/packages.ts
+++ b/packages/core/src/executors/init/platform/packages.ts
@@ -23,6 +23,12 @@ export const execute = (options: InitOptions, config: Config) => {
           path.android.debugPath(),
           "java"
         );
+        await rename.pkgDirectory(
+          "com.helloworld",
+          config.android.packageName,
+          path.android.releasePath(),
+          "java"
+        );
       },
       "packages",
       "platform::android"

--- a/packages/core/src/utils/path.ts
+++ b/packages/core/src/utils/path.ts
@@ -212,12 +212,20 @@ const getMainPath = (): string =>
   resolvePathFromProject("android", "app", "src", "main");
 
 /**
- * Returns the path to the main directory.
+ * Returns the path to the debug directory.
  *
- * @return The path to the main directory.
+ * @return The path to the debug directory.
  */
 const getDebugPath = (): string =>
   resolvePathFromProject("android", "app", "src", "debug");
+
+/**
+ * Returns the path to the release directory.
+ *
+ * @return The path to the release directory.
+ */
+const getReleasePath = (): string =>
+  resolvePathFromProject("android", "app", "src", "release");
 
 /**
  * Returns the path to the assets directory.
@@ -362,6 +370,7 @@ export const android = {
   gradlePropertiesPath: getGradlePropertiesPath,
   mainPath: getMainPath,
   debugPath: getDebugPath,
+  releasePath: getReleasePath,
   assetsPath: getAssetsPath,
   resourcesPath: getResourcesPath,
   rootDirPath: getRootDirPathAndroid,


### PR DESCRIPTION
## Describe your changes

In React Native v0.71.* they moved conditionalizing ReactNativeFlipper from checking if it's debug to an abstraction class to the release directory which was missed during the upgrade process.

Added the packaged namespace'd `release` dir into the android template and updated the `packages` executor to update the package path.

## Issue ticket number and link

N/a.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Run the example app and ensure the release dir has the proper namespace.

<img width="313" alt="Screen Shot 2023-07-25 at 3 47 55 PM" src="https://github.com/brandingbrand/flagship/assets/17734240/8aabeaaf-8b05-4d94-bb99-b5f4bb8e0cdd">

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required