### PR TITLE
fix(cli): enable verbose option

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run tests
         run: yarn test
       - name: Initialize react native app
-        run: yarn workspace @brandingbrand/code-example prebuild --build internal --env prod --platform android
+        run: yarn workspace @brandingbrand/code-example prebuild --build internal --env prod --platform android --verbose

--- a/packages/cli/src/actions/info.ts
+++ b/packages/cli/src/actions/info.ts
@@ -5,7 +5,7 @@ import { isWindows } from "@brandingbrand/code-cli-kit";
 
 import pkg from "../../package.json";
 
-import { defineAction, logger } from "@/lib";
+import { config, defineAction, logger } from "@/lib";
 
 /**
  * Executes the default action, providing detailed information and performing necessary checks.
@@ -72,7 +72,7 @@ export default defineAction(
     }
 
     // Pause logs when not in CI in favor of react-ink
-    if (!ci.isCI) {
+    if (!ci.isCI && !config.options.verbose) {
       logger.pause();
     }
   },

--- a/packages/cli/src/actions/packagers.ts
+++ b/packages/cli/src/actions/packagers.ts
@@ -30,6 +30,7 @@ export default defineAction(
             config.code.pluginPath,
             config.generateOptions.name
           ),
+          stdout: config.options.verbose ? "inherit" : "ignore"
         });
 
         // Execute package installation using the detected package manager
@@ -49,6 +50,7 @@ export default defineAction(
       try {
         await execa("bundle", ["install"], {
           cwd: path.project.resolve("android"),
+          stdout: config.options.verbose ? "inherit" : "ignore"
         });
       } catch (e: any) {
         throw Error(
@@ -64,6 +66,7 @@ export default defineAction(
       try {
         await execa("bundle", ["install"], {
           cwd: path.project.resolve("ios"),
+          stdout: config.options.verbose ? "inherit" : "ignore"
         });
       } catch (e: any) {
         throw Error(
@@ -79,6 +82,7 @@ export default defineAction(
       try {
         await execa("pod", ["install"], {
           cwd: path.project.resolve("ios"),
+          stdout: config.options.verbose ? "inherit" : "ignore"
         });
       } catch (e: any) {
         throw Error(`Error: failed to run "pod install" for iOS: ${e.message}`);

--- a/packages/cli/src/cmds/prebuild.tsx
+++ b/packages/cli/src/cmds/prebuild.tsx
@@ -1,7 +1,7 @@
+import chalk from "chalk";
 import { Option, program } from "commander";
 import { detect } from "detect-package-manager";
 import type { PrebuildOptions } from "@brandingbrand/code-cli-kit";
-import chalk from "chalk";
 
 import * as actions from "@/actions";
 import { Actions } from "@/components";
@@ -38,7 +38,7 @@ program
       .default("native")
   )
   .option("-r, --release", "Bundle only specified environment.", false)
-  .option("-v, --verbose", "Show stdout.", false)
+  .option("--verbose", "Show stdout.", false)
   .action(async (options: PrebuildOptions) => {
     /**
      * Update the configuration options with the provided options and command type.

--- a/packages/cli/src/components/Actions.tsx
+++ b/packages/cli/src/components/Actions.tsx
@@ -11,6 +11,7 @@ import {
   Group,
   Status,
   TEMPLATE_EVENT,
+  config,
   emitter,
 } from "@/lib";
 
@@ -26,7 +27,7 @@ type Event = {
   status: Status;
 };
 
-export function Actions(): JSX.Element {
+export function Actions() {
   const [actions, setActions] = useState({});
 
   function handler(event: Event): void {
@@ -51,6 +52,8 @@ export function Actions(): JSX.Element {
   if (!Components || isPending) return <></>;
 
   const { Box } = Components;
+
+  if (config.options.verbose) return null;
 
   return (
     <Box flexDirection="column">


### PR DESCRIPTION
## Describe your changes

Pause `react-ink` when `--verbose` option is enabled. Additionally, do not redirect stdout for exec commands.

## Issue ticket number and link

[Ticket](https://brandingbrand.atlassian.net/browse/ENG-5297)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. `yarn install`
2. `yarn build`
3. `yarn test`
4. `cd apps/example`
5. `yarn flagship-code prebuild --build internal --env prod --verbose`
6. Verify verbosity

## Demo

<details>
  <summary>terminal</summary>

```sh
$ /Users/christopherherman/git/flagship/node_modules/.bin/flagship-code prebuild --build internal --env prod --verbose


          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
          ▒▒                   ▒▒▒
          ▒▒                 ▒▒▒
          ▒▒               ▒▒▒
          ▒▒             ▒▒▒
          ▒▒           ▒▒▒
          ▒▒         ▒▒▒
          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
          ▒▒     ▒▒▒           ▒▒▒
          ▒▒   ▒▒▒           ▒▒▒
          ▒▒ ▒▒▒           ▒▒▒
          ▒▒▒▒           ▒▒▒
          ▒▒           ▒▒▒
          ▒▒         ▒▒▒
          ▒▒       ▒▒▒
          ▒▒     ▒▒▒
          ▒▒   ▒▒▒
          ▒▒ ▒▒▒
          ▒▒▒▒


Welcome to Flagship Code v13.0.0-alpha.3
  Configurable - Extensible - Toolkit

Running iOS postlink script.

Linking AppDelegate...
   Removing Unneeded imports
   No imports could be removed. Check the manual installation docs to verify that everything is properly setup:
   https://wix.github.io/react-native-navigation/docs/installing#native-installation
   Importing ReactNativeNavigation.h
   Bootstrapping Navigation !!!!
   Removing Application launch content
   No elements could be removed. Check the manual installation docs to verify that everything is properly setup:
   https://wix.github.io/react-native-navigation/docs/installing#native-installation
AppDelegate linked successfully!

Updating Podfile...
   RNN Pod has not been added to Podfile

🍏  iOS
    ios/app/BootSplash.storyboard
    ios/app.xcodeproj/project.pbxproj
    ios/app/Info.plist
    ios/app/Images.xcassets/BootSplashLogo.imageset/Contents.json
    ios/app/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo-1fnapbz.png (212x212)
    ios/app/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo-1fnapbz@2x.png (424x424)
    ios/app/Images.xcassets/BootSplashLogo.imageset/bootsplash_logo-1fnapbz@3x.png (636x636)

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  🔑  Get a license key for brand image / dark mode support  ┃
┃      https://zoontek.gumroad.com/l/bootsplash-generator     ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

💖  Thanks for using react-native-bootsplash


Running Android postlink script.

Linking MainApplication...
   Extending NavigationApplication
   Changing host implementation to NavigationReactNativeHost
   Removing call to SOLoader.init()
MainApplication.java linked successfully!

Linking MainActivity...
   Extending NavigationActivity
   Removing getMainComponentName function
   Removing createReactActivityDelegate function
MainActivity linked successfully!

Linking root build.gradle...
   Adding RNNKotlinVersion to extension block
   Adding Kotlin plugin
   Already specified minSdkVersion 21
Root build.gradle linked successfully!

🤖  Android
    android/app/src/main/res/values/colors.xml
    android/app/src/main/res/drawable-mdpi/bootsplash_logo.png (288x288)
    android/app/src/main/res/drawable-hdpi/bootsplash_logo.png (432x432)
    android/app/src/main/res/drawable-xhdpi/bootsplash_logo.png (576x576)
    android/app/src/main/res/drawable-xxhdpi/bootsplash_logo.png (864x864)
    android/app/src/main/res/drawable-xxxhdpi/bootsplash_logo.png (1152x1152)

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  🔑  Get a license key for brand image / dark mode support  ┃
┃      https://zoontek.gumroad.com/l/bootsplash-generator     ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

💖  Thanks for using react-native-bootsplash

Auto-linking React Native modules for target `app`: RNBootSplash, RNCAsyncStorage, RNDeviceInfo, RNPermissions, ReactNativeNavigation, react-native-app-restart, and react-native-sensitive-info
Framework build type is static library
[Codegen] Generating ./build/generated/ios/React-Codegen.podspec.json
Analyzing dependencies
Fetching podspec for `DoubleConversion` from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`
[Codegen] Found FBReactNativeSpec
Fetching podspec for `RCT-Folly` from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`
[Codegen] Found rncore
Fetching podspec for `boost` from `../node_modules/react-native/third-party-podspecs/boost.podspec`
Fetching podspec for `glog` from `../node_modules/react-native/third-party-podspecs/glog.podspec`
Fetching podspec for `hermes-engine` from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`
[Hermes] Using the release tarball from Maven Central
Downloading dependencies
Installing CocoaAsyncSocket (7.6.5)
Installing DoubleConversion (1.1.6)
Installing FBLazyVector (0.72.14)
Installing FBReactNativeSpec (0.72.14)
Installing Flipper (0.182.0)
Installing Flipper-Boost-iOSX (1.76.0.1.11)
Installing Flipper-DoubleConversion (3.2.0.1)
Installing Flipper-Fmt (7.1.7)
Installing Flipper-Folly (2.6.10)
Installing Flipper-Glog (0.5.0.5)
Installing Flipper-PeerTalk (0.0.4)
Installing FlipperKit (0.182.0)
Installing HMSegmentedControl (1.5.6)
Installing OpenSSL-Universal (1.1.1100)
Installing RCT-Folly (2021.07.22.00)
Installing RCTRequired (0.72.14)
Installing RCTTypeSafety (0.72.14)
Installing RNBootSplash (5.4.0)
Installing RNCAsyncStorage (1.21.0)
Installing RNDeviceInfo (10.12.0)
Installing RNPermissions (4.1.1)
Installing React (0.72.14)
Installing React-Codegen (0.72.14)
Installing React-Core (0.72.14)
Installing React-CoreModules (0.72.14)
Installing React-NativeModulesApple (0.72.14)
Installing React-RCTActionSheet (0.72.14)
Installing React-RCTAnimation (0.72.14)
Installing React-RCTAppDelegate (0.72.14)
Installing React-RCTBlob (0.72.14)
Installing React-RCTImage (0.72.14)
Installing React-RCTLinking (0.72.14)
Installing React-RCTNetwork (0.72.14)
Installing React-RCTSettings (0.72.14)
Installing React-RCTText (0.72.14)
Installing React-RCTVibration (0.72.14)
Installing React-callinvoker (0.72.14)
Installing React-cxxreact (0.72.14)
Installing React-debug (0.72.14)
Installing React-hermes (0.72.14)
Installing React-jsi (0.72.14)
Installing React-jsiexecutor (0.72.14)
Installing React-jsinspector (0.72.14)
Installing React-logger (0.72.14)
Installing React-perflogger (0.72.14)
Installing React-rncore (0.72.14)
Installing React-runtimeexecutor (0.72.14)
Installing React-runtimescheduler (0.72.14)
Installing React-utils (0.72.14)
Installing ReactCommon (0.72.14)
Installing ReactNativeNavigation (7.37.2)
Installing SocketRocket (0.6.1)
Installing Yoga (1.14.0)
Installing YogaKit (1.18.1)
Installing boost (1.76.0)
Installing fmt (6.2.1)
Installing glog (0.3.5)
Installing hermes-engine (0.72.14)
Installing libevent (2.1.12)
Installing react-native-app-restart (0.4.0)
Installing react-native-sensitive-info (5.5.8)
Generating Pods project
Setting REACT_NATIVE build settings
Setting CLANG_CXX_LANGUAGE_STANDARD to c++17 on /Users/christopherherman/git/flagship/apps/example/ios/app.xcodeproj
Pod install took 16 [s] to run
Integrating client project

[!] Please close any current Xcode sessions and use `app.xcworkspace` for this project from now on.
Pod installation complete! There are 70 dependencies from the Podfile and 61 total pods installed.
🚀 Generated native project(s), ready to launch your app!

Useful commands:

    yarn react-native run-ios
        Run your iOS app locally

    yarn react-native run-andorid
        Run your Android app locally

    yarn react-native start
        Start the Metro development server

    yarn flagship-code plugin <plugin-name>
        Generate a Flagship Code plugin

✨  Done in 26.02s.
```
</details

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
