### PR TITLE
feat(cli): fsapp v10 env export default

### DIFF
--- a/.changeset/loud-fireants-battle.md
+++ b/.changeset/loud-fireants-battle.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-cli": patch
+---
+
+update envs to default export for fsapp v10

--- a/packages/cli/src/actions/env.ts
+++ b/packages/cli/src/actions/env.ts
@@ -119,7 +119,7 @@ export default defineAction(
       mod.exports.default = {};
 
       // Add each environment's content to the module's default export
-      // In fsapp <v10 the export is expected to be a default export
+      // In fsapp <v11 the export is expected to be a default export
       // https://github.com/brandingbrand/flagship/blob/7b540442d2b83ad710e98981bd368039f0eb635c/packages/fsapp/src/index.ts#L6
       envContents.forEach((it) => {
         mod.exports.default[it.name] ||= { app: it.content };


### PR DESCRIPTION
## Describe your changes

Update envs to default export: https://github.com/brandingbrand/flagship/blob/7b540442d2b83ad710e98981bd368039f0eb635c/packages/fsapp/src/index.ts#L6.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. downgrade fsapp to v10
2. `yarn flagship-code prebuild --build internal --env prod`
3. verify project_env_index.js has default export envs

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
