### PR TITLE
chore(ci): pr-test.yml ubuntu-latest -> arc-rs-small

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-rs-small
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
Swaps `runs-on: ubuntu-latest` for `runs-on: arc-rs-small` in this workflow, per the org-wide GitHub Actions self-hosted runner migration.

Toolchain compatibility was checked against workflows already proven on `arc-rs-small` before opening this draft. No workflow logic changed.

Draft only — nothing merges without review. Part of the ubuntu-latest -> arc-rs-small/bb-arm-runners consolidation (see arc-rs-medium -> arc-rs-small and arc-runner-set-general -> arc-rs-small draft PRs already opened).
