### PR TITLE
fix(code): jest-preset js

### DIFF
--- a/packages/jest-config/jest-preset.js
+++ b/packages/jest-config/jest-preset.js
@@ -18,7 +18,7 @@ module.exports = {
    *
    * @type {string}
    */
-  testEnvironment: require.resolve("./src/test-environment.ts"),
+  testEnvironment: require.resolve("./build/test-environment.js"),
 
   /**
    * Setup files to be executed after Jest environment setup.
@@ -28,7 +28,7 @@ module.exports = {
    *
    * @type {string[]}
    */
-  setupFilesAfterEnv: [require.resolve("./src/setup-files-after-env.ts")],
+  setupFilesAfterEnv: [require.resolve("./build/setup-files-after-env.js")],
 
   /**
    * Module name mapper for path aliasing in Jest.

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -3,18 +3,26 @@
   "version": "1.0.0-alpha.0",
   "license": "MIT",
   "files": [
+    "build",
+    "index.d.ts",
     "jest-preset.js"
   ],
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
   "types": "./index.d.ts",
+  "dependencies": {
+    "ts-jest": "^29.1.2"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/temp": "^0.9.4",
     "jest": "^29.7.0",
     "temp": "^0.9.4",
-    "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
   }
 }

--- a/packages/jest-config/tsconfig.json
+++ b/packages/jest-config/tsconfig.json
@@ -1,3 +1,8 @@
 {
   "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "noEmit": false,
+  },
 }


### PR DESCRIPTION
## Describe your changes

Update jest-preset.js to link to js files instead of ts files. When published you can only use js files. This will not interrupt the current monorepo workflow as cli and cli-kit are required to be built anyway before testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

I created a packaged release via `npm pack`. I then utilized this *.tar in example app to test.

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
