### PR TITLE
chore: update setup-ruby version in pr-test work flow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 20
       - name: Setup Ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899
+        uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984
         with:
           ruby-version: '3.1'
       - name: Install dependencies


### PR DESCRIPTION
## Describe your changes
update the setup-ruby action version to work with latest ubuntu runner and not have it get picked up as self hosted runner

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
* verify test PR workflow after change

## Checklist before requesting a review
- [x] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes
