### PR TITLE
feat(privacy-manifest): ENG-5152 allow custom privacy manifest

### DIFF
--- a/packages/core/src/executors/init/platform/index.ts
+++ b/packages/core/src/executors/init/platform/index.ts
@@ -10,11 +10,13 @@ import * as packages from "./packages";
 import * as cocoapods from "./cocoapods";
 import * as frameworks from "./frameworks";
 import * as entitlements from "./entitlements";
+import * as privacyManifest from "./privacyManifest";
 
 export const executors = [
   clean,
   template,
   entitlements,
+  privacyManifest,
   frameworks,
   packages,
   manifest,

--- a/packages/core/src/executors/init/platform/privacyManifest.ts
+++ b/packages/core/src/executors/init/platform/privacyManifest.ts
@@ -1,0 +1,44 @@
+import { fs, path } from "../../../utils";
+import { withSummary } from "../../../utils/summary";
+
+import type { Config } from "../../../types/Config";
+import type { InitOptions } from "../../../types/Options";
+
+export const execute = (options: InitOptions, config: Config) => {
+  return {
+    /**
+     * Executes initialization tasks for iOS platform.
+     * This function copies a privacy manifest file to the iOS project directory if the manifest exists.
+     * @returns {Promise<void>} A promise representing the completion of the initialization task.
+     */
+    ios: withSummary(
+      async () => {
+        const { privacyManifestPath } = config.ios;
+
+        if (!privacyManifestPath) return;
+
+        // Resolving absolute path of privacy manifest file relative to .coderc directory
+        const privacyManifestAbsolutePath =
+          path.config.resolve(privacyManifestPath);
+
+        // Checking if privacy manifest file exists
+        if (!fs.existsSync(privacyManifestAbsolutePath)) {
+          throw new Error(
+            `[PrivacyManifestExecutor]: privacy manifest path does not exist: ${privacyManifestAbsolutePath}`
+          );
+        }
+
+        // Copying privacy manifest file to iOS project directory
+        await fs.copyFile(
+          privacyManifestAbsolutePath,
+          path.project.resolve("ios", config.ios.name, `PrivacyInfo.xcprivacy`)
+        );
+      },
+      "privacy-manifest",
+      "platform::ios"
+    ),
+    android: async () => {
+      //
+    },
+  };
+};

--- a/packages/core/src/types/Config.ts
+++ b/packages/core/src/types/Config.ts
@@ -57,6 +57,12 @@ export interface IOS {
    * App version Info
    */
   versioning?: IOSVersion;
+  /**
+   * Optional PrivacyInfo.xcprivacy path to override the default PrivacyInfo.xcprivacy
+   *
+   * https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+   */
+  privacyManifestPath?: string;
 }
 
 export interface Plist {


### PR DESCRIPTION
## Describe your changes

The default provided PrivacyInfo.xcprivacy covers the basics for a React Native app w/ Flagship Code™. The ideal way for third-party SDKs to include their PrivacyInfo.xcprivacy is via their bundle linking via the podspec. Unfortunately some of these third-party SDKs are not maintained - we need a way to adding those required reasons via an override.

Now you can provide a path to a custom PrivacyInfo.xcprivacy that will override the default provided PrivacyInfo.xcrprivacy.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5152)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

`yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes