### PR TITLE
chore: update checkout and setup-node to their node24 runtime releases and assert exact react pins

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Install, build, and upload your site
         uses: withastro/action@acfe56dffc635abfb9506c77d51ce097030360d1
         with:

--- a/.github/workflows/pr-compile.yml
+++ b/.github/workflows/pr-compile.yml
@@ -15,11 +15,12 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984
         with:
@@ -45,11 +46,12 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -8,11 +8,12 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@f26937343756480a8cb3ae1f623b9c8d89ed6984
         with:
@@ -33,7 +34,7 @@ jobs:
     outputs:
       versions: ${{ steps.list.outputs.versions }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: List supported react-native template versions
         id: list
         run: echo "versions=$(ls packages/templates/react-native | jq --raw-input --slurp --compact-output 'split("\n") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
@@ -47,11 +48,12 @@ jobs:
       matrix:
         rn-version: ${{ fromJSON(needs.template-versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Install dependencies
         run: yarn
       - name: Build packages

--- a/.github/workflows/rn-release-watch.yml
+++ b/.github/workflows/rn-release-watch.yml
@@ -20,11 +20,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Unit-test the release-watch detection logic
         run: node --test scripts/rn-release-watch.test.mjs
 
@@ -36,11 +37,12 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
       - name: Use Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: 20
+          package-manager-cache: false
       - name: Watch npm for a newly-stable RN minor and file an adoption issue
         run: node scripts/rn-release-watch.mjs
         env:

--- a/packages/plugin-verify-dependencies/__tests__/profile.ts
+++ b/packages/plugin-verify-dependencies/__tests__/profile.ts
@@ -37,6 +37,19 @@ describe('dependency profiles', () => {
   );
 
   it.each(entries)(
+    'profile %s pins react exactly, with no range operator',
+    (_version, profile) => {
+      // Every React Native minor is built and tested against one patch of
+      // react, and the community template pins it exactly for that reason.
+      // A range here lets a consumer resolve a react the minor was never
+      // built against, and `verify-dependencies` will not flag it because
+      // the installed version still satisfies the range.
+      expect(profile.react).toBeDefined();
+      expect(profile.react!.version).toMatch(/^\d+\.\d+\.\d+$/);
+    },
+  );
+
+  it.each(entries)(
     'profile %s pins @react-native scoped packages to its own version',
     (version, profile) => {
       const scoped = Object.entries(profile).filter(([name]) =>


### PR DESCRIPTION
## Summary

Two small pieces of maintenance, neither changing how anything behaves at runtime.

- Move `actions/checkout` and `actions/setup-node` to the releases that run on the Node 24 action runtime, pinned by commit as before.
- Assert that every dependency profile pins `react` exactly rather than as a range.

## What does not change

The Node this repository builds under is unchanged. Every `setup-node` step still passes `node-version: 22`, and no `node-version` line is touched here. What moves is the runtime GitHub executes the actions themselves under, declared as `runs.using: node24` in each action's own `action.yml` at the pinned commits.

## Why the action bump now

Runners have defaulted to Node 24 since 16 June 2026. The v4 pins already run under it, which is why every job logs a forced-migration warning rather than failing. Node 20 support is removed entirely in the autumn, and the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out goes with it, so at that point these pins stop working instead of warning. That includes the scheduled release watcher, which would fail without anyone being notified.

Because the June default switch has already happened and CI is green, both actions are demonstrably working under Node 24 today. This makes the declaration match what is already the case.

`setup-node` v5 lists one breaking change: it enables package-manager caching automatically when the root `package.json` declares a `packageManager` field, which this repository does. No workflow caches dependencies today, so `package-manager-cache: false` is set on every occurrence to keep this a runtime change only. Whether CI should cache installs is a separate question worth answering deliberately, including whether a stale store can produce a passing run that a cold install would not.

Node 24 drops support for macOS 13.4 and below and for ARM32. Not applicable here: the jobs run on `ubuntu-latest` and `macos-15`.

## Why the assertion

Each React Native minor is built and tested against one patch of `react`, which is why the community template pins it exactly. A range in a profile lets a consumer resolve a `react` the minor was never built against, and nothing surfaces it, because `verify-dependencies` compares the installed version against the profile and a range still matches.

One profile carried a caret for the entire life of its minor before it was noticed. Every profile satisfies the new assertion as of today, so this adds no work; it keeps that true when the next profile is written.

Scoped deliberately to `react`. The other exactly-pinned template entries are already covered by the existing `react-native` and `@react-native/*` assertions, and the ranged entries have no single tested pairing to preserve.

## Verification

- `yarn install`, `yarn build`, and the `plugin-verify-dependencies` suite pass: 38 tests, 12 of them the new assertion.
- The assertion was proven able to fail, not just to pass. Reintroducing a caret on one profile's `react` fails that one test and nothing else; restoring the exact pin returns 38 of 38. An assertion that has never been observed failing is not yet a guardrail.
- The workflow changes are exercised by this pull request's own runs, since every job here uses both bumped actions.

