### PR TITLE
fix(plugins): expose @types

### DIFF
--- a/packages/plugin-fastlane/package.json
+++ b/packages/plugin-fastlane/package.json
@@ -16,6 +16,8 @@
   },
   "types": "src/index.ts",
   "dependencies": {
+    "@types/ejs": "^3.1.5",
+    "@types/fs-extra": "^11.0.4",
     "ejs": "^3.1.9",
     "fs-extra": "^11.2.0"
   },
@@ -27,7 +29,6 @@
     "@brandingbrand/code-jest-config": "1.0.0-alpha.1",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
-    "@types/ejs": "^3.1.5",
     "@types/eslint": "^8.56.1",
     "eslint": "^8.56.0",
     "typescript": "^5.3.3"

--- a/packages/plugin-splash-screen/package.json
+++ b/packages/plugin-splash-screen/package.json
@@ -16,6 +16,7 @@
   },
   "types": "src/index.ts",
   "dependencies": {
+    "@types/fs-extra": "^11.0.4",
     "fs-extra": "^11.2.0",
     "react-native-bootsplash": "5.4.0"
   },

--- a/packages/plugin-target-extension/package.json
+++ b/packages/plugin-target-extension/package.json
@@ -16,6 +16,7 @@
   },
   "types": "src/index.ts",
   "dependencies": {
+    "@types/fs-extra": "^11.0.4",
     "fs-extra": "^11.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Describe your changes

It's required to export any `@types` that are utilized within the plugins because they are un-compiled packages. When importing these types it imports them from source so the `@types` need to exist otherwise you will get a typescript error when running typescript compile.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. `yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
