### PR TITLE
fix(code-app-env): ENG-6394 - cast showDevMenu to boolean on Android

### DIFF
--- a/.changeset/itchy-elephants-drum.md
+++ b/.changeset/itchy-elephants-drum.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-app-env": patch
+---
+
+fix: ensure showDevMenu is casted to boolean on Android

--- a/packages/app-env/android/src/main/java/com/brandingbrand/flagshipenv/FlagshipEnvModule.kt
+++ b/packages/app-env/android/src/main/java/com/brandingbrand/flagshipenv/FlagshipEnvModule.kt
@@ -37,7 +37,7 @@ class FlagshipEnvModule(reactContext: ReactApplicationContext) :
         val showDevMenu = resources.getString(showDevMenuResourceId)
 
         constants["envName"] = sharedPref.getString("envName", envName) ?: envName
-        constants["showDevMenu"] = showDevMenu
+        constants["showDevMenu"] = showDevMenu.toBoolean()
         constants["appVersion"] = getPackageInfo().versionName
         constants["buildNumber"] = getPackageInfo().longVersionCode.toString()
 


### PR DESCRIPTION
## Describe your changes

- cast string property `flagship_dev_menu` to `boolean` as RN side expects

## Issue ticket number and link

[ENG-6394](https://brandingbrand.atlassian.net/browse/ENG-6394)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan

1. run `flagship-code prebuild` in test app with the `--release` flag
2. confirm dev menu does not show on Android

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes


[ENG-6394]: https://brandingbrand.atlassian.net/browse/ENG-6394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ