### PR TITLE
fix: center cli text

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@brandingbrand/code-cli-kit": "13.0.0",
+    "ansi-align": "^3.0.1",
     "bundle-require": "^4.0.2",
     "chalk": "^4.1.2",
     "ci-info": "^4.0.0",
@@ -51,6 +52,7 @@
     "@brandingbrand/code-jest-config": "1.0.0",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
+    "@types/ansi-align": "3.0.5",
     "@types/eslint": "^8.56.1",
     "@types/node": "^20.10.6",
     "@types/react": "^18.2.55",

--- a/packages/cli/src/actions/info.ts
+++ b/packages/cli/src/actions/info.ts
@@ -6,6 +6,7 @@ import {isWindows} from '@brandingbrand/code-cli-kit';
 import pkg from '../../package.json';
 
 import {config, defineAction, logger} from '@/lib';
+import ansiAlign from 'ansi-align';
 
 /**
  * Executes the default action, providing detailed information and performing necessary checks.
@@ -40,11 +41,13 @@ export default defineAction(
           ▒▒▒▒
 
 `);
+
     logger.info(
-      chalk.bold
-        .blue`Welcome to Flagship Code ${chalk.bold.white`v${pkg.version}`}`,
+      ansiAlign([
+        chalk.bold.blue`Flagship Code ${chalk.bold.white`v${pkg.version}`}`,
+        chalk.dim`Configurable - Extensible - Toolkit`,
+      ]).join('\n'),
     );
-    logger.info(chalk.dim`  Configurable - Extensible - Toolkit`);
 
     // Check if the script is running on Windows, and throw an error if it is
     if (isWindows) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,11 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/ansi-align@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/ansi-align/-/ansi-align-3.0.5.tgz#47302af78848bfcc2432b9050ce81e7c11a6d541"
+  integrity sha512-W6b8auzVjGP4JS2ejBl9OzwL1N3aBGqY7gamD28GymzcdNVeVGS+jfLeNWO/iknHLWa00hqGPaT3AcXhKax4aA==
+
 "@types/babel__core@^7.1.14", "@types/babel__core@^7.20.4":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"


### PR DESCRIPTION
## Describe your changes

CLI text is not centered - use popular package `ansi-align` to center the CLI text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `yarn flagship-code prebuild --build internal --env prod`

<details>
  <summary>cli</summary>

```
          ▒▒▒▒▒▒▒▒▒▒▒▒▒
          ▒▒                   ▒▒▒
          ▒▒                 ▒▒▒
          ▒▒               ▒▒▒
          ▒▒             ▒▒▒
          ▒▒           ▒▒▒
          ▒▒         ▒▒▒
          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
          ▒▒     ▒▒▒           ▒▒▒
          ▒▒   ▒▒▒           ▒▒▒
          ▒▒ ▒▒▒           ▒▒▒
          ▒▒▒▒           ▒▒▒
          ▒▒           ▒▒▒
          ▒▒         ▒▒▒
          ▒▒       ▒▒▒
          ▒▒     ▒▒▒
          ▒▒   ▒▒▒
          ▒▒ ▒▒▒
          ▒▒▒▒


       Flagship Code v13.0.0
Configurable - Extensible - Toolkit
```
</details>

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
