### PR TITLE
fix: ENG-6270 - replace RN SafeAreaview with react-native-safe-area-context

### DIFF
--- a/.changeset/seven-goats-do.md
+++ b/.changeset/seven-goats-do.md
@@ -1,0 +1,11 @@
+---
+"@brandingbrand/code-app-env": major
+---
+
+Migrate to react-native-safe-area-context for RN81+
+
+**BREAKING CHANGE:**
+
+This release adds a new necessary peer dependency: `react-native-safe-area-context`.
+
+The React Native dev team has deprecated the old `SafeAreaView` component in favor of this recommended library.

--- a/packages/app-env/package.json
+++ b/packages/app-env/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^19.0.0",
     "react": "19.1.0",
     "react-native": "^0.81.0",
+    "react-native-safe-area-context": "^5.6.2",
     "react-native-sensitive-info": "^5.5.8",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3"
@@ -54,7 +55,8 @@
   "peerDependencies": {
     "@brandingbrand/react-native-app-restart": "*",
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-safe-area-context": ">=5"
   },
   "create-react-native-library": {
     "type": "module-legacy",

--- a/packages/app-env/src/app/components/DevMenuModal/DevMenuModal.tsx
+++ b/packages/app-env/src/app/components/DevMenuModal/DevMenuModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Modal, ModalProps, SafeAreaView, StyleSheet} from 'react-native';
+import {Modal, ModalProps, StyleSheet} from 'react-native';
+import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context';
 
 import {useModal, useScreen} from '../../lib/context';
 
@@ -29,12 +30,14 @@ export function DevMenuModal() {
 
   return (
     <Modal {...DEFAULT_MODAL_PROPS} visible={visible}>
-      <SafeAreaView style={styles.safeAreaContainer}>
-        <DevMenuModalHeader />
-        {activeScreen ? <activeScreen.Component /> : null}
-        <DevMenuList />
-        <DevMenuModalFooter />
-      </SafeAreaView>
+      <SafeAreaProvider>
+        <SafeAreaView style={styles.safeAreaContainer}>
+          <DevMenuModalHeader />
+          {activeScreen ? <activeScreen.Component /> : null}
+          <DevMenuList />
+          <DevMenuModalFooter />
+        </SafeAreaView>
+      </SafeAreaProvider>
     </Modal>
   );
 }

--- a/packages/plugin-network-security-config/package.json
+++ b/packages/plugin-network-security-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandingbrand/code-plugin-network-security-config",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "plugin for Flagship Code to generate the network security configuration XML file for Android applications.",
   "license": "MIT",
   "main": "src/index.ts",

--- a/packages/preset-react-native/package.json
+++ b/packages/preset-react-native/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@brandingbrand/code-plugin-clean": "^1.0.0",
     "@brandingbrand/code-plugin-env": "^1.1.0",
-    "@brandingbrand/code-plugin-network-security-config": "^1.0.0",
+    "@brandingbrand/code-plugin-network-security-config": "^0.0.1",
     "@brandingbrand/code-plugin-packager-install": "^1.0.0",
     "@brandingbrand/code-plugin-transform-template": "^1.1.0",
     "@brandingbrand/code-plugin-verify-dependencies": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,7 +2537,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@brandingbrand/code-plugin-network-security-config@npm:^1.0.0, @brandingbrand/code-plugin-network-security-config@workspace:packages/plugin-network-security-config":
+"@brandingbrand/code-plugin-network-security-config@npm:^0.0.1, @brandingbrand/code-plugin-network-security-config@workspace:packages/plugin-network-security-config":
   version: 0.0.0-use.local
   resolution: "@brandingbrand/code-plugin-network-security-config@workspace:packages/plugin-network-security-config"
   dependencies:
@@ -2678,7 +2678,7 @@ __metadata:
   dependencies:
     "@brandingbrand/code-plugin-clean": "npm:^1.0.0"
     "@brandingbrand/code-plugin-env": "npm:^1.1.0"
-    "@brandingbrand/code-plugin-network-security-config": "npm:^1.0.0"
+    "@brandingbrand/code-plugin-network-security-config": "npm:^0.0.1"
     "@brandingbrand/code-plugin-packager-install": "npm:^1.0.0"
     "@brandingbrand/code-plugin-transform-template": "npm:^1.1.0"
     "@brandingbrand/code-plugin-verify-dependencies": "npm:^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,6 +2245,7 @@ __metadata:
     cosmiconfig: "npm:^9.0.0"
     react: "npm:19.1.0"
     react-native: "npm:^0.81.0"
+    react-native-safe-area-context: "npm:^5.6.2"
     react-native-sensitive-info: "npm:^5.5.8"
     tsup: "npm:^8.0.1"
     typescript: "npm:^5.3.3"
@@ -2252,6 +2253,7 @@ __metadata:
     "@brandingbrand/react-native-app-restart": "*"
     react: "*"
     react-native: "*"
+    react-native-safe-area-context: ">=5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Describe your changes


- **BREAKING CHANGE:** Replaces use of built in SafeAreaView, which has been deprecated as of RN81, with `react-native-safe-area-context`
    - This change is breaking, as it adds a new required peer dependency.
- down-version network-security-policy package so we don't accidentally forget to do so before publish, and end up publishing V2 as the first release.
    - This is fine at this stage, as this is a new plugin that has not yet been published

## Issue ticket number and link

[ENG-6270](https://brandingbrand.atlassian.net/browse/ENG-6270)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Checklist before requesting a review

- [ ] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes


[ENG-6270]: https://brandingbrand.atlassian.net/browse/ENG-6270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ