### PR TITLE
fix(plugin-fastlane): scope assemble to app project

### DIFF
--- a/.changeset/curly-glasses-sniff.md
+++ b/.changeset/curly-glasses-sniff.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-fastlane": patch
+---
+
+project scope android fastfile task

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -21,6 +21,7 @@
     "@brandingbrand/code-plugin-target-extension": "1.0.0"
   },
   "changesets": [
+    "curly-glasses-sniff",
     "honest-windows-study"
   ]
 }

--- a/apps/react-native/package.json
+++ b/apps/react-native/package.json
@@ -107,7 +107,7 @@
     "@brandingbrand/code-plugin-permissions": "*",
     "@brandingbrand/code-plugin-splash-screen": "*",
     "@brandingbrand/code-plugin-target-extension": "*",
-    "@brandingbrand/code-plugin-fastlane": "2.0.0-alpha.0",
+    "@brandingbrand/code-plugin-fastlane": "2.0.0-alpha.1",
     "@react-native-community/eslint-config": "^3.2.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^29.2.1",

--- a/packages/plugin-fastlane/CHANGELOG.md
+++ b/packages/plugin-fastlane/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @brandingbrand/code-plugin-fastlane
 
+## 2.0.0-alpha.1
+
+### Patch Changes
+
+- project scope android fastfile task
+
 ## 2.0.0-alpha.0
 
 ### Major Changes

--- a/packages/plugin-fastlane/assets/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/assets/android/fastlane/Fastfile
@@ -2,12 +2,12 @@ default_platform :android
 
 lane :assemble do
   # assemble the release variant i.e. apk
-  gradle(task: "assembleRelease")
+  gradle(task: "app:assembleRelease")
 end
 
 lane :bundle do
   # bundle the release variant i.e. aab
-  gradle(task: "bundleRelease")
+  gradle(task: "app:bundleRelease")
 end
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>

--- a/packages/plugin-fastlane/package.json
+++ b/packages/plugin-fastlane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandingbrand/code-plugin-fastlane",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "plugin for Flagship Code for fastlane app center builds",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Describe your changes
Update the Fastfile for Android to have the task scoped to the app project 
this prevents it from trying to assemble react-native packages as libraries and just builds the app
[04bd401](https://github.com/NickBurkhartBB/flagship/commit/04bd4014265edc2d3d6e269942b02aac91f996b6)

Setup changeset for next alpha version

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
* init example project
* run fastfile assemble in Android project to verify app:assembleRelease task is run
 
## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes
