### PR TITLE
ENG-5771: Add firebase app distribution support

### DIFF
--- a/apps/docs/src/content/docs/packages/plugin-fastlane.mdx
+++ b/apps/docs/src/content/docs/packages/plugin-fastlane.mdx
@@ -82,9 +82,9 @@ For more detailed guidance and information, please refer to the [Flagship Code C
 
 ### Build Configuration
 
-Depending on the plugin, there might be additional configuration required. Regarding the `plugin-fastlane`, there's an optional additional build configuration feature available to extend your Fastlane setup. Presently, the only extension supported is for AppCenter uploads. Providing the AppCenter configuration will prompt the plugin to update your Fastlane setup accordingly.
+Depending on the plugin, there might be additional configuration required. Regarding the `plugin-fastlane`, there's an optional additional build configuration feature available to extend your Fastlane setup. Presently, the only extensions supported are for uploads to AppCenter and/or Firebase App Distribution. Providing configuration for either services will prompt the plugin to update your Fastlane setup accordingly.
 
-For the purpose of illustration, the `build.internal.ts` configuration shall be presented as follows if you want to include AppCenter uploads:
+For the purpose of illustration, the `build.internal.ts` configuration shall be presented as follows if you want to include both AppCenter and Firebase App Distribution uploads:
 
 ```ts title="build.internal.ts"
 import { defineBuild } from "@brandingbrand/code-cli-kit";
@@ -108,6 +108,10 @@ export default defineBuild<CodePluginFastlane>({
           destinationType: "group",
           destinations: ["iat"],
         },
+        firebase: {
+          appId: '1234',
+          groups: ['iat'],
+        },
       },
       android: {
         appCenter: {
@@ -115,6 +119,10 @@ export default defineBuild<CodePluginFastlane>({
           appName: "MyApp-Android",
           destinationType: "group",
           destinations: ["iat"],
+        },
+        firebase: {
+          appId: '4321',
+          groups: ['iat'],
         },
       },
     },
@@ -164,6 +172,26 @@ _required_
 
 Array of distribution destinations.
 
+##### `codePluginFastlane.plugin.ios.firebase`
+
+#### `FirebaseIOS`
+
+###### `appId`
+
+**type:** `"string"
+
+_required_
+
+The Firebase app id.
+
+###### `groups`
+
+**type:** `string[]`
+
+_required_
+
+Array of distribution groups.
+
 ##### `codePluginFastlane.plugin.android.appCenter`
 
 **type:** [AppCenterAndroid](#appcenterandroid)
@@ -204,6 +232,26 @@ _required_
 
 Array of distribution destinations.
 
+##### `codePluginFastlane.plugin.android.firebase`
+
+#### `FirebaseAndroid`
+
+###### `appId`
+
+**type:** `"string"
+
+_required_
+
+The Firebase app id.
+
+###### `groups`
+
+**type:** `string[]`
+
+_required_
+
+Array of distribution groups.
+
 :::note
-If you don't need AppCenter then do not include the `codePluginFastlane` configuration.
+If you don't need AppCenter or Firebase App Distribution then do not include the `codePluginFastlane` configuration.
 :::

--- a/packages/plugin-fastlane/__tests__/index.ts
+++ b/packages/plugin-fastlane/__tests__/index.ts
@@ -99,11 +99,6 @@ describe('plugin-fastlane', () => {
       'utf-8',
     );
 
-    const pluginfileContent = await fs.readFile(
-      path.project.resolve('ios', 'fastlane', 'Pluginfile'),
-      'utf-8',
-    );
-
     expect(fastfileContent).toContain(
       `@profiles = ['${path.project.resolve('coderc', 'signing', 'enterprise.mobileprovision')}']`,
     );
@@ -123,9 +118,8 @@ describe('plugin-fastlane', () => {
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
 
-    expect(fastfileContent).toContain('lane :increment_build_appcenter');
-    expect(fastfileContent).not.toContain('firebase');
-    expect(pluginfileContent).not.toContain('firebase');
+    expect(fastfileContent).toContain('appcenter_upload');
+    expect(fastfileContent).not.toContain('firebase_app_distribution');
   });
 
   it('ios with firebase config', async () => {
@@ -146,15 +140,8 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
       path.project.resolve('ios', 'fastlane', 'Fastfile'),
       'utf-8',
     );
-    const pluginfileContent = await fs.readFile(
-      path.project.resolve('ios', 'fastlane', 'Pluginfile'),
-      'utf-8',
-    );
-
-    expect(fastfileContent).toContain('lane :increment_build_firebase');
-    expect(fastfileContent).toContain('firebase');
-    expect(fastfileContent).not.toContain('appcenter');
-    expect(pluginfileContent).not.toContain('appcenter');
+    expect(fastfileContent).toContain('firebase_app_distribution');
+    expect(fastfileContent).not.toContain('appcenter_upload');
   });
 
   it('android', async () => {
@@ -174,54 +161,19 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
       'utf-8',
     );
 
-    expect(fastfileContent).toContain(`lane :appcenter_bundle do
-  increment_build`);
     expect(fastfileContent).not.toContain('<%=');
     expect(fastfileContent).not.toContain('%>');
 
-    expect(fastfileContent).toContain('lane :increment_build_appcenter');
-    expect(fastfileContent).not.toContain('firebase');
-    expect(pluginfileContent).not.toContain('firebase');
+    expect(fastfileContent).toContain('appcenter_upload');
+    expect(fastfileContent).not.toContain('firebase_app_distribution');
 
     expect(gemfileContent).toContain(`gem 'fastlane'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
 
-    expect(fastfileContent).toContain('lane :increment_build_appcenter');
-    expect(fastfileContent).not.toContain('firebase');
-    expect(pluginfileContent).not.toContain('firebase');
-  });
-
-  it('android bundle without increment build', async () => {
-    await plugin.android?.(
-      {
-        ...config,
-        android: {
-          ...config.android,
-          versioning: {version: '1.0.0', build: 5},
-        },
-      },
-      options as any,
-    );
-
-    const fastfileContent = await fs.readFile(
-      path.project.resolve('android', 'fastlane', 'Fastfile'),
-      'utf-8',
-    );
-    const gemfileContent = await fs.readFile(
-      path.project.resolve('android', 'Gemfile'),
-      'utf-8',
-    );
-
-    expect(fastfileContent).not.toContain(`lane :appcenter_bundle do
-  increment_build`);
-    expect(fastfileContent).not.toContain('<%=');
-    expect(fastfileContent).not.toContain('%>');
-    expect(gemfileContent).toContain(`gem 'fastlane'
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
+    expect(fastfileContent).toContain('appcenter_upload');
+    expect(fastfileContent).not.toContain('firebase_app_distribution');
   });
 
   it('android with firebase config', async () => {
@@ -231,15 +183,8 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
       path.project.resolve('android', 'fastlane', 'Fastfile'),
       'utf-8',
     );
-    const pluginfileContent = await fs.readFile(
-      path.project.resolve('android', 'fastlane', 'Pluginfile'),
-      'utf-8',
-    );
 
-    expect(fastfileContent).toContain('lane :increment_build_firebase');
-    expect(fastfileContent).toContain('lane :firebase_assemble');
-    expect(fastfileContent).toContain('lane :firebase_bundle');
-    expect(fastfileContent).not.toContain('appcenter');
-    expect(pluginfileContent).not.toContain('appcenter');
+    expect(fastfileContent).toContain('firebase_app_distribution');
+    expect(fastfileContent).not.toContain('appcenter_upload');
   });
 });

--- a/packages/plugin-fastlane/__tests__/index.ts
+++ b/packages/plugin-fastlane/__tests__/index.ts
@@ -156,11 +156,6 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
       'utf-8',
     );
 
-    const pluginfileContent = await fs.readFile(
-      path.project.resolve('android', 'fastlane', 'Pluginfile'),
-      'utf-8',
-    );
-
     expect(fastfileContent).not.toContain('<%=');
     expect(fastfileContent).not.toContain('%>');
 
@@ -174,6 +169,37 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
 
     expect(fastfileContent).toContain('appcenter_upload');
     expect(fastfileContent).not.toContain('firebase_app_distribution');
+  });
+
+  it('android bundle without increment build', async () => {
+    await plugin.android?.(
+      {
+        ...config,
+        android: {
+          ...config.android,
+          versioning: {version: '1.0.0', build: 5},
+        },
+      },
+      options as any,
+    );
+
+    const fastfileContent = await fs.readFile(
+      path.project.resolve('android', 'fastlane', 'Fastfile'),
+      'utf-8',
+    );
+    const gemfileContent = await fs.readFile(
+      path.project.resolve('android', 'Gemfile'),
+      'utf-8',
+    );
+
+    expect(fastfileContent).not.toContain(`lane :appcenter_bundle do
+  increment_build`);
+    expect(fastfileContent).not.toContain('<%=');
+    expect(fastfileContent).not.toContain('%>');
+    expect(gemfileContent).toContain(`gem 'fastlane'
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)`);
   });
 
   it('android with firebase config', async () => {

--- a/packages/plugin-fastlane/src/index.ts
+++ b/packages/plugin-fastlane/src/index.ts
@@ -78,18 +78,6 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`,
       },
     );
 
-    // Render Pluginfile template for iOS
-    await withUTF8(
-      path.project.resolve('ios', 'fastlane', 'Pluginfile'),
-      content => {
-        return ejs.render(content, {
-          ...build,
-          ...options,
-          ...(!build.codePluginFastlane ? {codePluginFastlane: {}} : {}),
-        });
-      },
-    );
-
     // Get list of provisioning profiles files
     const files = await fs.readdir(
       path.project.resolve(build.ios.signing.profilesDir),
@@ -192,18 +180,6 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`,
     // Render Fastfile template for Android
     await withUTF8(
       path.project.resolve('android', 'fastlane', 'Fastfile'),
-      content => {
-        return ejs.render(content, {
-          ...build,
-          ...options,
-          ...(!build.codePluginFastlane ? {codePluginFastlane: {}} : {}),
-        });
-      },
-    );
-
-    // Render PluginFile template for Android
-    await withUTF8(
-      path.project.resolve('android', 'fastlane', 'Pluginfile'),
       content => {
         return ejs.render(content, {
           ...build,

--- a/packages/plugin-fastlane/src/index.ts
+++ b/packages/plugin-fastlane/src/index.ts
@@ -78,6 +78,18 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`,
       },
     );
 
+    // Render Pluginfile template for iOS
+    await withUTF8(
+      path.project.resolve('ios', 'fastlane', 'Pluginfile'),
+      content => {
+        return ejs.render(content, {
+          ...build,
+          ...options,
+          ...(!build.codePluginFastlane ? {codePluginFastlane: {}} : {}),
+        });
+      },
+    );
+
     // Get list of provisioning profiles files
     const files = await fs.readdir(
       path.project.resolve(build.ios.signing.profilesDir),
@@ -180,6 +192,18 @@ eval_gemfile(plugins_path) if File.exist?(plugins_path)`,
     // Render Fastfile template for Android
     await withUTF8(
       path.project.resolve('android', 'fastlane', 'Fastfile'),
+      content => {
+        return ejs.render(content, {
+          ...build,
+          ...options,
+          ...(!build.codePluginFastlane ? {codePluginFastlane: {}} : {}),
+        });
+      },
+    );
+
+    // Render PluginFile template for Android
+    await withUTF8(
+      path.project.resolve('android', 'fastlane', 'Pluginfile'),
       content => {
         return ejs.render(content, {
           ...build,

--- a/packages/plugin-fastlane/src/types.ts
+++ b/packages/plugin-fastlane/src/types.ts
@@ -37,6 +37,21 @@ type AppCenterIOS = {
 };
 
 /**
+ * Represents the configuration for Firebase App Distribution for iOS.
+ */
+type FirebaseIOS = {
+  /**
+   * The application id in firebase.
+   */
+  appId: string;
+
+  /**
+   * Array of testing groups
+   */
+  groups: string[];
+};
+
+/**
  * Represents the configuration for Fastlane specific to iOS.
  */
 type FastlaneIOS = {
@@ -44,6 +59,7 @@ type FastlaneIOS = {
    * Configuration for App Center for iOS.
    */
   appCenter?: AppCenterIOS;
+  firebase?: FirebaseIOS;
 };
 
 /**
@@ -72,6 +88,21 @@ type AppCenterAndroid = {
 };
 
 /**
+ * Represents the configuration for Firebase App Distribution for Android.
+ */
+type FirebaseAndroid = {
+  /**
+   * The application id in firebase.
+   */
+  appId: string;
+
+  /**
+   * Array of testing groups
+   */
+  groups: string[];
+};
+
+/**
  * Represents the configuration for Fastlane specific to Android.
  */
 type FastlaneAndroid = {
@@ -79,4 +110,5 @@ type FastlaneAndroid = {
    * Configuration for App Center for Android.
    */
   appCenter?: AppCenterAndroid;
+  firebase?: FirebaseAndroid;
 };

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -33,31 +33,31 @@ end
 
 lane :increment_build_appcenter do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
-    increment_build
+  increment_build
   <% } else { -%>
-    UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
+  UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
   <% } -%>
 end
 
 lane :increment_build_firebase do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
-    begin
-      version = firebase_app_distribution_get_latest_release(
-        app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
-        service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
-      )
+  begin
+    version = firebase_app_distribution_get_latest_release(
+      app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
+      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
+    )
 
-      if version[:buildVersion]
-        build_number = version[:buildVersion].to_i + 1
-        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
-        puts "Fastlane: updated build number to #{build_number}"
-      end
-    rescue StandardError => e
-      puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
-      puts "Fastlane: #{e.message}"
+    if version[:buildVersion]
+      build_number = version[:buildVersion].to_i + 1
+      sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+      puts "Fastlane: updated build number to #{build_number}"
     end
+  rescue StandardError => e
+    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+    puts "Fastlane: #{e.message}"
+  end
   <% } else { -%>
-    UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
+  UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
   <% } -%>
 end
 

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -32,15 +32,15 @@ end
 <% } -%>
 
 lane :increment_build_appcenter do
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
   increment_build
-  <% } else { -%>
+<% } else { -%>
   UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
-  <% } -%>
+<% } -%>
 end
 
 lane :increment_build_firebase do
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
   begin
     version = firebase_app_distribution_get_latest_release(
       app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
@@ -56,9 +56,9 @@ lane :increment_build_firebase do
     puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
     puts "Fastlane: #{e.message}"
   end
-  <% } else { -%>
+<% } else { -%>
   UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
-  <% } -%>
+<% } -%>
 end
 
 

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -10,24 +10,29 @@ lane :bundle do
   gradle(task: "app:bundleRelease")
 end
 
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+lane :increment_build do
+  begin
+    version = appcenter_fetch_version_number(
+        owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+        app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+        version: "<%- android.versioning?.version || "1.0.0" %>"
+    )
+    if version["build_number"]
+      build_number = version["build_number"].to_i + 1
+      sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+
+      puts "Fastlane: updated build number to #{build_number}"
+    end
+  rescue
+    puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
+  end
+end
+<% } -%>
+
 lane :increment_build_appcenter do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
-    begin
-      version = appcenter_fetch_version_number(
-          owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
-          app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
-          version: "<%- android.versioning?.version || "1.0.0" %>"
-      )
-
-      if version["build_number"]
-        build_number = version["build_number"].to_i + 1
-        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
-
-        puts "Fastlane: updated build number to #{build_number}"
-      end
-    rescue
-      puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
-    end
+    increment_build
   <% } else { -%>
     UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
   <% } -%>
@@ -55,7 +60,35 @@ lane :increment_build_firebase do
   <% } -%>
 end
 
-lane :distribute_internal do
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+lane :appcenter_assemble do
+  increment_build
+  assemble
+
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
+  )
+end
+
+lane :appcenter_bundle do
+<% if(!android.versioning || android.versioning.build === undefined) { -%>
+  increment_build
+<% } -%>
+  bundle
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
+  )
+end
+<% } -%>
+
+lane :distribute_package do
   assemble
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
@@ -76,7 +109,7 @@ lane :distribute_internal do
 <% } -%>
 end
 
-lane :distribute_store do
+lane :distribute_bundle do
   bundle
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -10,102 +10,84 @@ lane :bundle do
   gradle(task: "app:bundleRelease")
 end
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
 lane :increment_build_appcenter do
-  begin
-    version = appcenter_fetch_version_number(
-        owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
-        app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
-        version: "<%- android.versioning?.version || "1.0.0" %>"
-    )
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+    begin
+      version = appcenter_fetch_version_number(
+          owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+          app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+          version: "<%- android.versioning?.version || "1.0.0" %>"
+      )
 
-    if version["build_number"]
-      build_number = version["build_number"].to_i + 1
-      sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+      if version["build_number"]
+        build_number = version["build_number"].to_i + 1
+        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
 
-      puts "Fastlane: updated build number to #{build_number}"
+        puts "Fastlane: updated build number to #{build_number}"
+      end
+    rescue
+      puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
     end
-  rescue
-    puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
-  end
+  <% } else { -%>
+    UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
+  <% } -%>
 end
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
-lane :appcenter_assemble do
-  increment_build_appcenter
-
-  assemble
-
-  appcenter_upload(
-    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
-    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
-    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
-    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
-  )
-end
-
-lane :appcenter_bundle do
-<% if(!android.versioning || android.versioning.build === undefined) { -%>
-  increment_build_appcenter
-<% } -%>
-
-  bundle
-
-  appcenter_upload(
-    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
-    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
-    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
-    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
-  )
-end
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
 
 lane :increment_build_firebase do
-  begin
-    version = firebase_app_distribution_get_latest_release(
-      app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
-      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
-    )
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
+    begin
+      version = firebase_app_distribution_get_latest_release(
+        app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
+        service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
+      )
 
-    if version[:buildVersion]
-      build_number = version[:buildVersion].to_i + 1
-      sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
-      puts "Fastlane: updated build number to #{build_number}"
+      if version[:buildVersion]
+        build_number = version[:buildVersion].to_i + 1
+        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+        puts "Fastlane: updated build number to #{build_number}"
+      end
+    rescue StandardError => e
+      puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+      puts "Fastlane: #{e.message}"
     end
-  rescue StandardError => e
-    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
-    puts "Fastlane: #{e.message}"
-  end
-
+  <% } else { -%>
+    UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
+  <% } -%>
 end
 
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
-
-lane :firebase_assemble do
-  increment_build_firebase
-
+lane :distribute_internal do
   assemble
 
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
+  )
+<% } -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
   firebase_app_distribution(
     app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
     service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
     release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
     groups: "<%= codePluginFastlane.plugin.android.firebase.groups %>"
   )
+<% } -%>
 end
 
-lane :firebase_bundle do
+lane :distribute_store do
   bundle
 
-<% if(!android.versioning || android.versioning.build === undefined) { -%>
-  increment_build_firebase
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.android.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
+  )
 <% } -%>
-
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
   firebase_app_distribution(
     app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
     service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
@@ -113,6 +95,5 @@ lane :firebase_bundle do
     android_artifact_type: "AAB",
     groups: "<%= codePluginFastlane.plugin.android.firebase.groups %>"
   )
-end
-
 <% } -%>
+end

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -18,6 +18,7 @@ lane :increment_build do
         app_name: "<%= codePluginFastlane.plugin.android.appCenter.appName %>",
         version: "<%- android.versioning?.version || "1.0.0" %>"
     )
+
     if version["build_number"]
       build_number = version["build_number"].to_i + 1
       sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
@@ -64,6 +65,7 @@ end
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
 lane :appcenter_assemble do
   increment_build
+
   assemble
 
   appcenter_upload(
@@ -78,6 +80,7 @@ lane :appcenter_bundle do
 <% if(!android.versioning || android.versioning.build === undefined) { -%>
   increment_build
 <% } -%>
+
   bundle
   appcenter_upload(
     owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -11,7 +11,7 @@ lane :bundle do
 end
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
-lane :increment_build do
+lane :increment_build_appcenter do
   begin
     version = appcenter_fetch_version_number(
         owner_name: "<%= codePluginFastlane.plugin.android.appCenter.organization %>",
@@ -33,7 +33,7 @@ end
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
 lane :appcenter_assemble do
-  increment_build
+  increment_build_appcenter
 
   assemble
 
@@ -47,7 +47,7 @@ end
 
 lane :appcenter_bundle do
 <% if(!android.versioning || android.versioning.build === undefined) { -%>
-  increment_build
+  increment_build_appcenter
 <% } -%>
 
   bundle
@@ -59,4 +59,60 @@ lane :appcenter_bundle do
     destinations: "<%= codePluginFastlane.plugin.android.appCenter.destinations %>"
   )
 end
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
+
+lane :increment_build_firebase do
+  begin
+    version = firebase_app_distribution_get_latest_release(
+      app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
+      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
+    )
+
+    if version[:buildVersion]
+      build_number = version[:buildVersion].to_i + 1
+      sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+      puts "Fastlane: updated build number to #{build_number}"
+    end
+  rescue StandardError => e
+    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+    puts "Fastlane: #{e.message}"
+  end
+
+end
+
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
+
+lane :firebase_assemble do
+  increment_build_firebase
+
+  assemble
+
+  firebase_app_distribution(
+    app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
+    service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
+    groups: "<%= codePluginFastlane.plugin.android.firebase.groups %>"
+  )
+end
+
+lane :firebase_bundle do
+  bundle
+
+<% if(!android.versioning || android.versioning.build === undefined) { -%>
+  increment_build_firebase
+<% } -%>
+
+  firebase_app_distribution(
+    app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
+    service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
+    android_artifact_type: "AAB",
+    groups: "<%= codePluginFastlane.plugin.android.firebase.groups %>"
+  )
+end
+
 <% } -%>

--- a/packages/plugin-fastlane/template/android/fastlane/Pluginfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Pluginfile
@@ -2,10 +2,5 @@
 #
 # Ensure this file is checked in to source control!
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
 gem 'fastlane-plugin-appcenter'
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
 gem 'fastlane-plugin-firebase_app_distribution'
-<% } -%>

--- a/packages/plugin-fastlane/template/android/fastlane/Pluginfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Pluginfile
@@ -2,4 +2,10 @@
 #
 # Ensure this file is checked in to source control!
 
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.appCenter) { -%>
 gem 'fastlane-plugin-appcenter'
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.android && codePluginFastlane.plugin.android.firebase) { -%>
+gem 'fastlane-plugin-firebase_app_distribution'
+<% } -%>

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -78,9 +78,9 @@ end
 
 lane :increment_build_appcenter do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
-    increment_build
+  increment_build
   <% } else { -%>
-    UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
+  UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
   <% } -%>
 end
 
@@ -102,24 +102,24 @@ end
 
 lane :increment_build_firebase do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
-    begin
-      version = firebase_app_distribution_get_latest_release(
-        app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
-        service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
-      )
+  begin
+    version = firebase_app_distribution_get_latest_release(
+      app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
+      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    )
 
-      if version[:buildVersion]
-        build_number = increment_build_number(
-          build_number: version[:buildVersion].to_i + 1
-        )
-        puts "Fastlane: updated build number to #{build_number}"
-      end
-    rescue StandardError => e
-      puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
-      puts "Fastlane: #{e.message}"
+    if version[:buildVersion]
+      build_number = increment_build_number(
+        build_number: version[:buildVersion].to_i + 1
+      )
+      puts "Fastlane: updated build number to #{build_number}"
     end
+  rescue StandardError => e
+    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+    puts "Fastlane: #{e.message}"
+  end
   <% } else { -%>
-    UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
+  UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
   <% } -%>
 end
 
@@ -127,21 +127,21 @@ lane :distribute do
   build
 
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
-    appcenter_upload(
-      owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
-      app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
-      destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
-      destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
-    )
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
+  )
   <% } -%>
 
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
-    firebase_app_distribution(
-      app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
-      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
-      release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
-      groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
-    )
+  firebase_app_distribution(
+    app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
+    service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
+    groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
+  )
   <% } -%>
 end
 

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -1,6 +1,6 @@
 default_platform :ios
 
-# make a provisioned build and upload to appcenter
+# make a provisioned build
 lane :build do
   keychain_password = SecureRandom.uuid
   keychain_name = 'ios-build.keychain'
@@ -57,7 +57,7 @@ lane :compile do
 end
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
-lane :increment_build do
+lane :increment_build_appcenter do
   begin
     version = appcenter_fetch_version_number(
         owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
@@ -78,7 +78,7 @@ end
 
 <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
 lane :appcenter do
-  increment_build
+  increment_build_appcenter
 
   build
 
@@ -89,4 +89,42 @@ lane :appcenter do
     destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
   )
 end
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+lane :increment_build_firebase do
+  begin
+    version = firebase_app_distribution_get_latest_release(
+      app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
+      service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    )
+
+    if version[:buildVersion]
+      build_number = increment_build_number(
+        build_number: version[:buildVersion].to_i + 1
+      )
+      puts "Fastlane: updated build number to #{build_number}"
+    end
+  rescue StandardError => e
+    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+    puts "Fastlane: #{e.message}"
+  end
+end
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+
+lane :firebase do
+  increment_build_firebase
+
+  build
+
+  firebase_app_distribution(
+    app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
+    service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+    release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
+    groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
+  )
+end
+
 <% } -%>

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -77,11 +77,11 @@ end
 <% } -%>
 
 lane :increment_build_appcenter do
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
   increment_build
-  <% } else { -%>
+<% } else { -%>
   UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
-  <% } -%>
+<% } -%>
 end
 
 
@@ -101,7 +101,7 @@ end
 <% } -%>
 
 lane :increment_build_firebase do
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
   begin
     version = firebase_app_distribution_get_latest_release(
       app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
@@ -118,30 +118,30 @@ lane :increment_build_firebase do
     puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
     puts "Fastlane: #{e.message}"
   end
-  <% } else { -%>
+<% } else { -%>
   UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
-  <% } -%>
+<% } -%>
 end
 
 lane :distribute do
   build
 
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
   appcenter_upload(
     owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
     app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
     destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
     destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
   )
-  <% } -%>
+<% } -%>
 
-  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
   firebase_app_distribution(
     app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
     service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
     release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
     groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
   )
-  <% } -%>
+<% } -%>
 end
 

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -56,27 +56,49 @@ lane :compile do
   )
 end
 
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+lane :increment_build do
+  begin
+    version = appcenter_fetch_version_number(
+        owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
+        app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
+        version: "<%= ios.versioning?.version || "1.0.0" %>"
+    )
+    if version["build_number"]
+      build_number = increment_build_number(
+        build_number: version["build_number"].to_i + 1
+      )
+      puts "Fastlane: updated build number to #{build_number}"
+    end
+  rescue
+    puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
+  end
+end
+<% } -%>
+
 lane :increment_build_appcenter do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
-    begin
-      version = appcenter_fetch_version_number(
-          owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
-          app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
-          version: "<%= ios.versioning?.version || "1.0.0" %>"
-      )
-      if version["build_number"]
-        build_number = increment_build_number(
-          build_number: version["build_number"].to_i + 1
-        )
-        puts "Fastlane: updated build number to #{build_number}"
-      end
-    rescue
-      puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
-    end
+    increment_build
   <% } else { -%>
     UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
   <% } -%>
 end
+
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+lane :appcenter do
+  increment_build
+
+  build
+
+  appcenter_upload(
+    owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
+    app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
+    destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
+    destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
+  )
+end
+<% } -%>
 
 lane :increment_build_firebase do
   <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -56,75 +56,70 @@ lane :compile do
   )
 end
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
 lane :increment_build_appcenter do
-  begin
-    version = appcenter_fetch_version_number(
-        owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
-        app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
-        version: "<%= ios.versioning?.version || "1.0.0" %>"
-    )
-    if version["build_number"]
-      build_number = increment_build_number(
-        build_number: version["build_number"].to_i + 1
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+    begin
+      version = appcenter_fetch_version_number(
+          owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
+          app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
+          version: "<%= ios.versioning?.version || "1.0.0" %>"
       )
-      puts "Fastlane: updated build number to #{build_number}"
+      if version["build_number"]
+        build_number = increment_build_number(
+          build_number: version["build_number"].to_i + 1
+        )
+        puts "Fastlane: updated build number to #{build_number}"
+      end
+    rescue
+      puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
     end
-  rescue
-    puts "Fastlane: did not find any applicable versions for appcenter_fetch_version_number"
-  end
+  <% } else { -%>
+    UI.user_error!("Fastlane: Tried to increment build number with appcenter but no appcenter configuration was provided in the build configuration.")
+  <% } -%>
 end
-<% } -%>
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
-lane :appcenter do
-  increment_build_appcenter
+lane :increment_build_firebase do
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+    begin
+      version = firebase_app_distribution_get_latest_release(
+        app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
+        service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+      )
 
+      if version[:buildVersion]
+        build_number = increment_build_number(
+          build_number: version[:buildVersion].to_i + 1
+        )
+        puts "Fastlane: updated build number to #{build_number}"
+      end
+    rescue StandardError => e
+      puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
+      puts "Fastlane: #{e.message}"
+    end
+  <% } else { -%>
+    UI.user_error!("Fastlane: Tried to increment build number with firebase but no firebase configuration was provided in the build configuration.")
+  <% } -%>
+end
+
+lane :distribute do
   build
 
-  appcenter_upload(
-    owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
-    app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
-    destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
-    destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
-  )
-end
-<% } -%>
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
+    appcenter_upload(
+      owner_name: "<%= codePluginFastlane.plugin.ios.appCenter.organization %>",
+      app_name: "<%= codePluginFastlane.plugin.ios.appCenter.appName %>",
+      destination_type: "<%= codePluginFastlane.plugin.ios.appCenter.destinationType %>",
+      destinations: "<%= codePluginFastlane.plugin.ios.appCenter.destinations %>"
+    )
+  <% } -%>
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
-lane :increment_build_firebase do
-  begin
-    version = firebase_app_distribution_get_latest_release(
+  <% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+    firebase_app_distribution(
       app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
       service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
+      release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
+      groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
     )
-
-    if version[:buildVersion]
-      build_number = increment_build_number(
-        build_number: version[:buildVersion].to_i + 1
-      )
-      puts "Fastlane: updated build number to #{build_number}"
-    end
-  rescue StandardError => e
-    puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
-    puts "Fastlane: #{e.message}"
-  end
-end
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
-
-lane :firebase do
-  increment_build_firebase
-
-  build
-
-  firebase_app_distribution(
-    app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
-    service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
-    release_notes: ENV["FIREBASE_DISTRIBUTE_RELEASE_NOTES"],
-    groups: "<%= codePluginFastlane.plugin.ios.firebase.groups %>"
-  )
+  <% } -%>
 end
 
-<% } -%>

--- a/packages/plugin-fastlane/template/ios/fastlane/Pluginfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Pluginfile
@@ -2,4 +2,10 @@
 #
 # Ensure this file is checked in to source control!
 
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
 gem 'fastlane-plugin-appcenter'
+<% } -%>
+
+<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
+gem 'fastlane-plugin-firebase_app_distribution'
+<% } -%>

--- a/packages/plugin-fastlane/template/ios/fastlane/Pluginfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Pluginfile
@@ -2,10 +2,5 @@
 #
 # Ensure this file is checked in to source control!
 
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.appCenter) { -%>
 gem 'fastlane-plugin-appcenter'
-<% } -%>
-
-<% if(codePluginFastlane.plugin && codePluginFastlane.plugin.ios && codePluginFastlane.plugin.ios.firebase) { -%>
 gem 'fastlane-plugin-firebase_app_distribution'
-<% } -%>


### PR DESCRIPTION
## Describe your changes

This PR updates the Fastlane plugin to optionally support a configuration for firebase app distribution.  If the config is provided the plugin will add the necessary lanes.  Besides including this configuration, the only other step for projects to integrate with FAD is to update their Github actions/workflows and to create a secret in their repo, GOOGLE_SERVICE_CREDENTIALS, which contains the firebase credentials for the google service account.

Overview of changes:
 - Update Fastfile templates to provide conditional firebase lanes.
 - Update Pluginfile templates to conditionally provide the necessary appcenter and/or firebase gems.
 - Fastlane Pluginfiles templates are now rendered to account for conditional gem installations
 - Updated tests

~~NOTE: I still need to verify Firebase Android release builds. I'm getting a failure on those builds because the app isn't linked to a Google Play account.~~

Firebase release uploads have been verified to be working with this plugin logic using the theory app.

![Screenshot 2024-11-04 at 10 51 05 AM](https://github.com/user-attachments/assets/ec851728-9ce9-4406-b5a9-97e8d28c3b1f)

https://console.firebase.google.com/project/theory-57e35/appdistribution/app/android:com.fastretailing.theory/releases

## Issue ticket number and link

https://brandingbrand.atlassian.net/browse/ENG-5771

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan

I created an example shopify template using the flagship accelerator. I used the config provided below and updated my repo to include the google service credential secret for the shopify project. I've given Nick Burkhart view permissions to the project so he can check it out. Currently the firebase builds are working for both platforms except the release Android builds aren't uploading because there isn't a Google Play account linked to the Firebase Shopify app.

```
  codePluginFastlane: {
    plugin: {
      ios: {
        appCenter: {
          organization: 'Branding-Brand',
          appName: 'Shopify-iOS-Internal',
          destinationType: 'group',
          destinations: ['IAT'],
        },
        firebase: {
          groups: ['IAT'],
          appId: '1:300374277703:ios:cdf8a81375502895bcbb62',
        },
      },
      android: {
        appCenter: {
          organization: 'Branding-Brand',
          appName:
            'Shopify-Android-Internal',
          destinationType: 'group',
          destinations: ['IAT'],
        },
        firebase: {
          groups: ['IAT'],
          appId: '1:300374277703:android:764c235c8f6d7dc6bcbb62',
        },
      },
    },
  },
```

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [x] Documentation has been updated to reflect these changes