### PR TITLE
fix: ENG-6379 - code-app-env - DataView perf 

### DIFF
--- a/.changeset/brown-elephants-grab.md
+++ b/.changeset/brown-elephants-grab.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": patch
+---
+
+Use FlatList to optimize display of large datasets in CodeBlocks

--- a/.changeset/gentle-ladybugs-hide.md
+++ b/.changeset/gentle-ladybugs-hide.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": minor
+---
+
+Dev Screen generators now accept a `title` prop

--- a/.changeset/lazy-lobsters-share.md
+++ b/.changeset/lazy-lobsters-share.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": patch
+---
+
+add disabled prop for DataView actions

--- a/.changeset/long-donkeys-approve.md
+++ b/.changeset/long-donkeys-approve.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": minor
+---
+
+DataViews can recursively parse and format JSON strings within content before displaying them. Controllable via `deepParse` prop.

--- a/.changeset/lovely-countries-do.md
+++ b/.changeset/lovely-countries-do.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": patch
+---
+
+Fix display of multiple actions in a DataView

--- a/.changeset/metal-cups-give.md
+++ b/.changeset/metal-cups-give.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": minor
+---
+
+Add DataViewer dev screen for displaying any arbitrary data in DevMenu

--- a/.changeset/slimy-actors-mix.md
+++ b/.changeset/slimy-actors-mix.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": minor
+---
+
+Add line numbers to CodeBlock views

--- a/.changeset/tall-pigs-travel.md
+++ b/.changeset/tall-pigs-travel.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": minor
+---
+
+AsyncStorageDevScreen: Add filter method props to independently control which AsyncStorage keys are displayed and cleared.

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -4,8 +4,8 @@ import {
   env,
   FlagshipEnv,
 } from '@brandingbrand/code-app-env';
-import {DataView} from '@brandingbrand/code-app-env/ui';
-import React from 'react';
+import {DataView, DataViewAction} from '@brandingbrand/code-app-env/ui';
+import React, {useMemo, useState} from 'react';
 import {ScrollView, View} from 'react-native';
 import {
   SafeAreaProvider,
@@ -42,18 +42,48 @@ function App(): React.JSX.Element {
 
 const screens = [
   defineDevMenuScreen('Example Custom Screen', () => {
+    const [deepParse, setDeepParse] = useState(false);
+    const [secondButtonDisabled, setSecondButtonDisabled] = useState(false);
+
+    const actions = useMemo<DataViewAction[]>(
+      () => [
+        {
+          label: deepParse ? 'Disable Deep Parse' : 'Enable Deep Parse',
+          onPress: () => {
+            setDeepParse(prev => !prev);
+          },
+        },
+        {
+          label: 'Test Button\nPlease Ignore',
+          onPress: () => {
+            console.log('Test Button Pressed');
+            setSecondButtonDisabled(true);
+          },
+          disabled: secondButtonDisabled,
+        }
+      ],
+      [deepParse, secondButtonDisabled],
+    );
+
     return (
       <DataView
         title="Custom Title"
-        content={{
-          testProp: 'This is some data to display.',
-          about: 'Anything could go in this code block!',
-        }}
-        actions={[{label: 'Test Button', onPress: () => {}}]}
+        deepParse={deepParse}
+        content={exampleCustomScreenContent}
+        actions={actions}
       />
     );
   }),
 ];
+
+const exampleCustomScreenContent = {
+  testProp: 'This is some data to display.',
+  about: 'Anything could go in this code block!',
+  nestedJSONStr: `{
+    "nestedProp": "In code, this property is within a JSON object string. It should appear to be an object when displayed in the data viewer",
+    "doubleNestedJSONStr": "{\\"doubleNestedProp\\": \\"This is a double nested JSON object inside the first nested JSON string.\\"}"
+  }`,
+};
 
 const useStyles = createStyleSheet(palette => ({
   background: {

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -4,7 +4,10 @@ import {
   env,
   FlagshipEnv,
 } from '@brandingbrand/code-app-env';
+import {AsyncStorageDevScreen} from '@brandingbrand/code-app-env/screens/AsyncStorage';
+import {createDataViewerDevScreen} from '@brandingbrand/code-app-env/screens/DataViewer';
 import {DataView, DataViewAction} from '@brandingbrand/code-app-env/ui';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, {useMemo, useState} from 'react';
 import {ScrollView, View} from 'react-native';
 import {
@@ -41,9 +44,9 @@ function App(): React.JSX.Element {
 }
 
 const screens = [
+  AsyncStorageDevScreen,
   defineDevMenuScreen('Example Custom Screen', () => {
     const [deepParse, setDeepParse] = useState(false);
-    const [secondButtonDisabled, setSecondButtonDisabled] = useState(false);
 
     const actions = useMemo<DataViewAction[]>(
       () => [
@@ -54,29 +57,39 @@ const screens = [
           },
         },
         {
-          label: 'Test Button\nPlease Ignore',
+          label: 'Set Testing\nAsyncStorage Data',
           onPress: () => {
-            console.log('Test Button Pressed');
-            setSecondButtonDisabled(true);
+            AsyncStorage.setItem('testKey', JSON.stringify(exampleDevScreenData))
+              .then(() => {
+                console.log('AsyncStorage setItem succeeded');
+              })
+              .catch(error => {
+                console.error('AsyncStorage setItem failed', error);
+              });
           },
-          disabled: secondButtonDisabled,
-        }
+        },
       ],
-      [deepParse, secondButtonDisabled],
+      [deepParse],
     );
 
     return (
       <DataView
         title="Custom Title"
         deepParse={deepParse}
-        content={exampleCustomScreenContent}
+        content={exampleDevScreenData}
         actions={actions}
       />
     );
   }),
+  createDataViewerDevScreen<any>({
+    title: 'Example Generic Data Viewer',
+    initialContent: 'loading...',
+    deepParseContent: true,
+    onGetContent: async () => exampleDevScreenData,
+  }),
 ];
 
-const exampleCustomScreenContent = {
+const exampleDevScreenData = {
   testProp: 'This is some data to display.',
   about: 'Anything could go in this code block!',
   nestedJSONStr: `{

--- a/packages/app-env/src/app/components/EnvSwitcher/EnvSwitcherContentPreview.tsx
+++ b/packages/app-env/src/app/components/EnvSwitcher/EnvSwitcherContentPreview.tsx
@@ -13,5 +13,5 @@ export function EnvSwitcherContentPreview() {
     return JSON.stringify(data, null, 2);
   }, [env]);
 
-  return <CodeBlock>{content}</CodeBlock>;
+  return <CodeBlock content={content} />;
 }

--- a/packages/app-env/src/app/components/ui/Button.tsx
+++ b/packages/app-env/src/app/components/ui/Button.tsx
@@ -32,7 +32,7 @@ export function Button({
       style={[styles.button, typeStyles[type], sizeStyles[size], style]}
       {...restProps}>
       {typeof children === 'string' ? (
-        <Text type={textPresetMap[type]} style={textStyle}>
+        <Text type={textPresetMap[type]} style={[styles.button__text, textStyle]}>
           {children}
         </Text>
       ) : (
@@ -83,4 +83,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 1000,
   },
+  button__text: {
+    textAlign: 'center',
+  }
 });

--- a/packages/app-env/src/app/components/ui/CodeBlock.tsx
+++ b/packages/app-env/src/app/components/ui/CodeBlock.tsx
@@ -43,7 +43,9 @@ export function CodeBlock({content}: CodeBlockProps) {
     height: number;
   }>(CHAR_DIMS_DEFAULT);
 
-  const onLineLayout = useCallback((event: any) => {
+  const onLineNumberLayout = useCallback((event: any) => {
+    // Normally we'd want to div this by the length of the text content, but because we only
+    // hook this to the first line, we'll always measure the width of the `1` character.
     const {width, height} = event.nativeEvent.layout;
     setCharDims({width, height});
   }, []);
@@ -57,21 +59,38 @@ export function CodeBlock({content}: CodeBlockProps) {
     [charDims.height],
   );
 
+  const lineGutterStyle = useMemo(
+    () => [
+      styles.codeBlock__lineGutter,
+      {
+        width: getLineGutterWidth(data.length, charDims.width),
+      },
+    ],
+    [data.length, charDims.width],
+  );
+
   const renderLine = useCallback(
     ({item, index}: ListRenderItemInfo<string>) => {
       return (
         <View style={styles.codeBlock__line}>
+          <View style={lineGutterStyle}>
+            <Text
+              type="code"
+              onLayout={index === 0 ? onLineNumberLayout : undefined}
+              numberOfLines={1}>
+              {index + 1}
+            </Text>
+          </View>
           <Text
             type="code"
             style={styles.codeBlock__lineContent}
-            onLayout={index === 0 ?onLineLayout : undefined}
             numberOfLines={1}>
             {item}
           </Text>
         </View>
       );
     },
-    [],
+    [lineGutterStyle],
   );
 
   return (
@@ -92,6 +111,9 @@ export function CodeBlock({content}: CodeBlockProps) {
 }
 
 const keyExtractor = (_: string, index: number) => String(index);
+
+const getLineGutterWidth = (totalLines: number, charWidth: number) =>
+  Math.ceil(String(totalLines).length * charWidth);
 
 const truncateLine = (line: string, maxLength: number = 1000) =>
   line.length <= maxLength ? line : `${line.slice(0, maxLength - 3)}...`;

--- a/packages/app-env/src/app/components/ui/CodeBlock.tsx
+++ b/packages/app-env/src/app/components/ui/CodeBlock.tsx
@@ -1,28 +1,100 @@
-import React from 'react';
-import {ScrollView, StyleSheet} from 'react-native';
+import React, {useCallback, useMemo, useState} from 'react';
+import {
+  FlatList,
+  ListRenderItemInfo,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 import {palette} from '../../lib/theme';
 
 import {Text} from './Text';
 
 export interface CodeBlockProps {
-  children: string;
+  content: string | string[];
 }
 
-export function CodeBlock({children}: CodeBlockProps) {
+// pre-calculated approximates used to prevent excessive layout shifts.
+// These may differ slightly between devices, but should be close enough as a starting point.
+const CHAR_DIMS_DEFAULT = Platform.select({
+  ios: {
+    width: 7.333332,
+    height: 13.666672,
+  },
+  default: {
+    width: 7.111111,
+    height: 16.444443,
+  },
+});
+
+export function CodeBlock({content}: CodeBlockProps) {
+  const data = useMemo(() => {
+    const lines = Array.isArray(content) ? content : content.split('\n');
+
+    // New Arch doesn't handle extremely long lines as well as before,
+    // so we truncate lines over 1000 characters to avoid performance issues.
+    return lines.map(line => truncateLine(line));
+  }, [content]);
+
+  const [charDims, setCharDims] = useState<{
+    width: number;
+    height: number;
+  }>(CHAR_DIMS_DEFAULT);
+
+  const onLineLayout = useCallback((event: any) => {
+    const {width, height} = event.nativeEvent.layout;
+    setCharDims({width, height});
+  }, []);
+
+  const getItemLayout = useCallback(
+    (_: any, index: number) => ({
+      length: charDims.height,
+      offset: charDims.height * index,
+      index,
+    }),
+    [charDims.height],
+  );
+
+  const renderLine = useCallback(
+    ({item, index}: ListRenderItemInfo<string>) => {
+      return (
+        <View style={styles.codeBlock__line}>
+          <Text
+            type="code"
+            style={styles.codeBlock__lineContent}
+            onLayout={index === 0 ?onLineLayout : undefined}
+            numberOfLines={1}>
+            {item}
+          </Text>
+        </View>
+      );
+    },
+    [],
+  );
+
   return (
-    <ScrollView style={styles.codeBlock}>
-      <ScrollView
-        horizontal
-        contentContainerStyle={styles.codeBlock__contentContainer}
-        showsHorizontalScrollIndicator={false}>
-        <Text type="code" style={styles.codeBlock__text}>
-          {children}
-        </Text>
-      </ScrollView>
+    <ScrollView
+      horizontal
+      style={styles.codeBlock}
+      showsHorizontalScrollIndicator={false}>
+      <FlatList
+        data={data}
+        renderItem={renderLine}
+        keyExtractor={keyExtractor}
+        showsVerticalScrollIndicator={false}
+        getItemLayout={getItemLayout}
+        maxToRenderPerBatch={24}
+        contentContainerStyle={styles.codeBlock__contentContainer}></FlatList>
     </ScrollView>
   );
 }
+
+const keyExtractor = (_: string, index: number) => String(index);
+
+const truncateLine = (line: string, maxLength: number = 1000) =>
+  line.length <= maxLength ? line : `${line.slice(0, maxLength - 3)}...`;
 
 const styles = StyleSheet.create({
   codeBlock: {
@@ -34,7 +106,17 @@ const styles = StyleSheet.create({
   codeBlock__contentContainer: {
     padding: 8,
   },
-  codeBlock__text: {
+  codeBlock__line: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 12,
+  },
+  codeBlock__lineGutter: {
+    alignItems: 'flex-end',
+    opacity: 0.55,
+  },
+  codeBlock__lineContent: {
     flex: 1,
+    flexDirection: 'row',
   },
 });

--- a/packages/app-env/src/app/components/ui/DataView.tsx
+++ b/packages/app-env/src/app/components/ui/DataView.tsx
@@ -1,6 +1,8 @@
 import {useMemo} from 'react';
 import {StyleSheet, View} from 'react-native';
 
+import {tryDeepJSONParse} from '../../lib/data-parser';
+
 import {Button} from './Button';
 import {CodeBlock} from './CodeBlock';
 import {Text} from './Text';
@@ -37,6 +39,13 @@ export interface DataViewProps {
    */
   contentIndent?: number;
   /**
+   * Whether to attempt to deeply parse any JSON strings found within the content
+   * before formatting it for display.
+   *
+   * @default true
+   */
+  deepParse?: boolean;
+  /**
    * Optional title to display above the content.
    */
   title?: string;
@@ -46,14 +55,23 @@ export function DataView({
   actions,
   content,
   contentIndent = 2,
+  deepParse,
   title,
 }: DataViewProps) {
   const contentStr = useMemo(() => {
-    if (typeof content === 'string') {
+    // non-object primitives should be returned as-is
+    if (typeof content !== 'object') {
       return content;
     }
-    return JSON.stringify(content, null, contentIndent);
-  }, [content, contentIndent]);
+
+    // objects should be traversed so that any unparsed JSON strings within them are formatted with consistent indentation.
+    return JSON.stringify(
+      deepParse ? tryDeepJSONParse(content) : content,
+      null,
+      contentIndent,
+    );
+  }, [content, contentIndent, deepParse]);
+
   return (
     <View style={styles.container}>
       <View style={styles.contentContainer}>

--- a/packages/app-env/src/app/components/ui/DataView.tsx
+++ b/packages/app-env/src/app/components/ui/DataView.tsx
@@ -18,6 +18,12 @@ export interface DataViewAction {
    * The function to call when the action button is pressed.
    */
   onPress: () => void;
+  /**
+   * Whether the action button should be disabled.
+   *
+   * @default false
+   */
+  disabled?: boolean;
 }
 
 export interface DataViewProps {
@@ -80,9 +86,9 @@ export function DataView({
       </View>
       {actions?.length ? (
         <View style={styles.actionRow}>
-          {actions.map(({label, onPress}, index) => (
+          {actions.map(({label, onPress, disabled}, index) => (
             <View key={index} style={styles.actionRow__column}>
-              <Button onPress={onPress}>
+              <Button type={disabled ? 'primaryDisabled' : 'primary'} disabled={disabled} onPress={onPress}>
                 {label}
               </Button>
             </View>

--- a/packages/app-env/src/app/components/ui/DataView.tsx
+++ b/packages/app-env/src/app/components/ui/DataView.tsx
@@ -79,11 +79,13 @@ export function DataView({
         <CodeBlock content={contentStr} />
       </View>
       {actions?.length ? (
-        <View style={styles.buttonContainer}>
-          {actions.map(({label, onPress}) => (
-            <Button key={label} onPress={onPress}>
-              {label}
-            </Button>
+        <View style={styles.actionRow}>
+          {actions.map(({label, onPress}, index) => (
+            <View key={index} style={styles.actionRow__column}>
+              <Button onPress={onPress}>
+                {label}
+              </Button>
+            </View>
           ))}
         </View>
       ) : null}
@@ -101,8 +103,13 @@ const styles = StyleSheet.create({
     gap: 8,
     flex: 1,
   },
-  buttonContainer: {
-    justifyContent: 'center',
+  actionRow: {
+    flexDirection: 'row',
+    gap: 8,
+    justifyContent: 'space-around',
     alignItems: 'center',
   },
+  actionRow__column: {
+    flex: 1,
+  }
 });

--- a/packages/app-env/src/app/components/ui/DataView.tsx
+++ b/packages/app-env/src/app/components/ui/DataView.tsx
@@ -58,7 +58,7 @@ export function DataView({
     <View style={styles.container}>
       <View style={styles.contentContainer}>
         {title ? <Text type="titleSm">{title}</Text> : null}
-        <CodeBlock>{contentStr}</CodeBlock>
+        <CodeBlock content={contentStr} />
       </View>
       {actions?.length ? (
         <View style={styles.buttonContainer}>

--- a/packages/app-env/src/app/lib/data-parser.ts
+++ b/packages/app-env/src/app/lib/data-parser.ts
@@ -1,0 +1,52 @@
+/**
+ * Attempts to recursively parse any JSON strings within the input.
+ *
+ * If the input is a string that appears to be a JSON object or array, this function will act
+ * similarly to JSON.parse. If parsing fails, the input will be returned unmodified.
+ *
+ * If the input is a string, but does not appear to be a JSON object or array,
+ * it will be returned unmodified.
+ *
+ * If the input is an object or array, this function will attempt to recursively parse any
+ * string values within the input. detected strings follow the same parsing
+ * rules as the top-level input.
+ *
+ * A new object or array will be returned with the same structure as the input,
+ * but with any successfully parsed JSON strings replaced with their corresponding
+ * JavaScript object or array values.
+ *
+ * **WARNING** This method may be extremely expensive for large complex objects.
+ * Use with caution, and heavily memoize results to avoid repeated parsing operations.
+ *
+ */
+export const tryDeepJSONParse = (input: any): any => {
+  if (
+    typeof input === 'string' &&
+    (isMaybeObjectString(input) || isMaybeArrayString(input))
+  ) {
+    try {
+      const finalInput = tryDeepJSONParse(JSON.parse(input));
+      return finalInput;
+    } catch {
+      return input;
+    }
+  }
+
+  if (typeof input === 'object' && input !== null) {
+    return Array.isArray(input)
+      ? input.map(it => tryDeepJSONParse(it))
+      : Object.fromEntries(
+        Object.entries(input).map(([key, value]) => [
+          key,
+          tryDeepJSONParse(value),
+        ]),
+      );
+  }
+
+  return input;
+};
+
+const isMaybeObjectString = (input: string): boolean =>
+  input.trim().startsWith('{') && input.trim().endsWith('}');
+const isMaybeArrayString = (input: string): boolean =>
+  input.trim().startsWith('[') && input.trim().endsWith(']');

--- a/packages/app-env/src/app/screens/AsyncStorage.tsx
+++ b/packages/app-env/src/app/screens/AsyncStorage.tsx
@@ -5,7 +5,10 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {DataView} from '../components/ui';
 import {defineDevMenuScreen} from '../lib/define-screen';
 
-interface AsyncStorageDevScreenProps {
+
+export type AsyncStorageKeyFilterPredicate = (key: string) => boolean;
+
+export interface AsyncStorageDevScreenProps {
   /**
    * If true, AsyncStorage values that are detected as
    * JSON strings will be parsed and formatted for display.
@@ -13,24 +16,56 @@ interface AsyncStorageDevScreenProps {
    * @default true
    */
   parseValues?: boolean;
+
+  /**
+   * A filter predicate function that determines whether the given AsyncStorage
+   * key should be displayed in the AsyncStorage dev screen.
+   *
+   * If `undefined`, all AsyncStorage keys will be displayed in the dev screen.
+   *
+   * This filter **does not** affect which keys are removed when the "Clear AsyncStorage"
+   * action is invoked. It only controls which keys are displayed in the dev screen.
+   */
+  displayKeyFilter?: AsyncStorageKeyFilterPredicate;
+
+  /**
+   * A filter predicate function that determines whether the given AsyncStorage
+   * key should be removed when the "Clear AsyncStorage" action is invoked.
+   *
+   * if `undefined`, all keys will be removed when the "Clear AsyncStorage" action
+   * is invoked, even if the keys are hidden by the `displayKeyFilter`.
+   */
+  clearKeyFilter?: AsyncStorageKeyFilterPredicate;
 }
 
-function AsyncStorageDevScreenImpl({parseValues = true}: AsyncStorageDevScreenProps) {
+function AsyncStorageDevScreenImpl({
+  parseValues = true,
+  displayKeyFilter,
+  clearKeyFilter,
+}: AsyncStorageDevScreenProps) {
   const [content, setContent] = useState<string | readonly KeyValuePair[]>(
     'Loading...',
   );
 
   const fetchContent = useCallback(async () => {
-    const keys = await storage.getAllKeys();
+    let keys = await storage.getAllKeys();
+    if (displayKeyFilter) {
+      keys = keys.filter(displayKeyFilter);
+    }
+
     const data = await storage.multiGet(keys);
     setContent(data);
-  }, []);
+  }, [displayKeyFilter]);
 
-  const deleteAll = useCallback(async () => {
-    const keys = await storage.getAllKeys();
+  const clearContent = useCallback(async () => {
+    let keys = await storage.getAllKeys();
+    if (clearKeyFilter) {
+      keys = keys.filter(clearKeyFilter);
+    }
+
     await storage.multiRemove(keys);
     await fetchContent();
-  }, [fetchContent]);
+  }, [fetchContent, clearKeyFilter]);
 
   useEffect(() => {
     fetchContent();
@@ -40,13 +75,15 @@ function AsyncStorageDevScreenImpl({parseValues = true}: AsyncStorageDevScreenPr
     () => [
       {
         label: 'Clear AsyncStorage',
-        onPress: deleteAll,
+        onPress: clearContent,
       },
     ],
-    [],
+    [clearContent],
   );
 
-  return <DataView deepParse={parseValues} content={content} actions={actions} />;
+  return (
+    <DataView deepParse={parseValues} content={content} actions={actions} />
+  );
 }
 
 export const AsyncStorageDevScreen =

--- a/packages/app-env/src/app/screens/AsyncStorage.tsx
+++ b/packages/app-env/src/app/screens/AsyncStorage.tsx
@@ -1,13 +1,18 @@
 import storage from '@react-native-async-storage/async-storage';
 import {KeyValuePair} from '@react-native-async-storage/async-storage/lib/typescript/types';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
-import {DataView} from '../components/ui';
-import {defineDevMenuScreen} from '../lib/define-screen';
+import {createDataViewerDevScreen} from './DataViewer';
 
 export type AsyncStorageKeyFilterPredicate = (key: string) => boolean;
 
-export interface AsyncStorageDevScreenProps {
+export interface AsyncStorageDevScreenOpts {
+  /**
+   * The title to display within the Dev Menu.
+   *
+   * @default 'AsyncStorage'
+   */
+  title?: string;
+
   /**
    * If true, AsyncStorage values that are detected as
    * JSON strings will be parsed and formatted for display.
@@ -37,73 +42,45 @@ export interface AsyncStorageDevScreenProps {
   clearKeyFilter?: AsyncStorageKeyFilterPredicate;
 }
 
-function AsyncStorageDevScreenImpl({
-  parseValues = true,
-  displayKeyFilter,
-  clearKeyFilter,
-}: AsyncStorageDevScreenProps) {
-  const [content, setContent] = useState<string | readonly KeyValuePair[]>(
-    'Loading...',
-  );
-
-  const fetchContent = useCallback(async () => {
-    let keys = await storage.getAllKeys();
-    if (displayKeyFilter) {
-      keys = keys.filter(displayKeyFilter);
-    }
-
-    const data = await storage.multiGet(keys);
-    setContent(data);
-  }, [displayKeyFilter]);
-
-  const clearContent = useCallback(async () => {
-    let keys = await storage.getAllKeys();
-    if (clearKeyFilter) {
-      keys = keys.filter(clearKeyFilter);
-    }
-
-    await storage.multiRemove(keys);
-    await fetchContent();
-  }, [fetchContent, clearKeyFilter]);
-
-  useEffect(() => {
-    fetchContent();
-  }, []);
-
-  const actions = useMemo(
-    () => [
+export const createAsyncStorageDevScreen = (
+  opts: AsyncStorageDevScreenOpts,
+) => {
+  const {
+    clearKeyFilter,
+    displayKeyFilter,
+    parseValues = true,
+    title,
+  } = opts
+  return createDataViewerDevScreen<string | readonly { key: string; value: any }[]>({
+    title: title ?? 'AsyncStorage',
+    initialContent: 'Loading...',
+    deepParseContent: parseValues,
+    onGetContent: async () => {
+      let keys = await storage.getAllKeys();
+      if (displayKeyFilter) {
+        keys = keys.filter(displayKeyFilter);
+      }
+      return (await storage.multiGet(keys)).map(it => ({
+        key: it[0],
+        value: it[1],
+      }));
+    },
+    actions: ctx => [
       {
-        label: 'Clear AsyncStorage',
-        onPress: clearContent,
+        label: `Clear AsyncStorage${Array.isArray(ctx.content) && ctx.content.length > 0 ? ` (${ctx.content.length} items)` : ''}`,
+        onPress: async () => {
+          let keys = await storage.getAllKeys();
+          if (clearKeyFilter) {
+            keys = keys.filter(clearKeyFilter);
+          }
+
+          await storage.multiRemove(keys);
+          await ctx.refetch();
+        },
+        disabled: Array.isArray(ctx.content) ? ctx.content.length === 0 : true,
       },
     ],
-    [clearContent],
-  );
+  });
+};
 
-  return (
-    <DataView deepParse={parseValues} content={content} actions={actions} />
-  );
-}
-
-export const AsyncStorageDevScreen =
-  defineDevMenuScreen<AsyncStorageDevScreenProps>(
-    'AsyncStorage',
-    AsyncStorageDevScreenImpl,
-  );
-
-export const createAsyncStorageDevScreen = (
-  props: AsyncStorageDevScreenProps & {
-    /**
-     * The title to display within the Dev Menu.
-     *
-     * @default 'AsyncStorage'
-     */
-    title?: string;
-  },
-) =>
-  defineDevMenuScreen(
-    props.title ?? 'AsyncStorage',
-    function ConfiguredAsyncStorageDevScreen() {
-      return <AsyncStorageDevScreenImpl {...props} />;
-    },
-  );
+export const AsyncStorageDevScreen = createAsyncStorageDevScreen({});

--- a/packages/app-env/src/app/screens/AsyncStorage.tsx
+++ b/packages/app-env/src/app/screens/AsyncStorage.tsx
@@ -1,5 +1,4 @@
 import storage from '@react-native-async-storage/async-storage';
-import {KeyValuePair} from '@react-native-async-storage/async-storage/lib/typescript/types';
 
 import {createDataViewerDevScreen} from './DataViewer';
 
@@ -45,13 +44,10 @@ export interface AsyncStorageDevScreenOpts {
 export const createAsyncStorageDevScreen = (
   opts: AsyncStorageDevScreenOpts,
 ) => {
-  const {
-    clearKeyFilter,
-    displayKeyFilter,
-    parseValues = true,
-    title,
-  } = opts
-  return createDataViewerDevScreen<string | readonly { key: string; value: any }[]>({
+  const {clearKeyFilter, displayKeyFilter, parseValues = true, title} = opts;
+  return createDataViewerDevScreen<
+    string | readonly {key: string; value: any}[]
+  >({
     title: title ?? 'AsyncStorage',
     initialContent: 'Loading...',
     deepParseContent: parseValues,

--- a/packages/app-env/src/app/screens/AsyncStorage.tsx
+++ b/packages/app-env/src/app/screens/AsyncStorage.tsx
@@ -5,7 +5,6 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {DataView} from '../components/ui';
 import {defineDevMenuScreen} from '../lib/define-screen';
 
-
 export type AsyncStorageKeyFilterPredicate = (key: string) => boolean;
 
 export interface AsyncStorageDevScreenProps {
@@ -93,10 +92,17 @@ export const AsyncStorageDevScreen =
   );
 
 export const createAsyncStorageDevScreen = (
-  props: AsyncStorageDevScreenProps,
+  props: AsyncStorageDevScreenProps & {
+    /**
+     * The title to display within the Dev Menu.
+     *
+     * @default 'AsyncStorage'
+     */
+    title?: string;
+  },
 ) =>
   defineDevMenuScreen(
-    `AsyncStorage`,
+    props.title ?? 'AsyncStorage',
     function ConfiguredAsyncStorageDevScreen() {
       return <AsyncStorageDevScreenImpl {...props} />;
     },

--- a/packages/app-env/src/app/screens/AsyncStorage.tsx
+++ b/packages/app-env/src/app/screens/AsyncStorage.tsx
@@ -1,40 +1,66 @@
 import storage from '@react-native-async-storage/async-storage';
+import {KeyValuePair} from '@react-native-async-storage/async-storage/lib/typescript/types';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {DataView} from '../components/ui';
 import {defineDevMenuScreen} from '../lib/define-screen';
 
-export const AsyncStorageDevScreen = defineDevMenuScreen(
-  'AsyncStorage',
-  function AsyncStorageDevScreen() {
-    const [content, setContent] = useState('Loading...');
+interface AsyncStorageDevScreenProps {
+  /**
+   * If true, AsyncStorage values that are detected as
+   * JSON strings will be parsed and formatted for display.
+   *
+   * @default true
+   */
+  parseValues?: boolean;
+}
 
-    const fetchContent = useCallback(async () => {
-      const keys = await storage.getAllKeys();
-      const data = await storage.multiGet(keys);
-      setContent(JSON.stringify(data, null, 2));
-    }, []);
+function AsyncStorageDevScreenImpl({parseValues = true}: AsyncStorageDevScreenProps) {
+  const [content, setContent] = useState<string | readonly KeyValuePair[]>(
+    'Loading...',
+  );
 
-    const deleteAll = useCallback(async () => {
-      const keys = await storage.getAllKeys();
-      await storage.multiRemove(keys);
-      await fetchContent();
-    }, [fetchContent]);
+  const fetchContent = useCallback(async () => {
+    const keys = await storage.getAllKeys();
+    const data = await storage.multiGet(keys);
+    setContent(data);
+  }, []);
 
-    useEffect(() => {
-      fetchContent();
-    }, []);
+  const deleteAll = useCallback(async () => {
+    const keys = await storage.getAllKeys();
+    await storage.multiRemove(keys);
+    await fetchContent();
+  }, [fetchContent]);
 
-    const actions = useMemo(
-      () => [
-        {
-          label: 'Clear AsyncStorage',
-          onPress: deleteAll,
-        },
-      ],
-      [],
-    );
+  useEffect(() => {
+    fetchContent();
+  }, []);
 
-    return <DataView content={content} actions={actions} />;
-  },
-);
+  const actions = useMemo(
+    () => [
+      {
+        label: 'Clear AsyncStorage',
+        onPress: deleteAll,
+      },
+    ],
+    [],
+  );
+
+  return <DataView deepParse={parseValues} content={content} actions={actions} />;
+}
+
+export const AsyncStorageDevScreen =
+  defineDevMenuScreen<AsyncStorageDevScreenProps>(
+    'AsyncStorage',
+    AsyncStorageDevScreenImpl,
+  );
+
+export const createAsyncStorageDevScreen = (
+  props: AsyncStorageDevScreenProps,
+) =>
+  defineDevMenuScreen(
+    `AsyncStorage`,
+    function ConfiguredAsyncStorageDevScreen() {
+      return <AsyncStorageDevScreenImpl {...props} />;
+    },
+  );

--- a/packages/app-env/src/app/screens/DataViewer.tsx
+++ b/packages/app-env/src/app/screens/DataViewer.tsx
@@ -1,0 +1,127 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+
+import {DataView, DataViewAction} from '../components/ui';
+import {defineDevMenuScreen} from '../lib/define-screen';
+
+export interface DataViewerDevScreenProps<ContentT = any> {
+  /**
+   * The title to display within the Dev Menu.
+   */
+  title: string;
+
+  /**
+   * Default value to display while the content is loading.
+   */
+  initialContent: ContentT;
+
+  /**
+   * Array of actions to display below the DataViewer, or a function that returns
+   * an array of actions based on the current context.
+   *
+   * @default undefined
+   */
+  actions?:
+    | DataViewAction[]
+    | ((context: {
+        content: ContentT;
+        refetch: () => Promise<void>;
+      }) => DataViewAction[]);
+
+  /**
+   * When data is returned as a stringifiable object or array, this value
+   * controls the number of spaces used to indent nested structures.
+   *
+   * @default 2
+   */
+  contentIndent?: number;
+
+  /**
+   * If true, Data provided will be recursively checked for stringified objects
+   * and arrays, which will be parsed and formatted for display.
+   *
+   * This occurs as an in-line replacement of the stringified value.
+   *
+   * @default false
+   */
+  deepParseContent?: boolean;
+
+  /**
+   * Function that will be called to retrieve the content to display in the DataViewer.
+   * Can return the content directly or a Promise that resolves to the content.
+   *
+   * If the data is static (unchanging) and accessed synchronously, `initialData`
+   * can be used to provide the value directly without needing `onGetData`.
+   *
+   * @default undefined
+   */
+  onGetContent?: () => ContentT | Promise<ContentT>;
+
+  /**
+   * The subtitle to display within the Dev Menu. shown directly above the `DataView`.
+   *
+   * @default undefined
+   */
+  subTitle?: string;
+}
+
+/**
+ * Generates a generic Dev Menu Screen for displaying arbitrary data through the `DataView` component.
+ */
+export const createDataViewerDevScreen = <ContentT,>(
+  opts: DataViewerDevScreenProps<ContentT>,
+) => {
+  const {
+    actions,
+    contentIndent,
+    deepParseContent,
+    initialContent,
+    onGetContent,
+    subTitle,
+    title,
+  } = opts;
+
+  return defineDevMenuScreen(title, function DataViewerDevScreen() {
+    const [content, setContent] = useState<ContentT>(initialContent);
+
+    const fetchData = useCallback(async () => {
+      if (!onGetContent) return;
+      try {
+        const data = await onGetContent();
+        setContent(data);
+      } catch (error) {
+        console.error(
+          `[DevMenu - ${title}] Error occurred while fetching data`,
+          error,
+        );
+      }
+    }, []);
+
+    useEffect(() => {
+      fetchData();
+    }, []);
+
+    const resolvedActions = useMemo(() => {
+      try {
+        return typeof actions === 'function'
+          ? actions({content, refetch: fetchData})
+          : actions;
+      } catch (error) {
+        console.error(
+          `[DevMenu - ${title}] Error occurred while resolving actions`,
+          error,
+        );
+        return undefined;
+      }
+    }, [content, fetchData]);
+
+    return (
+      <DataView
+        actions={resolvedActions}
+        content={content}
+        contentIndent={contentIndent}
+        deepParse={deepParseContent}
+        title={subTitle}
+      />
+    );
+  });
+};

--- a/packages/app-env/src/app/screens/SensitiveInfo.tsx
+++ b/packages/app-env/src/app/screens/SensitiveInfo.tsx
@@ -1,10 +1,15 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {deleteItem, getAllItems} from 'react-native-sensitive-info';
 
-import {DataView} from '../components/ui';
-import {defineDevMenuScreen} from '../lib/define-screen';
+import {createDataViewerDevScreen} from './DataViewer';
 
 export interface SensitiveInfoDevScreenProps {
+  /**
+   * The title to display within the Dev Menu.
+   *
+   * @default 'SensitiveInfo (<keychainService>)'
+   */
+  title?: string;
+
   /**
    * The keychain service to use when querying SensitiveInfo.
    * If undefined, the default keychain service will be used.
@@ -12,67 +17,33 @@ export interface SensitiveInfoDevScreenProps {
   keychainService?: string;
 }
 
-function SensitiveInfoDevScreenImpl({
-  keychainService,
-}: SensitiveInfoDevScreenProps) {
-  const [content, setContent] = useState<string | string[]>('loading...');
-
-  const fetchContent = useCallback(async () => {
-    const keys = await getAllItems({keychainService});
-    setContent(keys);
-  }, [keychainService]);
-
-  const deleteAll = useCallback(async () => {
-    const keys = await getAllItems({keychainService});
-    await Promise.all(
-      keys.map(async key => deleteItem(key, {keychainService})),
-    );
-    fetchContent();
-  }, [fetchContent, keychainService]);
-
-  useEffect(() => {
-    fetchContent();
-  }, [fetchContent]);
-
-  const actions = useMemo(
-    () => [
+export const createSensitiveInfoDevScreen = (
+  props: SensitiveInfoDevScreenProps,
+) =>
+  createDataViewerDevScreen<string | string[]>({
+    title:
+      props.title ??
+      `SensitiveInfo${props.keychainService ? ` (${props.keychainService})` : ''}`,
+    initialContent: 'loading...',
+    onGetContent: async () =>
+      getAllItems({keychainService: props.keychainService}),
+    actions: ctx => [
       {
-        label: `Clear SensitiveInfo${keychainService ? ` (${keychainService})` : ''}`,
-        onPress: deleteAll,
+        label: `Clear SensitiveInfo${props.keychainService ? ` (${props.keychainService})` : ''}`,
+        onPress: async () => {
+          const keys = await getAllItems({
+            keychainService: props.keychainService,
+          });
+          await Promise.all(
+            keys.map(async key =>
+              deleteItem(key, {keychainService: props.keychainService}),
+            ),
+          );
+          await ctx.refetch();
+        },
+        disabled: Array.isArray(ctx.content) ? ctx.content.length === 0 : true,
       },
     ],
-    [deleteAll, keychainService],
-  );
+  });
 
-  return (
-    <DataView
-      title={`Known Keys${keychainService ? ` (${keychainService})` : ''}`}
-      content={content}
-      actions={actions}
-    />
-  );
-}
-
-export const SensitiveInfoDevScreen =
-  defineDevMenuScreen<SensitiveInfoDevScreenProps>(
-    'SensitiveInfo',
-    SensitiveInfoDevScreenImpl,
-  );
-
-export const createSensitiveInfoDevScreen = (
-  props: SensitiveInfoDevScreenProps & {
-    /**
-     * The title to display within the Dev Menu.
-     *
-     * @default 'SensitiveInfo (<keychainService>)'
-     */
-    title?: string;
-  },
-) =>
-  defineDevMenuScreen(
-    props.title ??
-      `SensitiveInfo${props.keychainService ? ` (${props.keychainService})` : ''}`,
-    function ConfiguredSensitiveInfoDevScreen() {
-      return <SensitiveInfoDevScreenImpl {...props} />;
-    },
-  );
+export const SensitiveInfoDevScreen = createSensitiveInfoDevScreen({});

--- a/packages/app-env/src/app/screens/SensitiveInfo.tsx
+++ b/packages/app-env/src/app/screens/SensitiveInfo.tsx
@@ -5,10 +5,16 @@ import {DataView} from '../components/ui';
 import {defineDevMenuScreen} from '../lib/define-screen';
 
 export interface SensitiveInfoDevScreenProps {
+  /**
+   * The keychain service to use when querying SensitiveInfo.
+   * If undefined, the default keychain service will be used.
+   */
   keychainService?: string;
 }
 
-function SensitiveInfo({keychainService}: SensitiveInfoDevScreenProps) {
+function SensitiveInfoDevScreenImpl({
+  keychainService,
+}: SensitiveInfoDevScreenProps) {
   const [content, setContent] = useState<string | string[]>('loading...');
 
   const fetchContent = useCallback(async () => {
@@ -50,15 +56,23 @@ function SensitiveInfo({keychainService}: SensitiveInfoDevScreenProps) {
 export const SensitiveInfoDevScreen =
   defineDevMenuScreen<SensitiveInfoDevScreenProps>(
     'SensitiveInfo',
-    SensitiveInfo,
+    SensitiveInfoDevScreenImpl,
   );
 
 export const createSensitiveInfoDevScreen = (
-  props: SensitiveInfoDevScreenProps,
+  props: SensitiveInfoDevScreenProps & {
+    /**
+     * The title to display within the Dev Menu.
+     *
+     * @default 'SensitiveInfo (<keychainService>)'
+     */
+    title?: string;
+  },
 ) =>
   defineDevMenuScreen(
-    `SensitiveInfo${props.keychainService ? ` (${props.keychainService})` : ''}`,
+    props.title ??
+      `SensitiveInfo${props.keychainService ? ` (${props.keychainService})` : ''}`,
     function ConfiguredSensitiveInfoDevScreen() {
-      return <SensitiveInfo {...props} />;
+      return <SensitiveInfoDevScreenImpl {...props} />;
     },
   );


### PR DESCRIPTION
## Describe your changes

The following changes have been made to `code-app-env`:

- Features
    - `CodeBlock`s now display Line numbers for easier reference
        - This started as a way to consistently measure the dimensions of the text content for optimizing the flatlist, but the same measurement can be used to consistently size a gutter for line numbers, so I added this in. 
    - `DataView`s can now parse deeply nested JSON strings within provided data. This is optional, and controllable via prop.
        - The prime motivator for this feature is to address display issues with large stringified JSON datasets saved in AsyncStorage. These have been causing display issues in the data viewer, and leading to no data rendered. By parsing these JSON strings, we mat split an otherwise truncated dataset into viewable data.
    - `DataView` actions may now be disabled via `disabled` option. 
    - `AsyncStorageDevScreen` and `SensitiveInfoDevScreen` have been abstracted to a common `DataViewerDevScreen` which provides an easy way to define data viewer screens for other libraries, such as `react-native-keychain`.
    - `AsyncStorageDevScreen` now accepts new options, and a generator function has been created to bind these props to the screen.
        - `parseValues` - under the hood, enables `deepParse` for the data view. Practically, enables parsing of AsyncStorage values that are detected to be objects or arrays
        - `displayKeyFilter` - Controls which keys may be displayed in the data viewer. This provides a final fallback solution in the event the app has a key/value pair that either breaks the screen, or just shouldn't be displayed outright.
        - `clearKeyFilter` - Controls which keys may be cleared when cleared via CTA. Mainly provided for completeness sake with `displayKeyFilter`. I didn't want to have one prop that affects both.
- Fixes
	- Resolve Perf issues within `CodeBlock` displaying massive text strings. instead, we split content into text lines which are individually rendered in an optimized `FlatList`.
	- Fix display of multiple action CTAs in `DataView`.


## Issue ticket number and link

[ENG-6379](https://brandingbrand.atlassian.net/browse/ENG-6379)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan

1. Open Example App
2. Open Dev Menu
3. Confirm AsyncStorage, "Example Custom Screen", and "Example Generic Data Viewer Screen" all display as expected.
    - Note: the "Example Custom Screen" contains a CTA which can set example data in `AsyncStorage`.

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [x] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes


[ENG-6379]: https://brandingbrand.atlassian.net/browse/ENG-6379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ