### PR TITLE
chore(ci): deploy-docs.yml ubuntu-latest -> arc-rs-small

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -24,7 +24,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Swaps `runs-on: ubuntu-latest` for `runs-on: arc-rs-small` in this workflow, per the org-wide GitHub Actions self-hosted runner migration.

Toolchain compatibility was checked against workflows already proven on `arc-rs-small` before opening this draft. No workflow logic changed.

Draft only — nothing merges without review. Part of the ubuntu-latest -> arc-rs-small/bb-arm-runners consolidation (see arc-rs-medium -> arc-rs-small and arc-runner-set-general -> arc-rs-small draft PRs already opened).
