### PR TITLE
chore(ci): move standard CI to arc-rs-small

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -24,7 +24,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
Migrates standard CI from GitHub-hosted ubuntu-latest to the self-hosted arc-rs-small scale set (2026-07-24 runner audit, wave 2: workflows whose actions run anywhere Node runs; Azure-touching and Android workflows are intentionally excluded and tracked separately). Runner label change only, no workflow logic touched. Draft for review; do not merge without a capacity check on arc-rs-small.