### PR TITLE
fix(gems): pin concurrent-ruby

### DIFF
--- a/packages/cli/templates/react-native-0.72/addons/ios/Gemfile
+++ b/packages/cli/templates/react-native-0.72/addons/ios/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gem 'cocoapods', '~> 1.15.0'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '~> 1.25.0'
+gem 'concurrent-ruby', '< 1.3.4'

--- a/packages/cli/templates/react-native-0.73/addons/ios/Gemfile
+++ b/packages/cli/templates/react-native-0.73/addons/ios/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gem 'cocoapods', '~> 1.15.0'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '~> 1.25.0'
+gem 'concurrent-ruby', '< 1.3.4'


### PR DESCRIPTION


## Describe your changes

This pull request addresses a compatibility issue with the `concurrent-ruby` gem in the iOS continuous integration (CI) pipeline for React Native. The change ensures stability by pinning the `concurrent-ruby` gem to a version below `1.3.4`. This fix is applied to the `Gemfile` templates for React Native versions `0.72` and `0.73`.

## Issue ticket number and link

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

To test this change:

1. Ensure that the `Gemfile` updates are reflected in the iOS CI pipeline configuration for React Native versions `0.72` and `0.73`.
2. Run the CI pipeline to verify that the `concurrent-ruby` gem version is successfully pinned and no longer causes errors.
3. Confirm that other gem dependencies are unaffected and that the pipeline completes successfully.

## Checklist before requesting a review

- [x] A self-review of my code has been completed.
- [x] Tests have been added / updated if required.
- [x] Documentation has been updated to reflect these changes, where necessary.