### PR TITLE
ci: notify a webhook when an issue is labeled ready-to-ship

### DIFF
--- a/.github/workflows/notify-ready-to-ship.yml
+++ b/.github/workflows/notify-ready-to-ship.yml
@@ -1,0 +1,29 @@
+name: Notify on ready-to-ship
+
+# When an issue is labeled `ready-to-ship`, POST its number and title to a
+# webhook (stored in the DISPATCH_WEBHOOK_URL secret) so a downstream
+# automation can pick the issue up. No repo write access is used.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions: {}
+
+jobs:
+  notify:
+    if: github.event.label.name == 'ready-to-ship'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post issue to dispatch webhook
+        env:
+          DISPATCH_WEBHOOK_URL: ${{ secrets.DISPATCH_WEBHOOK_URL }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          payload=$(jq -n \
+            --arg n "$ISSUE_NUMBER" \
+            --arg t "$ISSUE_TITLE" \
+            '{issue_number: $n, issue_title: $t}')
+          curl -sf -X POST -H "Content-Type: application/json" \
+            --data "$payload" "$DISPATCH_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Adds a workflow that fires when an issue is labeled `ready-to-ship` and POSTs the issue number and title to a webhook stored in the `DISPATCH_WEBHOOK_URL` repo secret.
- Lets a downstream automation pick up an approved issue without anyone doing it by hand.

## Notes
- Uses `permissions: {}` (no repo write access).
- The issue title is passed via env var and `jq`, not interpolated into the shell, to avoid script injection.
- Requires the `DISPATCH_WEBHOOK_URL` repository secret to be set.
- Issue events fire workflows from the default branch, so this only runs once merged to `develop`.