### PR TITLE
fix: udpate-check log error

### DIFF
--- a/.changeset/lucky-rocks-deliver.md
+++ b/.changeset/lucky-rocks-deliver.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-cli": patch
+---
+
+update-check log error instead of program exit.

--- a/packages/cli/src/actions/info.ts
+++ b/packages/cli/src/actions/info.ts
@@ -1,4 +1,3 @@
-import ansiAlign from 'ansi-align';
 import ci from 'ci-info';
 import updateCheck from 'update-check';
 import {isWindows, logger} from '@brandingbrand/code-cli-kit';
@@ -26,15 +25,19 @@ export default defineAction(async () => {
   }
 
   // Check for package updates
-  const update = await updateCheck({
-    name: pkg.name,
-    version: pkg.version,
-  });
+  try {
+    const update = await updateCheck({
+      name: pkg.name,
+      version: pkg.version,
+    });
 
-  // Warn for new version available
-  if (update) {
-    logger.warn(
-      `A new version of ${pkg.name} is available: v${pkg.version} -> v${update.latest}`,
-    );
+    // Warn for new version available
+    if (update) {
+      logger.warn(
+        `new version of ${pkg.name} is available: v${pkg.version} -> v${update.latest}`,
+      );
+    }
+  } catch (e: any) {
+    logger.error(`failed to check for ${pkg.name} updates: ${e.message}`);
   }
 });


### PR DESCRIPTION
## Describe your changes

If update-check fails it will early exit the program. Wrap with try/catch and log error message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `yarn test`
- intentionally throw error in update check block
- `yarn flagship-code prebuild --build internal --env prod`
- Verify no early exit and error message

<details>
  <summary>error</summary>

<img width="865" alt="Screenshot 2024-08-08 at 10 46 12 AM" src="https://github.com/user-attachments/assets/f45ebc24-48b5-423b-b98c-0e9bad39ef85">
</details>

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
