### PR TITLE
feat(leanplum): ENG-5151 update leanplum support for privacy manifest

### DIFF
--- a/.changeset/lemon-news-shave.md
+++ b/.changeset/lemon-news-shave.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-leanplum": minor
+---
+
+update leanplum peer deps to prepare to support privacy manifest

--- a/packages/plugin-leanplum/package.json
+++ b/packages/plugin-leanplum/package.json
@@ -40,8 +40,8 @@
     "@brandingbrand/code-core": "*",
     "@brandingbrand/code-plugin-app-icon": "*",
     "@brandingbrand/code-plugin-firebase-app": "*",
-    "@leanplum/react-native-sdk": "^2.0.0",
-    "clevertap-react-native": "^0.9.4"
+    "@leanplum/react-native-sdk": "^2.2.0",
+    "clevertap-react-native": "^2.2.1"
   },
   "devDependencies": {
     "@brandingbrand/code-core": "*"


### PR DESCRIPTION
## Describe your changes

Update `leanplum` plugin to support privacy manifest.

There is an additional patch that will be required: https://github.com/Leanplum/Leanplum-ReactNative-SDK/blob/5b6c59da18d781bf931959b3346c3e93cf02be80/react-native-leanplum.podspec#L22 needs to be `6.4.0`. There also must be a resolution: https://github.com/Leanplum/Leanplum-ReactNative-SDK/blob/5b6c59da18d781bf931959b3346c3e93cf02be80/package.json#L64 to override `clevertap-react-native` version to `^2.2.1`.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5151)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

`yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
