### PR TITLE
fix(adr): disable network security config by default

### DIFF
--- a/.changeset/fresh-days-chew.md
+++ b/.changeset/fresh-days-chew.md
@@ -1,0 +1,6 @@
+---
+"@brandingbrand/code-cli-kit": minor
+"@brandingbrand/code-cli": minor
+---
+
+dynamically generate network_security_config.xml

--- a/packages/cli-kit/__tests__/network-security-config-xml.ts
+++ b/packages/cli-kit/__tests__/network-security-config-xml.ts
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment-options {"requireTemplate": true}
+ */
+
+import fs from 'fs/promises';
+
+import {withNetworkSecurityConfig} from '../src/parsers/xml';
+import path from '../src/lib/path';
+
+describe('network security configuration', () => {
+  it('AndroidManifest.xml should not contain @xml/network_security_config by default', async () => {
+    const androidManifest = await fs.readFile(
+      path.android.androidManifest,
+      'utf-8',
+    );
+
+    expect(androidManifest).not.toContain('@xml/network_security_config');
+  });
+
+  it('withNetworkSecurityConfig should add @xml/network_security_config to AndroidManifest.xml', async () => {
+    await withNetworkSecurityConfig(xml => {});
+
+    const androidManifest = await fs.readFile(
+      path.android.androidManifest,
+      'utf-8',
+    );
+
+    expect(androidManifest).toContain('@xml/network_security_config');
+  });
+
+  it('withNetworkSecurityConfig with a domain configuration should be added to @xml/network_security_config', async () => {
+    await withNetworkSecurityConfig(xml => {
+      if (!xml['network-security-config']['domain-config']) {
+        xml['network-security-config'] = {
+          'domain-config': [],
+        };
+      }
+
+      xml['network-security-config']['domain-config']?.push({
+        $: {cleartextTrafficPermitted: true},
+        domain: [
+          {
+            $: {
+              includeSubdomains: true,
+            },
+            _: 'localhost',
+          },
+        ],
+      });
+    });
+
+    const networkSecurityConfig = await fs.readFile(
+      path.project.resolve(
+        'android',
+        'app',
+        'src',
+        'main',
+        'res',
+        'xml',
+        'network_security_config.xml',
+      ),
+      'utf-8',
+    );
+
+    expect(networkSecurityConfig)
+      .toContain(`<domain-config cleartextTrafficPermitted=\"true\">
+        <domain includeSubdomains=\"true\">localhost</domain>
+    </domain-config>`);
+  });
+});

--- a/packages/cli-kit/__tests__/path.ts
+++ b/packages/cli-kit/__tests__/path.ts
@@ -104,15 +104,6 @@ describe('path', () => {
     );
   });
 
-  it('should have an android.networkSecurityConfig function that returns the path to android/app/src/main/res/xml/network_security_config.xml', () => {
-    const networkSecurityConfigPath = path.android.networkSecurityConfig;
-    expect(networkSecurityConfigPath).toEqual(
-      expect.stringMatching(
-        /.*android\/app\/src\/main\/res\/xml\/network_security_config\.xml$/,
-      ),
-    );
-  });
-
   it('should have an android.mainApplication function that returns the path to android/app/src/main/java/com/example/app/MainApplication.java', () => {
     const config = {
       android: {

--- a/packages/cli-kit/__tests__/xml.ts
+++ b/packages/cli-kit/__tests__/xml.ts
@@ -6,7 +6,6 @@ import {
   OPTS,
   withColors,
   withManifest,
-  withNetworkSecurityConfig,
   withStrings,
   withStyles,
   withXml,
@@ -120,43 +119,6 @@ describe('xml', () => {
     expect(fs.readFile).toHaveBeenCalledWith(path.android.colors);
     expect(callback).toHaveBeenCalledWith(xmlObject);
     expect(fs.writeFile).toHaveBeenCalledWith(path.android.colors, xmlContent);
-  });
-
-  it('withNetworkSecurityConfig should parse, modify, and write network security config XML file', async () => {
-    const xmlContent = `<?xml version="1.0" encoding="utf-8"?>
-    <network-security-config>
-        <domain-config>
-            <domain includeSubdomains="true">example.com</domain>
-            <trust-anchors>
-                <certificates src="@raw/my_ca"/>
-            </trust-anchors>
-        </domain-config>
-    </network-security-config>`;
-    const xmlObject = {
-      'network-security-config': {
-        'domain-config': {
-          domain: 'example.com',
-          'trust-anchors': {
-            certificates: '',
-          },
-        },
-      },
-    };
-
-    const callback = jest.fn();
-    jest.spyOn(XMLParser.prototype, 'parse').mockReturnValue(xmlObject);
-    jest.spyOn(XMLBuilder.prototype, 'build').mockReturnValue(xmlContent);
-
-    await withNetworkSecurityConfig(callback);
-
-    expect(fs.readFile).toHaveBeenCalledWith(
-      path.android.networkSecurityConfig,
-    );
-    expect(callback).toHaveBeenCalledWith(xmlObject);
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      path.android.networkSecurityConfig,
-      xmlContent,
-    );
   });
 
   it('withManifest should parse, modify, and write android manifest XML file', async () => {

--- a/packages/cli-kit/src/lib/path.ts
+++ b/packages/cli-kit/src/lib/path.ts
@@ -210,21 +210,6 @@ export default {
     ),
 
     /**
-     * Retrieves the absolute path to the Android network_security_config.xml file.
-     *
-     * @returns {string} The absolute path to "android/app/src/main/res/xml/network_security_config.xml".
-     */
-    networkSecurityConfig: resolvePathFromProject(
-      'android',
-      'app',
-      'src',
-      'main',
-      'res',
-      'xml',
-      'network_security_config.xml',
-    ),
-
-    /**
      * Retrieves the absolute path to the Android strings.xml file.
      *
      * @returns {string} The absolute path to "android/app/src/main/res/values/strings.xml".

--- a/packages/cli/__tests__/android-maniest-xml.ts
+++ b/packages/cli/__tests__/android-maniest-xml.ts
@@ -72,15 +72,4 @@ describe('android AndroidManifest.xml transformers', () => {
 
     expect(content).toContain(`android:screenOrientation="portrait"`);
   });
-
-  it("should update AndroidManifest.xml with the network security config", async () => {
-    const config = {
-      ...__flagship_code_build_config,
-    } as BuildConfig;
-
-    await transformer.transform(config, {} as any);
-    const content = await fs.readFile(path.android.androidManifest, "utf-8");
-
-    expect(content).toContain(`android:networkSecurityConfig="@xml/network_security_config"`);
-  });
 });

--- a/packages/cli/src/transformers/android/android-manifest-xml.ts
+++ b/packages/cli/src/transformers/android/android-manifest-xml.ts
@@ -105,25 +105,6 @@ export default defineTransformer<Transforms<AndroidManifestXML, void>>({
 
       mainActivity.$['android:screenOrientation'] = orientation;
     },
-
-    /**
-     * Function that applies the network security config to the AndroidManifest.xml file.
-     * @param xml The AndroidManifestXML object representing the contents of the AndroidManifest.xml file.
-     * @param config The build configuration containing Android-specific manifest options.
-     */
-    (xml: AndroidManifestXML, config: BuildConfig) => {
-      // Find the main application activity in the manifest and update its intent filter
-      const mainApplication = xml.manifest.application
-        ?.find((it) => it.$["android:name"] === ".MainApplication")
-
-      if (!mainApplication) {
-        throw new Error(
-          "[AndroidManifestTransformer]: cannot set network security configuration because .MainApplication not found"
-        );
-      }
-
-      mainApplication.$["android:networkSecurityConfig"] = "@xml/network_security_config"
-    },
   ],
 
   /**

--- a/packages/cli/template/extras/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/cli/template/extras/android/app/src/main/res/xml/network_security_config.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-</network-security-config>


### PR DESCRIPTION
## Describe your changes

When the network security configuration is added to the `AndroidManifest.xml` by default with an empty configuration it can interfere with the metro packager when developing.

Only update the `AndroidManifest.xml` with the network security configuration if someone utilizes the the parser. Note, the developer will be responsible for adding the local environments in non-release mode via their plugin.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `yarn test`

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
