### PR TITLE
fix(fastlane): increment android bundle build number

### DIFF
--- a/packages/plugin-fastlane/CHANGELOG.md
+++ b/packages/plugin-fastlane/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @brandingbrand/code-plugin-fastlane
 
+## 2.0.2
+
+### Patch Changes
+
+- Increment android bundle when build number does not exist
+
 ## 2.0.1
 
 ### Patch Changes

--- a/packages/plugin-fastlane/assets/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/assets/android/fastlane/Fastfile
@@ -46,6 +46,10 @@ lane :appcenter_assemble do
 end
 
 lane :appcenter_bundle do
+  <% if(!android.versioning || android.versioning.build === undefined) { -%>
+increment_build
+  <% } -%>
+
   bundle
 
   appcenter_upload(

--- a/packages/plugin-fastlane/package.json
+++ b/packages/plugin-fastlane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandingbrand/code-plugin-fastlane",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "plugin for Flagship Code for fastlane app center builds",
   "license": "MIT",
   "repository": {

--- a/packages/plugin-fastlane/test/index.test.ts
+++ b/packages/plugin-fastlane/test/index.test.ts
@@ -59,7 +59,9 @@ describe("plugin-fastlane", () => {
     await android({
       ...global.__FLAGSHIP_CODE_CONFIG__,
       android: {
-        ...global.__FLAGSHIP_CODE_CONFIG__.android,
+        name: "HelloWorld",
+        packageName: "com.helloworld",
+        displayName: "Hello World",
         signing: {
           keyAlias: "key0",
           storeFile: "signing/example.keystore",
@@ -98,10 +100,45 @@ describe("plugin-fastlane", () => {
       expect(result).toMatch(testCase);
     });
 
+    expect(result).toContain(`lane :appcenter_bundle do
+  increment_build`);
+
     expect(appBuildGradle).toContain(`{
             storeFile file('release.keystore')
             storePassword System.getenv("STORE_PASSWORD")
             keyAlias 'key0'
             keyPassword System.getenv("KEY_PASSWORD")`);
+  });
+
+  it("android not include increment_build", async () => {
+    await android({
+      ...global.__FLAGSHIP_CODE_CONFIG__,
+      android: {
+        ...global.__FLAGSHIP_CODE_CONFIG__.android,
+        signing: {
+          keyAlias: "key0",
+          storeFile: "signing/example.keystore",
+        },
+      },
+      codePluginFastlane: {
+        plugin: {
+          android: {
+            appCenter: {
+              organization: "Branding-Brand",
+              appName: "FlagshipCode-Android-Internal",
+              destinationType: "group",
+              destinations: ["IAT"],
+            },
+          },
+        },
+      },
+    });
+
+    const result = (
+      await fs.readFile(path.project.resolve("android", "fastlane", "Fastfile"))
+    ).toString();
+
+    expect(result).not.toContain(`lane :appcenter_bundle do
+  increment_build`);
   });
 });


### PR DESCRIPTION
## Describe your changes

Android bundle lane in fastlane not incrementing build number. It was a missed conditional in the migration. Added additional test cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. `yarn install`
2. `yarn build`
3. `yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
