### PR TITLE
fix(fastlane): ENG-5249 android app center release mode

### DIFF
--- a/.changeset/strange-walls-wash.md
+++ b/.changeset/strange-walls-wash.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-fastlane": patch
+---
+
+conditionalize android app center version capture to aggregate build number

--- a/packages/plugin-fastlane/assets/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/assets/android/fastlane/Fastfile
@@ -16,7 +16,9 @@ lane :increment_build do
     version = appcenter_fetch_version_number(
         owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
         app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+        <%_ if (!release) { -%>
         version: "<%- android.versioning && android.versioning.version || "1.0.0" %>"
+        <%_ } -%>
     )
 
     if version["build_number"]

--- a/packages/plugin-fastlane/test/index.test.ts
+++ b/packages/plugin-fastlane/test/index.test.ts
@@ -132,7 +132,8 @@ describe("plugin-fastlane", () => {
           },
         },
       },
-    });
+      release: true,
+    } as any);
 
     const result = (
       await fs.readFile(path.project.resolve("android", "fastlane", "Fastfile"))
@@ -140,5 +141,6 @@ describe("plugin-fastlane", () => {
 
     expect(result).not.toContain(`lane :appcenter_bundle do
   increment_build`);
+    expect(result).not.toContain("version: ");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2213,7 +2213,8 @@
     tslib "^2.0.0"
 
 "@brandingbrand/code-plugin-local@link:./apps/react-native/.coderc/plugins/plugin-local":
-  version "0.0.1"
+  version "0.0.0"
+  uid ""
 
 "@brandingbrand/engagement-utils@12.0.0-alpha.9":
   version "12.0.0-alpha.9"
@@ -11446,11 +11447,6 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
-nanoid@^3.3.6:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
-  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -12454,7 +12450,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.0.9, postcss@^8.2.1, postcss@^8.4.14, postcss@^8.4.21, postcss@^8.4.25:
+postcss@^8.0.9, postcss@^8.2.1, postcss@^8.4.14, postcss@^8.4.25:
   version "8.4.31"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==


### PR DESCRIPTION
## Describe your changes

Android build number for is important for not only the Google Play Store but also if you are installing subsequent versions of a mobile application. The build number must be incremental compared to the previous version installed.

Adding the conditional to release mode to always increment the build number based on the previously released version.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5249)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

`yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
