### PR TITLE
ci: add weekly RN release-watch workflow

### DIFF
--- a/.github/workflows/rn-release-watch.yml
+++ b/.github/workflows/rn-release-watch.yml
@@ -1,0 +1,48 @@
+name: RN Release Watch
+
+on:
+  schedule:
+    # Every Thursday at 13:00 UTC.
+    - cron: '0 13 * * 4'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log the outcome without filing an issue'
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - 'scripts/rn-release-watch.mjs'
+      - 'scripts/rn-release-watch.test.mjs'
+      - '.github/workflows/rn-release-watch.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Use Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 20
+      - name: Unit-test the release-watch detection logic
+        run: node --test scripts/rn-release-watch.test.mjs
+
+  watch:
+    needs: test
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Use Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 20
+      - name: Watch npm for a newly-stable RN minor and file an adoption issue
+        run: node scripts/rn-release-watch.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/scripts/rn-release-watch.mjs
+++ b/scripts/rn-release-watch.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// Watches npm for every React Native minor whose dot-zero release has been
+// published but isn't adopted yet, and files one `rn-adoption` tracking
+// issue per pending minor (ascending, deduped against existing issues).
+// Adoption itself stays manual (`yarn add-rn-version <version>`) -- this
+// only detects and files the issues.
+
+import {readdirSync} from 'node:fs';
+
+const TEMPLATE_DIR = new URL(
+  '../packages/templates/react-native/',
+  import.meta.url,
+);
+
+const MAINTAINER_GUIDE_URL =
+  'https://brandingbrand.github.io/flagship/maintain/add-rn-version/';
+
+/**
+ * Given the directory names under packages/templates/react-native, return
+ * the highest adopted React Native minor.
+ */
+export function computeHighestAdopted(templateDirNames) {
+  const adopted = templateDirNames
+    .filter(name => /^\d+\.\d+$/.test(name))
+    .map(name => name.split('.').map(Number))
+    .sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+
+  if (adopted.length === 0) {
+    throw new Error('No adopted react-native template versions found.');
+  }
+
+  const [major, minor] = adopted[adopted.length - 1];
+  return {major, minor, label: `${major}.${minor}`};
+}
+
+/**
+ * Given the highest adopted minor and the npm packument's `time` map, return
+ * every published dot-zero minor above it, ascending. Compares (major,
+ * minor) tuples rather than assuming a fixed major, so a jump straight to a
+ * new major (e.g. 1.0) is caught instead of silently missed.
+ *
+ * `npmVersions` is the packument's `versions` map -- entries npm marks
+ * `deprecated` are excluded. react-native@1000.0.0 (published 2024-01-31,
+ * "accidentally published and should not be used in production") is real
+ * data that would otherwise be picked up as the "highest" pending minor.
+ */
+export function computePendingMinors({highest, npmTime, npmVersions}) {
+  const pending = [];
+  for (const [version, releasedAt] of Object.entries(npmTime)) {
+    const match = /^(\d+)\.(\d+)\.0$/.exec(version);
+    if (!match) {
+      continue;
+    }
+    if (npmVersions[version]?.deprecated) {
+      continue;
+    }
+    const major = Number(match[1]);
+    const minor = Number(match[2]);
+    if (
+      major > highest.major ||
+      (major === highest.major && minor > highest.minor)
+    ) {
+      pending.push({
+        major,
+        minor,
+        label: `${major}.${minor}`,
+        version,
+        releasedAt,
+      });
+    }
+  }
+  return pending.sort((a, b) => a.major - b.major || a.minor - b.minor);
+}
+
+/**
+ * Pure date-math, for logging only -- there is no maturity wait gating
+ * whether a pending minor is eligible.
+ */
+export function evaluateRelease({releasedAt, now}) {
+  const ageDays = Math.floor(
+    (now.getTime() - new Date(releasedAt).getTime()) / 86_400_000,
+  );
+  return {ageDays};
+}
+
+/**
+ * Pure duplicate check: does an open-or-closed issue with this exact title
+ * already exist?
+ */
+export function findExistingIssue({existingIssues, title}) {
+  return existingIssues.find(issue => issue.title === title) ?? null;
+}
+
+export function buildIssueBody({minorLabel, dotZeroVersion, releasedAt, highest}) {
+  const diffUrl = `https://react-native-community.github.io/upgrade-helper/?from=${highest.label}.0&to=${dotZeroVersion}`;
+  return [
+    `React Native ${dotZeroVersion} shipped on ${releasedAt}.`,
+    '',
+    `This repo currently ships native templates through ${highest.label} (\`packages/templates/react-native\`); ${minorLabel} is not yet supported.`,
+    '',
+    `Follow the [Adding React Native Version Support](${MAINTAINER_GUIDE_URL}) guide for the full adoption process -- this issue only tracks that ${minorLabel} is ready to adopt.`,
+    '',
+    `Upstream template diff: ${diffUrl}`,
+    '',
+    '_Filed automatically by `.github/workflows/rn-release-watch.yml`._',
+  ].join('\n');
+}
+
+async function githubRequest(
+  path,
+  {token, method = 'GET', body, fetchImpl = fetch} = {},
+) {
+  const res = await fetchImpl(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'rn-release-watch',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API ${method} ${path} failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.json();
+}
+
+export async function run({
+  dryRun = false,
+  log = console.log,
+  now = new Date(),
+  fetchImpl = fetch,
+  readTemplateDirNames = () => readdirSync(TEMPLATE_DIR),
+} = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY; // "owner/repo"
+  if (!token || !repository) {
+    throw new Error('GITHUB_TOKEN and GITHUB_REPOSITORY must be set.');
+  }
+  const [owner, repo] = repository.split('/');
+
+  const templateDirNames = readTemplateDirNames();
+  const highest = computeHighestAdopted(templateDirNames);
+  log(`Highest adopted RN minor: ${highest.label}`);
+
+  const npmRes = await fetchImpl('https://registry.npmjs.org/react-native');
+  if (!npmRes.ok) {
+    throw new Error(
+      `npm registry lookup failed: ${npmRes.status} ${npmRes.statusText}`,
+    );
+  }
+  const {time: npmTime, versions: npmVersions} = await npmRes.json();
+
+  const pending = computePendingMinors({highest, npmTime, npmVersions});
+  if (pending.length === 0) {
+    log('No published RN minor above the highest adopted; nothing to do.');
+    return {filed: [], skipped: []};
+  }
+  log(
+    `Pending minors above ${highest.label}: ${pending
+      .map(minor => minor.label)
+      .join(', ')}`,
+  );
+
+  const searchResult = await githubRequest(
+    `/search/issues?q=${encodeURIComponent(
+      `repo:${owner}/${repo} is:issue label:rn-adoption`,
+    )}`,
+    {token, fetchImpl},
+  );
+  const existingIssues = searchResult.items;
+
+  const filed = [];
+  const skipped = [];
+  for (const minor of pending) {
+    const title = `RN ${minor.label} adoption tracking`;
+    const existing = findExistingIssue({existingIssues, title});
+    if (existing) {
+      log(
+        `Tracking issue already exists for ${minor.label}: ${existing.html_url}`,
+      );
+      skipped.push({
+        label: minor.label,
+        reason: 'duplicate',
+        url: existing.html_url,
+      });
+      continue;
+    }
+
+    const {ageDays} = evaluateRelease({releasedAt: minor.releasedAt, now});
+    log(`${minor.version} published ${minor.releasedAt} (${ageDays} days old).`);
+
+    const body = buildIssueBody({
+      minorLabel: minor.label,
+      dotZeroVersion: minor.version,
+      releasedAt: minor.releasedAt,
+      highest,
+    });
+
+    if (dryRun) {
+      log(`[dry run] Would file issue "${title}":\n${body}`);
+      filed.push({label: minor.label, reason: 'dry-run', title, body});
+      continue;
+    }
+
+    const created = await githubRequest(`/repos/${owner}/${repo}/issues`, {
+      token,
+      method: 'POST',
+      body: {title, body, labels: ['rn-adoption']},
+      fetchImpl,
+    });
+    log(`Filed ${created.html_url}`);
+    filed.push({label: minor.label, url: created.html_url});
+  }
+
+  return {filed, skipped};
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const dryRun = process.env.DRY_RUN === 'true';
+  run({dryRun}).catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/rn-release-watch.test.mjs
+++ b/scripts/rn-release-watch.test.mjs
@@ -1,0 +1,262 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeHighestAdopted,
+  computePendingMinors,
+  evaluateRelease,
+  findExistingIssue,
+  buildIssueBody,
+  run,
+} from './rn-release-watch.mjs';
+
+test('computeHighestAdopted picks the highest adopted template', () => {
+  const dirs = [
+    '0.72',
+    '0.73',
+    '0.74',
+    '0.75',
+    '0.76',
+    '0.77',
+    '0.78',
+    '0.79',
+    '0.80',
+    '0.81',
+    '0.82',
+    '0.83',
+  ];
+  assert.deepEqual(computeHighestAdopted(dirs), {
+    major: 0,
+    minor: 83,
+    label: '0.83',
+  });
+});
+
+test('computeHighestAdopted ignores non-version entries in the template dir', () => {
+  const dirs = ['0.72', '0.73', 'README.md', '.DS_Store'];
+  assert.deepEqual(computeHighestAdopted(dirs), {
+    major: 0,
+    minor: 73,
+    label: '0.73',
+  });
+});
+
+test('computeHighestAdopted throws when no adopted versions are found', () => {
+  assert.throws(() => computeHighestAdopted(['README.md']));
+});
+
+test('computePendingMinors returns every published dot-zero minor above the highest adopted, ascending', () => {
+  const highest = {major: 0, minor: 83, label: '0.83'};
+  const npmTime = {
+    created: '2015-03-26T22:43:20.000Z',
+    modified: '2026-07-27T00:00:00.000Z',
+    '0.83.0': '2026-01-01T00:00:00.000Z',
+    '0.83.1': '2026-01-15T00:00:00.000Z',
+    '0.84.0': '2026-02-11T00:00:00.000Z',
+    '0.85.0': '2026-04-01T00:00:00.000Z',
+    '0.85.2': '2026-04-20T00:00:00.000Z',
+    '0.86.0': '2026-06-01T00:00:00.000Z',
+  };
+  const pending = computePendingMinors({highest, npmTime, npmVersions: {}});
+  assert.deepEqual(
+    pending.map(minor => minor.label),
+    ['0.84', '0.85', '0.86'],
+  );
+});
+
+test('computePendingMinors catches a jump straight to a new major', () => {
+  const highest = {major: 0, minor: 83, label: '0.83'};
+  const npmTime = {
+    '0.83.0': '2026-01-01T00:00:00.000Z',
+    '1.0.0': '2026-05-01T00:00:00.000Z',
+  };
+  const pending = computePendingMinors({highest, npmTime, npmVersions: {}});
+  assert.deepEqual(
+    pending.map(minor => minor.label),
+    ['1.0'],
+  );
+});
+
+test('computePendingMinors returns nothing when the highest adopted minor is already current', () => {
+  const highest = {major: 0, minor: 83, label: '0.83'};
+  const npmTime = {'0.83.0': '2026-01-01T00:00:00.000Z'};
+  assert.deepEqual(
+    computePendingMinors({highest, npmTime, npmVersions: {}}),
+    [],
+  );
+});
+
+test('computePendingMinors excludes npm-deprecated dot-zero versions', () => {
+  // Real npm data: react-native@1000.0.0 was "accidentally published" in
+  // 2024 and is marked deprecated -- it must never be picked up as the
+  // highest pending minor.
+  const highest = {major: 0, minor: 83, label: '0.83'};
+  const npmTime = {
+    '0.83.0': '2026-01-01T00:00:00.000Z',
+    '0.84.0': '2026-02-11T00:00:00.000Z',
+    '1000.0.0': '2024-01-31T22:02:17.187Z',
+  };
+  const npmVersions = {
+    '1000.0.0': {
+      deprecated:
+        'This version of React Native was accidentally published and should not be used in production',
+    },
+  };
+  const pending = computePendingMinors({highest, npmTime, npmVersions});
+  assert.deepEqual(
+    pending.map(minor => minor.label),
+    ['0.84'],
+  );
+});
+
+test('evaluateRelease: reports age in days', () => {
+  const releasedAt = '2026-02-11T00:00:00Z';
+  const now = new Date('2026-07-27T00:00:00Z');
+  const result = evaluateRelease({releasedAt, now});
+  assert.equal(result.ageDays, 166);
+});
+
+test('evaluateRelease: freshly published (0 days old)', () => {
+  const now = new Date('2026-07-27T00:00:00Z');
+  const result = evaluateRelease({releasedAt: now.toISOString(), now});
+  assert.equal(result.ageDays, 0);
+});
+
+test('findExistingIssue: matches an issue with the exact title', () => {
+  const existingIssues = [
+    {title: 'Something unrelated', html_url: 'https://example.com/1'},
+    {title: 'RN 0.84 adoption tracking', html_url: 'https://example.com/2'},
+  ];
+  const found = findExistingIssue({
+    existingIssues,
+    title: 'RN 0.84 adoption tracking',
+  });
+  assert.equal(found?.html_url, 'https://example.com/2');
+});
+
+test('findExistingIssue: no match when the title differs', () => {
+  const existingIssues = [{title: 'RN 0.83 adoption tracking'}];
+  const found = findExistingIssue({
+    existingIssues,
+    title: 'RN 0.84 adoption tracking',
+  });
+  assert.equal(found, null);
+});
+
+test('findExistingIssue: no match against an empty issue list', () => {
+  assert.equal(
+    findExistingIssue({existingIssues: [], title: 'RN 0.84 adoption tracking'}),
+    null,
+  );
+});
+
+test('buildIssueBody: links the maintainer guide and the upstream template diff', () => {
+  const body = buildIssueBody({
+    minorLabel: '0.84',
+    dotZeroVersion: '0.84.0',
+    releasedAt: '2026-02-11T16:04:19.627Z',
+    highest: {major: 0, minor: 83, label: '0.83'},
+  });
+  assert.match(
+    body,
+    /\[Adding React Native Version Support\]\(https:\/\/brandingbrand\.github\.io\/flagship\/maintain\/add-rn-version\/\)/,
+  );
+  assert.match(
+    body,
+    /https:\/\/react-native-community\.github\.io\/upgrade-helper\/\?from=0\.83\.0&to=0\.84\.0/,
+  );
+  assert.doesNotMatch(body, /yarn add-rn-version/);
+});
+
+test('run(): end-to-end dry run files one issue per pending minor, ascending, deduped', async () => {
+  const requestedUrls = [];
+  const fetchImpl = async url => {
+    requestedUrls.push(String(url));
+    if (String(url).startsWith('https://registry.npmjs.org/react-native')) {
+      return {
+        ok: true,
+        json: async () => ({
+          time: {
+            '0.83.0': '2026-01-01T00:00:00.000Z',
+            '0.84.0': '2026-02-11T00:00:00.000Z',
+            '0.85.0': '2026-04-01T00:00:00.000Z',
+            '0.86.0': '2026-06-01T00:00:00.000Z',
+          },
+          versions: {},
+        }),
+      };
+    }
+    if (String(url).startsWith('https://api.github.com/search/issues')) {
+      return {
+        ok: true,
+        json: async () => ({
+          items: [{title: 'RN 0.85 adoption tracking', html_url: 'https://example.com/existing'}],
+        }),
+      };
+    }
+    throw new Error(`run() made an unexpected request: ${url}`);
+  };
+
+  process.env.GITHUB_TOKEN = 'test-token';
+  process.env.GITHUB_REPOSITORY = 'brandingbrand/flagship';
+  try {
+    const result = await run({
+      dryRun: true,
+      log: () => {},
+      now: new Date('2026-07-27T00:00:00Z'),
+      fetchImpl,
+      readTemplateDirNames: () => ['0.82', '0.83'],
+    });
+
+    assert.deepEqual(
+      result.filed.map(entry => entry.label),
+      ['0.84', '0.86'],
+    );
+    assert.deepEqual(
+      result.skipped.map(entry => entry.label),
+      ['0.85'],
+    );
+    assert.equal(result.skipped[0].reason, 'duplicate');
+    assert.match(
+      result.filed[0].body,
+      /React Native 0\.84\.0 shipped on 2026-02-11T00:00:00\.000Z\./,
+    );
+    assert.deepEqual(requestedUrls, [
+      'https://registry.npmjs.org/react-native',
+      'https://api.github.com/search/issues?q=repo%3Abrandingbrand%2Fflagship%20is%3Aissue%20label%3Arn-adoption',
+    ]);
+  } finally {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_REPOSITORY;
+  }
+});
+
+test('run(): no pending minors returns empty result without hitting the search API', async () => {
+  const requestedUrls = [];
+  const fetchImpl = async url => {
+    requestedUrls.push(String(url));
+    return {
+      ok: true,
+      json: async () => ({
+        time: {'0.83.0': '2026-01-01T00:00:00.000Z'},
+        versions: {},
+      }),
+    };
+  };
+
+  process.env.GITHUB_TOKEN = 'test-token';
+  process.env.GITHUB_REPOSITORY = 'brandingbrand/flagship';
+  try {
+    const result = await run({
+      dryRun: true,
+      log: () => {},
+      now: new Date('2026-07-27T00:00:00Z'),
+      fetchImpl,
+      readTemplateDirNames: () => ['0.82', '0.83'],
+    });
+    assert.deepEqual(result, {filed: [], skipped: []});
+    assert.deepEqual(requestedUrls, ['https://registry.npmjs.org/react-native']);
+  } finally {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_REPOSITORY;
+  }
+});


### PR DESCRIPTION
Watches npm for new React Native minors and files one `rn-adoption`-labeled tracking issue per pending minor above the highest adopted, ascending and deduped against existing tracking issues (a jump straight to a new major is caught the same way). Adoption itself stays manual (`yarn add-rn-version <version>`); this only detects and files the issue. Uses the stock `GITHUB_TOKEN` (`issues: write` only).

The logic works as follows:

- Each filed issue points to the published maintainer guide (`add-rn-version`) instead of an inline recipe, and links the upstream template diff (`rn-diff-purge`) for the target minor.
- npm-deprecated dot-zero releases (e.g. `react-native@1000.0.0`, accidentally published in 2024) are excluded so a bogus version can't be picked up as pending.
- Detection logic (pending-minor computation, publish check, deprecated-version exclusion, duplicate-issue check) lives in `scripts/rn-release-watch.mjs` as pure, dependency-injected functions callable outside Actions.
- Unit tests in `scripts/rn-release-watch.test.mjs` (`node --test`), including an end-to-end test that runs the watcher against mocked npm/GitHub responses and asserts the exact issue title/body it would file.
- A `test` job runs on every PR touching these files; the `watch` job itself runs weekly (Thursdays 13:00 UTC) or on manual dispatch (with a `dry_run` input).
- No maturity wait: a freshly-published (0-day-old) dot-zero release is filed immediately.

## Test plan
- [x] `node --test scripts/rn-release-watch.test.mjs`
- [x] `actionlint .github/workflows/rn-release-watch.yml`
- [x] Dry run against real npm/GitHub data (`DRY_RUN=true`)
- [ ] First scheduled/manual run in CI