### PR TITLE
feat(google-signin): ENG-5151 update google-signin support for privacy manifest

### DIFF
--- a/.changeset/big-penguins-tease.md
+++ b/.changeset/big-penguins-tease.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-google-signin": minor
+---
+
+update google-signin peer deps to prepare for privacy manifest support

--- a/packages/plugin-google-signin/package.json
+++ b/packages/plugin-google-signin/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@brandingbrand/code-core": "*",
     "@brandingbrand/code-plugin-firebase-app": "*",
-    "@react-native-google-signin/google-signin": "^9.0.2"
+    "@react-native-google-signin/google-signin": "^11.0.1"
   },
   "devDependencies": {
     "@brandingbrand/code-core": "*"


### PR DESCRIPTION
## Describe your changes

Update `google-signin` plugin to support privacy manifest.

There is an additional patch that will be required: https://github.com/react-native-google-signin/google-signin/blob/cb1702e88317fbd79b85d229c1b57198c2d16bb0/RNGoogleSignin.podspec#L19 needs to be `7.1.0`.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5151)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

`yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
