### PR TITLE
fix(plugin-verify-dependencies): pin react version to 19.2.0 for 0.83.X react-native

### DIFF
--- a/.changeset/great-hats-hang.md
+++ b/.changeset/great-hats-hang.md
@@ -1,0 +1,5 @@
+---
+"@brandingbrand/code-plugin-verify-dependencies": patch
+---
+
+pin react version to 19.2.0 to mirror react-native 0.83.X template

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -17,7 +17,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/native": "^7.3.14",
     "@react-navigation/native-stack": "^7.18.6",
-    "react": "^19.2.0",
+    "react": "19.2.0",
     "react-native": "^0.83.0",
     "react-native-permissions": "^4.1.5",
     "react-native-safe-area-context": "^5.6.2",
@@ -59,7 +59,7 @@
     "jest": "^29.2.1",
     "prettier": "^3.1.1",
     "react-native-bootsplash": "^5.4.0",
-    "react-test-renderer": "19.0.0",
+    "react-test-renderer": "19.2.0",
     "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "husky": ">=7",
     "lint-staged": ">=10",
     "prettier": "^3.1.1",
-    "react": "^19.2.0",
+    "react": "19.2.0",
     "react-native": "^0.83.0",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-sensitive-info": "^5.6.2",

--- a/packages/plugin-verify-dependencies/src/profile/0.83.ts
+++ b/packages/plugin-verify-dependencies/src/profile/0.83.ts
@@ -74,7 +74,7 @@ export default {
    * @see {@link https://reactjs.org/}
    */
   react: {
-    version: '^19.2.0',
+    version: '19.2.0',
     capabilities: ['@types/react'],
     required: true,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,13 +2563,13 @@ __metadata:
     eslint-plugin-react-native: "npm:^4.0.0"
     jest: "npm:^29.2.1"
     prettier: "npm:^3.1.1"
-    react: "npm:^19.2.0"
+    react: "npm:19.2.0"
     react-native: "npm:^0.83.0"
     react-native-bootsplash: "npm:^5.4.0"
     react-native-permissions: "npm:^4.1.5"
     react-native-safe-area-context: "npm:^5.6.2"
     react-native-screens: "npm:~4.16.0"
-    react-test-renderer: "npm:19.0.0"
+    react-test-renderer: "npm:19.2.0"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -2926,7 +2926,7 @@ __metadata:
     husky: "npm:>=7"
     lint-staged: "npm:>=10"
     prettier: "npm:^3.1.1"
-    react: "npm:^19.2.0"
+    react: "npm:19.2.0"
     react-native: "npm:^0.83.0"
     react-native-safe-area-context: "npm:^5.6.2"
     react-native-sensitive-info: "npm:^5.6.2"
@@ -16627,14 +16627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^19.0.0":
-  version: 19.2.1
-  resolution: "react-is@npm:19.2.1"
-  checksum: 10c0/0ebeaedb4ff615055cbcd758c7e22ba9644e21110adbd293dd1aada3591abf7399152a786cd120e324c10706d75e28c2130c27d1b9b5ae637aef4c52f4d17a91
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^19.1.0":
+"react-is@npm:^19.1.0, react-is@npm:^19.2.0":
   version: 19.2.8
   resolution: "react-is@npm:19.2.8"
   checksum: 10c0/ed5322c84efe035c8fc814b1614ff5ca7fb8c2872a7c045197daf99f9b1bd68f32a2c79ffcbcfcff2fc5d93924ff9f9447400898f5b1534e6302bb0736a257f0
@@ -16844,22 +16837,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-test-renderer@npm:19.0.0":
-  version: 19.0.0
-  resolution: "react-test-renderer@npm:19.0.0"
+"react-test-renderer@npm:19.2.0":
+  version: 19.2.0
+  resolution: "react-test-renderer@npm:19.2.0"
   dependencies:
-    react-is: "npm:^19.0.0"
-    scheduler: "npm:^0.25.0"
+    react-is: "npm:^19.2.0"
+    scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^19.0.0
-  checksum: 10c0/67c34dae4d3a60b9306d2b5cb6db436376ef20c651aaf092644298e3ffb92cd3c7b0da2017e7f1395bf2de8b42429874a5a63e8cc3c21febbab31b0309e41862
+    react: ^19.2.0
+  checksum: 10c0/cc116b908489316f06881bf7392c5fad4b5f66be42d2f04788f4179a19e86674d54f1006b33fe9eba28bde6edb4cb38764ab75b416f28d02e0182c5552c97551
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.0":
-  version: 19.2.4
-  resolution: "react@npm:19.2.4"
-  checksum: 10c0/cd2c9ff67a720799cc3b38a516009986f7fc4cb8d3e15716c6211cf098d1357ee3e348ab05ad0600042bbb0fd888530ba92e329198c92eafa0994f5213396596
+"react@npm:19.2.0":
+  version: 19.2.0
+  resolution: "react@npm:19.2.0"
+  checksum: 10c0/1b6d64eacb9324725bfe1e7860cb7a6b8a34bc89a482920765ebff5c10578eb487e6b46b2f0df263bd27a25edbdae2c45e5ea5d81ae61404301c1a7192c38330
   languageName: node
   linkType: hard
 
@@ -17874,17 +17867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:0.27.0":
+"scheduler@npm:0.27.0, scheduler@npm:^0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
   checksum: 10c0/4f03048cb05a3c8fddc45813052251eca00688f413a3cee236d984a161da28db28ba71bd11e7a3dd02f7af84ab28d39fb311431d3b3772fed557945beb00c452
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "scheduler@npm:0.25.0"
-  checksum: 10c0/a4bb1da406b613ce72c1299db43759526058fdcc413999c3c3e0db8956df7633acf395cb20eb2303b6a65d658d66b6585d344460abaee8080b4aa931f10eaafe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe your changes
React Native 0.83.X pins react to version 19.2.0 in all it's templates. https://raw.githubusercontent.com/react-native-community/rn-diff-purge/release/0.83.10/RnDiffApp/package.json
This aligns with that so we don't pick up newer versions of react which will possibly break with this version of react-native

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
* run align deps in example app for react native 0.83 and verify no changes, or modify and verify it sets correct
* run the example app
* ER: it runs and doesn't crash

## Checklist before requesting a review

- [x] A self-review of my code has been completed
- [ ] Tests have been added / updated if required
- [ ] Documentation has been updated to reflect these changes
