### PR TITLE
docs: describe react-native support as policy rather than enumerating versions

### DIFF
--- a/apps/docs/src/content/docs/guides/getting-started.mdx
+++ b/apps/docs/src/content/docs/guides/getting-started.mdx
@@ -10,25 +10,25 @@ Flagship Code is a comprehensive Configuration as Code (CaC) toolkit designed to
 
 In your `package.json` verify you are using matching the versions of `react-native` and `react` packages noted below.
 
-```json '"react": "^18.2.0",' '"react-native": "~0.72.0"' title="package.json"
+```json '"react": "^19.2.0",' '"react-native": "^0.83.0"' title="package.json"
 {
   "name": "my-awesome-app",
   "version": "1.0.0",
   "author": "Your Name <email@example.com>",
   "dependencies": {
-    "react": "^18.2.0",
-    "react-native": "~0.72.0"
+    "react": "^19.2.0",
+    "react-native": "^0.83.0"
   }
 }
 ```
 
-This Flagship Code v13 currently supports React Native version 0.72.+. Each major version of Flagship Code supports a new minor version of React Native.
+Each major version of Flagship Code supports a range of recent React Native minor versions. The CLI validates your project’s React Native version during `prebuild` and lists the currently supported versions when it encounters one it does not recognize.
 
 ### React Native Support
 
 Flagship Code™ is committed to maintaining compatibility with the latest versions of React Native. Recognizing the need for gradual migration in complex projects, we are implementing multi-version React Native support. This feature allows developers to seamlessly upgrade to newer versions of React Native while maintaining support for legacy versions within the same codebase.
 
-Currently, Flagship Code™ is fully compatible with React Native versions 0.72 and 0.73, and we are continuously expanding support to include new releases as they become available. The framework intelligently detects the installed version of React Native in your project and automatically selects the appropriate compatibility profile, ensuring that your development experience remains consistent and stable across different React Native versions. This approach enables teams to adopt new technologies at their own pace without compromising the functionality of existing code.
+Flagship Code™ supports a range of recent React Native minor versions: support for new releases is added shortly after they ship, and older versions are periodically retired in major releases. The framework intelligently detects the installed version of React Native in your project and automatically selects the appropriate compatibility profile, ensuring that your development experience remains consistent and stable across different React Native versions. This approach enables teams to adopt new technologies at their own pace without compromising the functionality of existing code.
 
 ### Dependencies
 
@@ -75,8 +75,8 @@ These should now be reflected in your `package.json`.
   "version": "1.0.0",
   "author": "Your Name <email@example.com>",
   "dependencies": {
-    "react": "~18.2.0",
-    "react-native": ">=0.72.0 <0.74.0"
+    "react": "^19.2.0",
+    "react-native": "^0.83.0"
   },
   "devDependencies": {
     "@brandingbrand/code-cli": "^14.0.0",

--- a/apps/docs/src/content/docs/guides/migration.mdx
+++ b/apps/docs/src/content/docs/guides/migration.mdx
@@ -8,7 +8,7 @@ Flagship Code has undergone a migration to a more adaptable project structure, f
 
 ## Dependencies
 
-The key highlight of the latest version of Flagship Code with respect to dependencies is its support for the most recent stable release of React Native, version 0.72.+. In adherence to industry best practices, we designate the stable version as the latest version minus one, recognizing that third-party libraries require time to align with the latest release.
+The key highlight of the latest version of Flagship Code with respect to dependencies is its support for the most recent stable release of React Native. In adherence to industry best practices, we designate the stable version as the latest version minus one, recognizing that third-party libraries require time to align with the latest release.
 
 In this update, all Flagship Code dependencies have undergone a major version upgrade, accompanied by notable deprecations. Particularly, the package `@brandingbrand/code-core` has been deprecated in favor of `@brandingbrand/code-cli-kit`. This change stems from the recognition that the former package name lacked clarity regarding its intended use-case. We believe that `code-cli-kit` better communicates that this package serves as a developer toolkit to support the CLI package.
 

--- a/apps/docs/src/content/docs/overview/objectives.md
+++ b/apps/docs/src/content/docs/overview/objectives.md
@@ -14,7 +14,7 @@ Given the prevalence of TypeScript in React Native projects, Flagship Code prior
 
 #### Version Compatibility Assurance
 
-In light of React Native's regular release cycle, Flagship Code prioritizes stable compatibility with the latest framework versions. Recognizing the potential impact of native code changes on both projects and third-party dependencies, Flagship Code adheres to a policy of ensuring compatibility with the latest stable version minus one, mitigating the risk of unforeseen regressions. Currently we support both 0.72 and 0.73 versions of React Native.
+In light of React Native's regular release cycle, Flagship Code prioritizes stable compatibility with the latest framework versions. Recognizing the potential impact of native code changes on both projects and third-party dependencies, Flagship Code adheres to a policy of ensuring compatibility with the latest stable version minus one, mitigating the risk of unforeseen regressions.
 
 #### Customizability and Extensibility
 


### PR DESCRIPTION
## Summary
- The getting-started guide stated Flagship Code v13 with support for React Native 0.72 and 0.73; current reality is v14 with a wider supported range. Rather than updating one enumeration to another that will also go stale, the supported-versions statements now describe how support works: a range of recent minors per major release, new releases added shortly after they ship, older versions retired in major releases, and the CLI listing supported versions when it encounters an unrecognized one.
- Code examples updated to current versions (react ^19.2.0, react-native ^0.83.0).

## Verification
- Docs site builds clean (`yarn workspace @brandingbrand/code-docs build`).