### PR TITLE
feat(plugin-fastlane): add option to reset build numbers in firebase inc build

### DIFF
--- a/.changeset/itchy-readers-cover.md
+++ b/.changeset/itchy-readers-cover.md
@@ -1,0 +1,7 @@
+---
+"@brandingbrand/code-plugin-fastlane": minor
+---
+
+new firebase increment option to reset build version to 1 if version mismatch during lane increment_build_firebase
+default behavior on iOS is to reset if new version found
+default behavior on Android is to just increment

--- a/apps/docs/src/content/docs/packages/plugin-fastlane.mdx
+++ b/apps/docs/src/content/docs/packages/plugin-fastlane.mdx
@@ -192,6 +192,14 @@ _required_
 
 Array of distribution groups.
 
+###### `resetBuildOnVersionChange`
+
+**type:** `boolean`
+
+_optional_
+
+Will reset the build version to 1 whenever the version retrieved from firebase is different then local build number. Default behavior is to reset.
+
 ##### `codePluginFastlane.plugin.android.appCenter`
 
 **type:** [AppCenterAndroid](#appcenterandroid)
@@ -251,6 +259,15 @@ The Firebase app id.
 _required_
 
 Array of distribution groups.
+
+###### `resetBuildOnVersionChange`
+
+**type:** `boolean`
+
+_optional_
+
+Will reset the build version to 1 whenever the version retrieved from firebase is different then local build number. Default behavior is to NOT reset.
+
 
 :::note
 If you don't need AppCenter or Firebase App Distribution then do not include the `codePluginFastlane` configuration.

--- a/packages/plugin-fastlane/src/types.ts
+++ b/packages/plugin-fastlane/src/types.ts
@@ -49,6 +49,10 @@ type FirebaseIOS = {
    * Array of testing groups
    */
   groups: string[];
+  /**
+   * reset build number on version mismatch
+   */
+  resetBuildOnVersionChange?: boolean;
 };
 
 /**
@@ -100,6 +104,10 @@ type FirebaseAndroid = {
    * Array of testing groups
    */
   groups: string[];
+  /**
+   * reset build number on version mismatch
+   */
+  resetBuildOnVersionChange?: boolean;
 };
 
 /**

--- a/packages/plugin-fastlane/template/android/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/android/fastlane/Fastfile
@@ -46,12 +46,23 @@ lane :increment_build_firebase do
       app: "<%= codePluginFastlane.plugin.android.firebase.appId %>",
       service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"]
     )
-
     if version[:buildVersion]
+<% if (codePluginFastlane.plugin.android.firebase.resetBuildOnVersionChange) { -%>
+      if version[:displayVersion] != "<%- android.versioning?.version %>"
+        build_number = 1
+        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+        puts "Fastlane: found change version reset build to #{build_number}"
+      else
+        build_number = version[:buildVersion].to_i + 1
+        sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
+        puts "Fastlane: updated build number to #{build_number}"
+      end
+<% } else { -%>
       build_number = version[:buildVersion].to_i + 1
       sh %Q{cd .. && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{build_number})}1' app/build.gradle)" > app/build.gradle && cd -}
       puts "Fastlane: updated build number to #{build_number}"
-    end
+<% } -%>
+    end 
   rescue StandardError => e
     puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
     puts "Fastlane: #{e.message}"

--- a/packages/plugin-fastlane/template/ios/fastlane/Fastfile
+++ b/packages/plugin-fastlane/template/ios/fastlane/Fastfile
@@ -107,13 +107,28 @@ lane :increment_build_firebase do
       app: "<%= codePluginFastlane.plugin.ios.firebase.appId %>",
       service_credentials_json_data: ENV["GOOGLE_SERVICE_CREDENTIALS"],
     )
-
+<% if(codePluginFastlane.plugin.ios.firebase.resetBuildOnVersionChange === false) { -%>
     if version[:buildVersion]
       build_number = increment_build_number(
         build_number: version[:buildVersion].to_i + 1
       )
       puts "Fastlane: updated build number to #{build_number}"
     end
+<% } else { -%>
+    if version[:buildVersion]
+      if version[:displayVersion] != "<%- ios.versioning?.version %>"
+        build_number = 1
+        puts "Fastlane: detected new version, resetting build number to #{build_number}"
+      else
+        build_number = version[:buildVersion].to_i + 1
+        puts "Fastlane: incremented build number to #{build_number}"
+      end
+      build_number = increment_build_number(
+        build_number: build_number
+      )
+      puts "Fastlane: updated build number to #{build_number}"
+    end
+<% } -%>
   rescue StandardError => e
     puts "Fastlane: did not find any applicable versions for 'firebase_app_distribution_get_latest_release"
     puts "Fastlane: #{e.message}"


### PR DESCRIPTION
## Describe your changes
add new build option for firebase plugin to to reset build version to 1 if version mismatch during lane increment_build_firebase
default behavior on iOS is to reset if new version found
default behavior on Android is to just increment

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test Plan
* the easiest way might to do a npm pack of the package then install in an existing app
* run init and view fast lane files
* run fastlane increment_build_firebase and verify output
* modify build config to some different options and init again 
* view fast files and run fastlane increment_build_firebase and verify output

## Checklist before requesting a review

- [ ] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes
