### PR TITLE
fix(privacy-manifest): ENG-5152 privacy manifest as pbxbuild resource

### DIFF
--- a/.changeset/nine-numbers-design.md
+++ b/.changeset/nine-numbers-design.md
@@ -1,0 +1,6 @@
+---
+"@brandingbrand/code-cli-kit": patch
+"@brandingbrand/code-cli": patch
+---
+
+add PrivacyInfo.xcprivacy as resource file

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -26,7 +26,7 @@
     "io-ts": "^2.2.21",
     "recast": "^0.23.5",
     "simple-plist": "^1.3.1",
-    "xcode": "^3.0.1"
+    "xcode": "^3.0.2-nightly.20240423000755527.sha.5158ec51"
   },
   "devDependencies": {
     "@brandingbrand/code-jest-config": "1.0.0-alpha.1",

--- a/packages/cli/__tests__/project-pbxproj.ts
+++ b/packages/cli/__tests__/project-pbxproj.ts
@@ -39,6 +39,12 @@ describe("ios project.pbxproj transformers", () => {
     expect(content).toContain(
       '/* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; name = "PrivacyInfo.xcprivacy"; path = "app/PrivacyInfo.xcprivacy"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };'
     );
+    expect(content).toMatch(
+      /\/\* PrivacyInfo\.xcprivacy in Resources \*\/ = {isa = PBXBuildFile; fileRef = \w+ \/\* PrivacyInfo\.xcprivacy \*\/; };/
+    );
+    expect(content).toMatch(
+      /\w+ \/\* PrivacyInfo\.xcprivacy in Resources \*\/,/
+    );
   });
 
   it("should update project.pbxproj with deployment target", async () => {

--- a/packages/cli/src/transformers/ios/project-pbxproj.ts
+++ b/packages/cli/src/transformers/ios/project-pbxproj.ts
@@ -64,7 +64,7 @@ export default defineTransformer<Transforms<XcodeProject, void>>({
       // Add the PrivacyInfo.xcprivacy privacy manifest for React Native base usage
       // privacy requirements: https://github.com/facebook/react-native/commit/2d84d835342d58bd28b2233f18691846de6933c9
       // Requirement from Apple: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files?language=objc
-      project.addHeaderFile("app/PrivacyInfo.xcprivacy", opt, groupKey);
+      project.addResourceFile("app/PrivacyInfo.xcprivacy", opt, groupKey);
 
       // *.entitlements file can be treated same as a header file with
       // respect to "xcode" module, force lastKnownFileType and defaultEncoding

--- a/yarn.lock
+++ b/yarn.lock
@@ -13261,6 +13261,14 @@ xcode@^3.0.1:
     simple-plist "^1.1.0"
     uuid "^7.0.3"
 
+xcode@^3.0.2-nightly.20240423000755527.sha.5158ec51:
+  version "3.0.2-nightly.20240423000755527.sha.5158ec51"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-3.0.2-nightly.20240423000755527.sha.5158ec51.tgz#524341abc2076bbdbc40450bef6dbd67cc9357b6"
+  integrity sha512-TNn/jVItqQNL4aXRnu5MR0PSN921KHZy/3ksiOFXCCvIque8O73+0mEvnaQ8HzndXq4vr4+jq2QIGDcxmRgm8w==
+  dependencies:
+    simple-plist "^1.1.0"
+    uuid "^7.0.3"
+
 xml-formatter@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/xml-formatter/-/xml-formatter-3.6.2.tgz#f68ad1519beef8353f8759ab6269b91265bdef4a"


### PR DESCRIPTION
## Describe your changes

The PR https://github.com/facebook/react-native/commit/520d120375c6b24bc161adea4f48d76537a34abc to add the PrivacyInfo.xcprivacy as a default file was not added correctly for Apple to recognize the manifest as part of the bundle. The PrivacyInfo.xcprivacy must be a PBXBuildFile and then added as resource file via PBXFileReference. If you go to the Build Phases -> Copy Bundle Resources the PrivacyInfo.xcprivacy will be listed there.

I have tested this with a separate app with 2 steps via beta testing:
1. Without PrivacyInfo.xcprivacy
2. With PrivacyInfo.xcprivacy

This resulted in errors for case 1 - and no errors for case 2.

Updated `xcode` library due to unsafe access of a `path` attribute https://github.com/apache/cordova-node-xcode/commit/e81ecabc18b0e43a1ae5457f16ebcbb8b0b62460.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5152)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. `yarn test`
2. Open Xcode after initializing demo app and verify PrivacyInfo.xcprivacy is listed under Copy Build Resources build phases

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
