### PR TITLE
fix: peer dependency versions

### DIFF
--- a/.changeset/angry-gifts-rescue.md
+++ b/.changeset/angry-gifts-rescue.md
@@ -1,0 +1,13 @@
+---
+"@brandingbrand/code-plugin-native-navigation": patch
+"@brandingbrand/code-plugin-target-extension": patch
+"@brandingbrand/code-plugin-splash-screen": patch
+"@brandingbrand/code-plugin-permissions": patch
+"@brandingbrand/code-plugin-app-icon": patch
+"@brandingbrand/code-plugin-fastlane": patch
+"@brandingbrand/code-plugin-asset": patch
+"@brandingbrand/code-cli-kit": patch
+"@brandingbrand/code-cli": patch
+---
+
+peer dependency alignment

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -36,7 +36,7 @@
     "@babel/runtime": "^7.20.0",
     "@brandingbrand/code-cli": "13.0.1",
     "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-jest-config": "*",
     "@brandingbrand/code-plugin-app-icon": "2.0.0",
     "@brandingbrand/code-plugin-asset": "2.0.0",
     "@brandingbrand/code-plugin-example": "link:./coderc/plugins/plugin-example",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -32,7 +32,7 @@
     "xcode": "^3.0.2-nightly.20240423000755527.sha.5158ec51"
   },
   "devDependencies": {
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,6 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
     "@npmcli/package-json": "^5.2.0",
     "ansi-align": "^3.0.1",
     "bundle-require": "^4.0.2",
@@ -47,11 +46,13 @@
     "write-package": "^7.0.0"
   },
   "peerDependencies": {
+    "@brandingbrand/code-cli-kit": "^13.0.0",
     "react": "^18.2.0",
     "react-native": "~0.72.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/ansi-align": "3.0.5",

--- a/packages/plugin-app-icon/package.json
+++ b/packages/plugin-app-icon/package.json
@@ -19,11 +19,11 @@
     "sharp": "^0.32.5"
   },
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0"
+    "@brandingbrand/code-cli-kit": "^13.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-asset/package.json
+++ b/packages/plugin-asset/package.json
@@ -20,11 +20,11 @@
     "react-native-asset": "2.1.1"
   },
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0"
+    "@brandingbrand/code-cli-kit": "^13.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-fastlane/package.json
+++ b/packages/plugin-fastlane/package.json
@@ -22,11 +22,11 @@
     "fs-extra": "^11.2.0"
   },
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0"
+    "@brandingbrand/code-cli-kit": "^13.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-native-navigation/package.json
+++ b/packages/plugin-native-navigation/package.json
@@ -16,12 +16,12 @@
   },
   "types": "src/index.ts",
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
+    "@brandingbrand/code-cli-kit": "^13.0.0",
     "react-native-navigation": "*"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-permissions/package.json
+++ b/packages/plugin-permissions/package.json
@@ -16,12 +16,12 @@
   },
   "types": "src/index.ts",
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
+    "@brandingbrand/code-cli-kit": "^13.0.0",
     "react-native-permissions": "^4.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-splash-screen/package.json
+++ b/packages/plugin-splash-screen/package.json
@@ -21,11 +21,11 @@
     "react-native-bootsplash": "5.4.0"
   },
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0"
+    "@brandingbrand/code-cli-kit": "^13.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",

--- a/packages/plugin-target-extension/package.json
+++ b/packages/plugin-target-extension/package.json
@@ -20,11 +20,11 @@
     "fs-extra": "^11.2.0"
   },
   "peerDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0"
+    "@brandingbrand/code-cli-kit": "^13.0.0"
   },
   "devDependencies": {
-    "@brandingbrand/code-cli-kit": "13.0.0",
-    "@brandingbrand/code-jest-config": "1.0.0",
+    "@brandingbrand/code-cli-kit": "*",
+    "@brandingbrand/code-jest-config": "*",
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*",
     "@types/eslint": "^8.56.1",


### PR DESCRIPTION
## Describe your changes

Fix peer-dependency versions to match a semver range. We should limit internal dev dependencies with * to denote the latest available package in the workspace.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- `yarn test`

<details>
  <summary>ios</summary>

![Simulator Screenshot - iPhone 15 - 2024-09-09 at 17 18 36](https://github.com/user-attachments/assets/1cc65036-6044-4807-984e-eea15bd0c208)
</details>

<details>
  <summary>android</summary>
  
![Screenshot_1725916763](https://github.com/user-attachments/assets/bf2ac48a-a8d5-4165-b8ab-6220c416a0b0)
</details>

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes
