### PR TITLE
chore: ENG-6377 - remove `react-native-bootsplash` from `code-plugin-splash-screen`

### DIFF
--- a/.changeset/long-dragons-destroy.md
+++ b/.changeset/long-dragons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-splash-screen": patch
+---
+
+Remove unused `react-native-bootsplash` dependency

--- a/packages/plugin-splash-screen/package.json
+++ b/packages/plugin-splash-screen/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@types/fs-extra": "^11.0.4",
     "fs-extra": "^11.2.0",
-    "react-native-bootsplash": "5.4.0",
     "sharp": "^0.32.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,7 +2815,6 @@ __metadata:
     eslint: "npm:^8.56.0"
     fs-extra: "npm:^11.2.0"
     jest: "npm:^29.7.0"
-    react-native-bootsplash: "npm:5.4.0"
     sharp: "npm:^0.32.5"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.3.3"
@@ -16532,26 +16531,6 @@ __metadata:
   bin:
     react-native-asset: lib/cli.js
   checksum: 10c0/38202e5c76cd873b13fbb0854bdd37abd0e1b99afe174d76d07fa99e1508e43a7810ef60075256bf80924ac0bb95b304f96b48947af4d4403a522e304f1b2e21
-  languageName: node
-  linkType: hard
-
-"react-native-bootsplash@npm:5.4.0":
-  version: 5.4.0
-  resolution: "react-native-bootsplash@npm:5.4.0"
-  dependencies:
-    "@emotion/hash": "npm:^0.9.1"
-    "@expo/config-plugins": "npm:^7.8.4"
-    detect-indent: "npm:^6.1.0"
-    node-html-parser: "npm:^6.1.12"
-    picocolors: "npm:^1.0.0"
-    prettier: "npm:^3.1.1"
-    sharp: "npm:^0.32.6"
-    ts-dedent: "npm:^2.2.0"
-    xml-formatter: "npm:^3.6.0"
-  peerDependencies:
-    react: ">=18.1.0"
-    react-native: ">=0.70.0"
-  checksum: 10c0/b848449dca6af0fb3544026de173a7e1ed475b4fd3e1ca9e6854f972314f164cbfcd1739dbd246bb4f5170694f574282ce3ef9af49f2e8a11c838f37eafba5a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes

remove `react-native-bootsplash` from `code-plugin-splash-screen`. this dep has been unused for a few versions now.

Due to how RN resolves modules, it's inclusion may lead to version conflict issues downstream, and we're beginning to use the newer version of this lib in other projects.

## Issue ticket number and link

[ENG-6377](https://brandingbrand.atlassian.net/browse/ENG-6377)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan

This should have zero impact, but a simple example app smoke test wouldn't hurt.

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes


[ENG-6377]: https://brandingbrand.atlassian.net/browse/ENG-6377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ