### PR TITLE
feat: abstract build config type

### DIFF
--- a/packages/cli-kit/src/@types/config.ts
+++ b/packages/cli-kit/src/@types/config.ts
@@ -14,6 +14,19 @@ export type CodeConfig = t.TypeOf<typeof FlagshipCodeConfigSchema>;
 export type BuildConfig = t.TypeOf<typeof BuildConfigSchema>;
 
 /**
+ * A utility type that enforces the structure of `BuildConfig` and allows for optional extensions.
+ *
+ * If the generic type `T` is exactly `BuildConfig`, it returns `BuildConfig`.
+ * Otherwise, it returns a type that merges `BuildConfig` with `T`, allowing
+ * for additional properties specified in `T`.
+ *
+ * @template T - The optional type extensions to `BuildConfig`.
+ */
+export type ExtendedBuildConfig<T> = T extends BuildConfig
+  ? BuildConfig
+  : BuildConfig & T;
+
+/**
  * Represents the configuration for environment settings.
  * @template T - The type of the environment configuration.
  */

--- a/packages/cli-kit/src/lib/guards.ts
+++ b/packages/cli-kit/src/lib/guards.ts
@@ -2,7 +2,13 @@ import type {PackageJson} from 'type-fest';
 
 import path from './path';
 
-import type {BuildConfig, CodeConfig, EnvConfig, PluginConfig} from '@/@types';
+import type {
+  BuildConfig,
+  CodeConfig,
+  EnvConfig,
+  ExtendedBuildConfig,
+  PluginConfig,
+} from '@/@types';
 
 /**
  * Import paths module to get package.json path
@@ -39,10 +45,8 @@ export function defineEnv<T>(env: EnvConfig<T>) {
  */
 export function defineBuild<T = BuildConfig>(
   build:
-    | (T extends BuildConfig ? BuildConfig : BuildConfig & T)
-    | ((
-        pkg: PackageJson,
-      ) => T extends BuildConfig ? BuildConfig : BuildConfig & T),
+    | ExtendedBuildConfig<T>
+    | ((pkg: PackageJson) => ExtendedBuildConfig<T>),
 ) {
   const pkg: PackageJson = require(path.project.resolve('package.json'));
 


### PR DESCRIPTION
## Describe your changes

It's not clear to the reasoning on why the type was being used the way it was. By conventional though it could be thought to do this a different way by setting a default value to the generic and conditionalizing it's value based on extending but when a generic value is not supplied in usage the generic value will be inferred thereby breaking the strict typing. Abstracting it and explaining it in a comment makes this more clear.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (non-breaking change which fixes an issue)

## Test Plan

- `yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
