### PR TITLE
fix: plugin-permissions react-native-permissions versions

### DIFF
--- a/.changeset/small-toys-argue.md
+++ b/.changeset/small-toys-argue.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-permissions": patch
+---
+
+utilize react-native-permissions ios setup script.

--- a/packages/plugin-permissions/__tests__/index.ts
+++ b/packages/plugin-permissions/__tests__/index.ts
@@ -8,8 +8,6 @@ import plugin from '../src';
 import type {CodePluginPermissions} from '../src/types';
 
 describe('plugin-permissions', () => {
-  jest.spyOn(fs, 'writeFile').mockImplementation(jest.fn());
-
   it('ios', async () => {
     const config: BuildConfig & CodePluginPermissions = {
       ios: {
@@ -39,13 +37,11 @@ describe('plugin-permissions', () => {
 
     await plugin.ios?.(config, {} as any);
 
-    expect(fs.writeFile).toHaveBeenCalledWith(
-      require.resolve('react-native-permissions/RNPermissions.podspec'),
-      expect.stringContaining(
-        '"ios/*.{h,m,mm}", "ios/AppTrackingTransparency/*.{h,m,mm}"',
-      ),
-      'utf-8',
-    );
+    expect(await fs.readFile(path.ios.podfile, 'utf-8'))
+      .toContain(`setup_permissions([
+  'AppTrackingTransparency',
+  'LocationAccuracy'
+])`);
     expect(await fs.readFile(path.ios.infoPlist, 'utf-8'))
       .toContain(`<key>NSUserTrackingUsageDescription</key>
     <string>Let me use your ad identifier</string>`);


### PR DESCRIPTION
## Describe your changes

In version 4.1.3 of react-native-permissions they changed the way they update their internal *.podspec file which our plugin does not accommodate for. To account for these changes - we will just execute the same ruby scripts that the documentation calls for.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `yarn test`
- Run example app and verify camera permission works

<details>
  <summary>ios</summary>

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-02 at 10 11 58](https://github.com/user-attachments/assets/cb300aa8-7cd4-4e57-aaeb-24be85df4db9)
</details>

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
