### PR TITLE
feat(env): ENG-5304 support fsapp <11

### DIFF
--- a/.changeset/slimy-sloths-applaud.md
+++ b/.changeset/slimy-sloths-applaud.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-cli": patch
+---
+
+add @brandingbrand/fsapp <v11 support

--- a/packages/cli/src/actions/env.ts
+++ b/packages/cli/src/actions/env.ts
@@ -113,10 +113,13 @@ export default defineAction(
     let projectEnvIndexPath;
 
     if (semver.satisfies(coercedVersion, "<11")) {
-      projectEnvIndexPath = require.resolve(
-        "@brandingbrand/fsapp/project_env_index.js",
+      // project_env_index.js doesn't exist in @brandingbrand/fsapp <v11 - it is assumed to be written to the root
+      // directory of the package. We can get the path based on the package.json and resolve to parent directory with
+      // the project_env_index.js identifier.
+      projectEnvIndexPath = path.resolve(require.resolve(
+        "@brandingbrand/fsapp/package.json",
         { paths: [process.cwd()] }
-      );
+      ), "..", "project_env_index.js");
     }
 
     if (semver.satisfies(coercedVersion, ">10")) {

--- a/packages/cli/src/actions/env.ts
+++ b/packages/cli/src/actions/env.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import type { PackageJson } from "type-fest";
 import { fs, path } from "@brandingbrand/code-cli-kit";
 
@@ -72,7 +73,7 @@ export default defineAction(
         // Throw an error if the environment file doesn't follow the expected format
         if (!name) {
           throw Error(
-            `Name Mismatch: env file ${it} does not follow expected format "env.<mode>.ts"`
+            `Name Mismatch: env file ${it} does not follow expected format "env.<variant>.ts".`
           );
         }
 
@@ -94,12 +95,40 @@ export default defineAction(
       mod.exports[it.name] ||= { app: it.content };
     });
 
+    // Get the version of the @brandingbrand/fsapp
+    // Use require.resolve to support monorepos with the paths set to current working directory
+    const {version} = require(require.resolve('@brandingbrand/fsapp/package.json', {paths: [process.cwd()]}));
+
+    // Coerce the version to a comparable semver version i.e. 12.0.0-alpha.1 -> 12.0.0
+    const coercedVersion = semver.coerce(version);
+
+    // If semver cannot parse the version then we cannot compare versions to be able to
+    // determine where project_env_index.js is located - throw error to user
+    if (!coercedVersion) {
+      throw Error("Type Mismatch: cannot parse @brandingbrand/fsapp version");
+    }
+
     // Resolve the path of the project environment index file from @brandingbrand/fsapp
     // There is a chance this could throw an error, this is fine, still even though we checked the dependencies object already
-    const projectEnvIndexPath = require.resolve(
-      "@brandingbrand/fsapp/src/project_env_index.js",
-      { paths: [process.cwd()] }
-    );
+    let projectEnvIndexPath;
+
+    if (semver.satisfies(coercedVersion, "<11")) {
+      projectEnvIndexPath = require.resolve(
+        "@brandingbrand/fsapp/project_env_index.js",
+        { paths: [process.cwd()] }
+      );
+    }
+
+    if (semver.satisfies(coercedVersion, ">10")) {
+      projectEnvIndexPath = require.resolve(
+        "@brandingbrand/fsapp/src/project_env_index.js",
+        { paths: [process.cwd()] }
+      );
+    }
+
+    if (!projectEnvIndexPath) {
+      throw Error("Missing File: cannot find project_env_index.js in @brandingbrand/fsapp to successfully link environments.")
+    }
 
     // Write the module to the project environment index file
     magicast.writeFile(mod, projectEnvIndexPath);


### PR DESCRIPTION
## Describe your changes

Env access is linked through `@brandingbrand/fsapp` with the `project_env_index.js` file. In fsapp v10 it's in the root directory whereas in v11 it's in the src directory. We need to conditionalize where we read that file from based on fsapp version.

Require the package.json of `@brandingbrand/fsapp` and determine which path we can use for the `project_env_index.js`.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5304)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

1. `yarn install`
2. `yarn build`
3. `cd apps/example`
4. `yarn flagship-code prebuild --build internal --env prod`
5. Verify cli runs successfully

## Demo

<details>
  <summary>cli</summary>

<img width="488" alt="Screenshot 2024-05-17 at 3 25 15 PM" src="https://github.com/brandingbrand/flagship/assets/17734240/3196945b-e90b-45bb-8771-7540d3a8dfd4">
</details>

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
