### PR TITLE
feat(code): add ios deep linking delegate

### DIFF
--- a/apps/example/coderc/build/build.internal.ts
+++ b/apps/example/coderc/build/build.internal.ts
@@ -13,6 +13,11 @@ export default defineBuild<
   ios: {
     bundleId: 'com.brandingbrand',
     displayName: 'Branding Brand',
+    plist: {
+      urlScheme: {
+        scheme: 'app',
+      },
+    },
   },
   android: {
     packageName: 'com.brandingbrand',

--- a/packages/cli-kit/__tests__/path.ts
+++ b/packages/cli-kit/__tests__/path.ts
@@ -41,6 +41,13 @@ describe("path", () => {
     );
   });
 
+  it("should have an ios.appDelegate function that returns the path to ios/app/AppDelegate.mm", () => {
+    const appDelegatePath = path.ios.appDelegate;
+    expect(appDelegatePath).toEqual(
+      expect.stringMatching(/.*ios\/app\/AppDelegate\.mm$/)
+    );
+  });
+
   it("should have an ios.podfile function that returns the path to ios/Podfile", () => {
     const podfilePath = path.ios.podfile;
     expect(podfilePath).toEqual(expect.stringMatching(/.*ios\/Podfile$/));

--- a/packages/cli-kit/src/lib/path.ts
+++ b/packages/cli-kit/src/lib/path.ts
@@ -103,6 +103,13 @@ export default {
     nativeConstants: resolvePathFromProject("ios", "app", "NativeConstants.m"),
 
     /**
+     * Retrieves the absolute path to the iOS AppDelegate.mm file.
+     *
+     * @returns {string} The absolute path to "ios/app/AppDelegate.mm".
+     */
+    appDelegate: resolvePathFromProject("ios", "app", "AppDelegate.mm"),
+
+    /**
      * Retrieves the absolute path to the iOS project.pbxproj file.
      *
      * @returns {string} The absolute path to "ios/app.xcodeproj/project.pbxproj".

--- a/packages/cli/__tests__/app-delegate-mm.ts
+++ b/packages/cli/__tests__/app-delegate-mm.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment-options {"requireTemplate": true}
+ */
+
+/// <reference types="@brandingbrand/code-jest-config" />
+
+import { type BuildConfig, fs, path } from "@brandingbrand/code-cli-kit";
+
+import transformer from "../src/transformers/ios/app-delegate-mm";
+
+describe("AppDelegate.mm transformers", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should not update AppDelegate.mm with RCTLinkingManager", async () => {
+    const config = {
+      ...__flagship_code_build_config,
+    } as BuildConfig;
+
+    await transformer.transform(config, {} as any);
+    const content = await fs.readFile(path.ios.appDelegate, "utf-8");
+
+    expect(content).not.toContain("RCTLinkingManager");
+  });
+
+  it("should update AppDelegate.mm with RCTLinkingManager", async () => {
+    const config = {
+      ...__flagship_code_build_config,
+      ios: {
+        ...__flagship_code_build_config,
+        plist: {
+          urlScheme: {
+            scheme: "app",
+          },
+        },
+      },
+    } as BuildConfig;
+
+    await transformer.transform(config, {} as any);
+    const content = await fs.readFile(path.ios.appDelegate, "utf-8");
+
+    expect(content).toContain("#import <React/RCTLinkingManager.h>");
+    expect(content).toContain(
+      "if ([RCTLinkingManager application:application openURL:url options:options]) {"
+    );
+  });
+});

--- a/packages/cli/__tests__/env-switcher-m.ts
+++ b/packages/cli/__tests__/env-switcher-m.ts
@@ -8,12 +8,12 @@ import { type BuildConfig, fs, path } from "@brandingbrand/code-cli-kit";
 
 import transformer from "../src/transformers/ios/env-switcher-m";
 
-describe("EnvSwitcher.java transformers", () => {
+describe("EnvSwitcher.m transformers", () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it("should not update EnvSwitcher.java with initialEnvName to staging", async () => {
+  it("should not update EnvSwitcher.m with initialEnvName to staging", async () => {
     const config = {
       ...__flagship_code_build_config,
     } as BuildConfig;

--- a/packages/cli/src/transformers/ios/app-delegate-mm.ts
+++ b/packages/cli/src/transformers/ios/app-delegate-mm.ts
@@ -1,0 +1,107 @@
+import {
+  type BuildConfig,
+  type PrebuildOptions,
+  withUTF8,
+  path,
+  string,
+} from "@brandingbrand/code-cli-kit";
+
+import { Transforms, defineTransformer } from "@/lib";
+
+/**
+ * Defines a transformer for the iOS project's "AppDelegate.mm" file.
+ *
+ * @type {typeof defineTransformer<(content: string, config: BuildConfig) => string>} - The type of the transformer.
+ * @property {string} file - The name of the file to be transformed ("AppDelegate.mm").
+ * @property {Array<(content: string, config: BuildConfig) => string>} transforms - An array of transformer functions.
+ * @property {Function} transform - The main transform function that applies all specified transformations.
+ * @returns {Promise<string>} The updated content of the "AppDelegate.mm" file.
+ */
+export default defineTransformer<Transforms<string>>({
+  /**
+   * The name of the file to be transformed ("AppDelegate.mm").
+   * @type {string}
+   */
+  file: "AppDelegate.mm",
+
+  /**
+   * An array of transformer functions to be applied to the "AppDelegate.mm" file.
+   * Each function receives the content of the file and the build configuration,
+   * and returns the updated content after applying specific transformations.
+   * @type {Array<(content: string, config: BuildConfig) => string>}
+   */
+  transforms: [
+    /**
+     * Transformer for add RCTLinkingManager import in "AppDelegate.mm".
+     * @param {string} content - The content of the file.
+     * @param {BuildConfig} config - The build configuration.
+     * @returns {string} - The updated content.
+     */
+    (
+      content: string,
+      config: BuildConfig,
+      options: PrebuildOptions
+    ): string => {
+      if (!config.ios.plist?.urlScheme) {
+        return content;
+      }
+
+      return string.replace(
+        content,
+        /(#import "AppDelegate\.h")/,
+        `$1
+
+#import <React/RCTLinkingManager.h>`
+      );
+    },
+
+    /**
+     * Transformer for add delegate method in "AppDelegate.mm".
+     * @param {string} content - The content of the file.
+     * @param {BuildConfig} config - The build configuration.
+     * @returns {string} - The updated content.
+     */
+    (
+      content: string,
+      config: BuildConfig,
+      options: PrebuildOptions
+    ): string => {
+      if (!config.ios.plist?.urlScheme) {
+        return content;
+      }
+
+      return string.replace(
+        content,
+        /(@end)/,
+        `- (BOOL)application:(UIApplication *)application
+  openURL:(NSURL *)url
+  options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  if ([RCTLinkingManager application:application openURL:url options:options]) {
+    return YES;
+  }
+
+  return NO;
+}
+
+$1`
+      );
+    },
+  ],
+
+  /**
+   * The main transform function that applies all specified transformations to the "AppDelegate.mm" file.
+   * @param {BuildConfig} config - The build configuration.
+   * @returns {Promise<void>} - The updated content of the "AppDelegate.mm" file.
+   */
+  transform: async function (
+    config: BuildConfig,
+    options: PrebuildOptions
+  ): Promise<void> {
+    return withUTF8(path.ios.appDelegate, (content: string) => {
+      return this.transforms.reduce((acc, curr) => {
+        return curr(acc, config, options);
+      }, content);
+    });
+  },
+});

--- a/packages/cli/src/transformers/ios/index.ts
+++ b/packages/cli/src/transformers/ios/index.ts
@@ -32,3 +32,8 @@ export { default as pbxproj } from "./project-pbxproj";
  * Represents the app.entitlements file transformers.
  */
 export { default as entitlements } from "./app-entitlements";
+
+/**
+ * Represents the AppDelegate.mm file transformers.
+ */
+export { default as appDelegate } from "./app-delegate-mm";


### PR DESCRIPTION
## Describe your changes

Adding `AppDelegate.mm` deep-linking delegate method.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Run the example app: `yarn flagship-code prebuild --build internal --env prod`. When the app has been installed to the simulator, close the app and run in the terminal: `xcrun simctl openurl booted "app://"` and verify app opens.

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required