### PR TITLE
docs: make the adoption handoff followable from the tracking issue

### DIFF
--- a/.agents/skills/upgrade-rn-version/SKILL.md
+++ b/.agents/skills/upgrade-rn-version/SKILL.md
@@ -87,7 +87,15 @@ Never adopt more than one version in a PR, never stack one adoption on another's
    - `test` is a cached task and the variable is not part of its cache key, so a run following a plain `yarn test` can replay the earlier result. `--force` is what prevents that.
 
    The proof is the `test-templates (0.XX)` job on the pull request, which cannot exist unless the template directory does. The two native builds in step 5 are part of this gate and are not implied by these four commands.
-8. **Changeset.** One file, message `add support for react-native 0.XX`, minor bump on the packages an adoption touches: `code-plugin-verify-dependencies`, `code-templates`, `code-cli-kit`, `code-cli`. Read the previous minor's changeset rather than this list if the two disagree. Declare another package only if this adoption actually modified it; do not declare one because it seems related.
+8. **Changeset.** One file, message `add support for react-native 0.XX`, minor bump on the packages an adoption touches: `code-plugin-verify-dependencies`, `code-templates`, `code-cli-kit`, `code-cli`. Declare another package only if this adoption actually modified it; do not declare one because it seems related.
+
+   Check that list against what the previous adoption actually bumped rather than trusting it:
+
+   ```sh
+   grep -rl "add support for react-native 0.YY" packages/*/CHANGELOG.md
+   ```
+
+   where `0.YY` is the minor below the one you are adopting. Those four packages are what it should name. If it names a different set, follow the CHANGELOGs and say so in the PR. Do not look for the previous minor's file in `.changeset/`: changesets are consumed when the release publishes, so the directory holds only unreleased ones and its absence there means nothing.
 9. **PR.** Draft from the first commit against `develop`. Mark ready once every item in the definition of done is satisfied, and request review from the repository's code owners. Carry the gate evidence in the PR description: the commands run, their results, and a link to the `PR Compile` run.
 
 ### Out of bounds, and when to stop
@@ -118,7 +126,7 @@ Stopping means: leave the pull request as a draft, record the step and the exact
 - [ ] The `test-templates (0.XX)` job exists on this pull request and is green. It appears only once `packages/templates/react-native/0.XX/` exists, because `PR Test` derives its matrix from that directory listing. A local run with `FLAGSHIP_CODE_TEST_RN_VERSION` set does not substitute for it.
 - [ ] `apps/example` and the root `package.json` agree on `react` and `react-native`, and `yarn why react` reports one resolved version.
 - [ ] The `PR Compile` workflow has run on this PR and both its `android` and `ios` jobs are green. Link the run in the PR description. A local build does not substitute for it, and neither does an expectation that it would pass.
-- [ ] Changeset present, correct packages and bump type.
+- [ ] Changeset present, correct packages and bump type, checked against the previous minor's CHANGELOG entries.
 - [ ] No placeholder implementations, no commented-out assertions, no partially-filled dependency profile.
 
 ### Anti-fake-test rules

--- a/.agents/skills/upgrade-rn-version/SKILL.md
+++ b/.agents/skills/upgrade-rn-version/SKILL.md
@@ -96,7 +96,11 @@ Never adopt more than one version in a PR, never stack one adoption on another's
    ```
 
    where `0.YY` is the minor below the one you are adopting. Those four packages are what it should name. If it names a different set, follow the CHANGELOGs and say so in the PR. Do not look for the previous minor's file in `.changeset/`: changesets are consumed when the release publishes, so the directory holds only unreleased ones and its absence there means nothing.
-9. **PR.** Draft from the first commit against `develop`. Mark ready once every item in the definition of done is satisfied, and request review from the repository's code owners. Carry the gate evidence in the PR description: the commands run, their results, and a link to the `PR Compile` run.
+9. **PR.** Draft from the first commit against `develop`. Mark ready once every item in the definition of done is satisfied. Carry the gate evidence in the PR description: the commands run, their results, and a link to the `PR Compile` run.
+
+   If a tracking issue exists for this minor, write `Closes #<issue>` in the PR description. `develop` is the default branch, so that closes the issue on merge instead of leaving a manual follow-up.
+
+   Do not add reviewers. This repository has no `CODEOWNERS` file, so there is nobody to derive; assignment is a maintainer's step.
 
 ### Out of bounds, and when to stop
 
@@ -127,6 +131,7 @@ Stopping means: leave the pull request as a draft, record the step and the exact
 - [ ] `apps/example` and the root `package.json` agree on `react` and `react-native`, and `yarn why react` reports one resolved version.
 - [ ] The `PR Compile` workflow has run on this PR and both its `android` and `ios` jobs are green. Link the run in the PR description. A local build does not substitute for it, and neither does an expectation that it would pass.
 - [ ] Changeset present, correct packages and bump type, checked against the previous minor's CHANGELOG entries.
+- [ ] `Closes #<issue>` in the PR description when a tracking issue exists for this minor.
 - [ ] No placeholder implementations, no commented-out assertions, no partially-filled dependency profile.
 
 ### Anti-fake-test rules

--- a/scripts/rn-release-watch.mjs
+++ b/scripts/rn-release-watch.mjs
@@ -15,6 +15,8 @@ const TEMPLATE_DIR = new URL(
 const MAINTAINER_GUIDE_URL =
   'https://brandingbrand.github.io/flagship/maintain/add-rn-version/';
 
+const SKILL_PATH = '.agents/skills/upgrade-rn-version/SKILL.md';
+
 /**
  * Given the directory names under packages/templates/react-native, return
  * the highest adopted React Native minor.
@@ -91,14 +93,25 @@ export function findExistingIssue({existingIssues, title}) {
   return existingIssues.find(issue => issue.title === title) ?? null;
 }
 
-export function buildIssueBody({minorLabel, dotZeroVersion, releasedAt, highest}) {
+export function buildIssueBody({
+  minorLabel,
+  dotZeroVersion,
+  releasedAt,
+  highest,
+  repository,
+}) {
   const diffUrl = `https://react-native-community.github.io/upgrade-helper/?from=${highest.label}.0&to=${dotZeroVersion}`;
+  const skillUrl = `https://github.com/${repository}/blob/HEAD/${SKILL_PATH}`;
   return [
     `React Native ${dotZeroVersion} shipped on ${releasedAt}.`,
     '',
     `This repo currently ships native templates through ${highest.label} (\`packages/templates/react-native\`); ${minorLabel} is not yet supported.`,
     '',
-    `Follow the [Adding React Native Version Support](${MAINTAINER_GUIDE_URL}) guide for the full adoption process -- this issue only tracks that ${minorLabel} is ready to adopt.`,
+    `The adoption procedure is [\`${SKILL_PATH}\`](${skillUrl}). Read it in full and follow it; it is the process of record and it names which trees an adoption may not touch.`,
+    '',
+    `The [maintainer guide](${MAINTAINER_GUIDE_URL}) is human-facing background on the same process. Where the two differ, the procedure above governs.`,
+    '',
+    `This issue only tracks that ${minorLabel} is ready to adopt.`,
     '',
     `Upstream template diff: ${diffUrl}`,
     '',
@@ -197,6 +210,7 @@ export async function run({
       dotZeroVersion: minor.version,
       releasedAt: minor.releasedAt,
       highest,
+      repository,
     });
 
     if (dryRun) {

--- a/scripts/rn-release-watch.test.mjs
+++ b/scripts/rn-release-watch.test.mjs
@@ -149,22 +149,42 @@ test('findExistingIssue: no match against an empty issue list', () => {
   );
 });
 
-test('buildIssueBody: links the maintainer guide and the upstream template diff', () => {
+test('buildIssueBody: links the adoption skill, the maintainer guide and the upstream template diff', () => {
   const body = buildIssueBody({
     minorLabel: '0.84',
     dotZeroVersion: '0.84.0',
     releasedAt: '2026-02-11T16:04:19.627Z',
     highest: {major: 0, minor: 83, label: '0.83'},
+    repository: 'brandingbrand/flagship',
   });
   assert.match(
     body,
-    /\[Adding React Native Version Support\]\(https:\/\/brandingbrand\.github\.io\/flagship\/maintain\/add-rn-version\/\)/,
+    /\[`\.agents\/skills\/upgrade-rn-version\/SKILL\.md`\]\(https:\/\/github\.com\/brandingbrand\/flagship\/blob\/HEAD\/\.agents\/skills\/upgrade-rn-version\/SKILL\.md\)/,
+  );
+  assert.match(
+    body,
+    /\[maintainer guide\]\(https:\/\/brandingbrand\.github\.io\/flagship\/maintain\/add-rn-version\/\)/,
   );
   assert.match(
     body,
     /https:\/\/react-native-community\.github\.io\/upgrade-helper\/\?from=0\.83\.0&to=0\.84\.0/,
   );
   assert.doesNotMatch(body, /yarn add-rn-version/);
+});
+
+test('buildIssueBody: puts the skill ahead of the maintainer guide and says which governs', () => {
+  const body = buildIssueBody({
+    minorLabel: '0.84',
+    dotZeroVersion: '0.84.0',
+    releasedAt: '2026-02-11T16:04:19.627Z',
+    highest: {major: 0, minor: 83, label: '0.83'},
+    repository: 'brandingbrand/flagship',
+  });
+  assert.ok(
+    body.indexOf('SKILL.md') < body.indexOf('maintainer guide'),
+    'the skill must be the first procedure the reader meets',
+  );
+  assert.match(body, /the procedure above governs/);
 });
 
 test('run(): end-to-end dry run files one issue per pending minor, ascending, deduped', async () => {


### PR DESCRIPTION
The weekly release watcher files an `rn-adoption` tracking issue, and that issue is where an adoption starts. Three things on that path could not be followed as written.

## 1. The tracking issue did not name the adoption procedure

`buildIssueBody` linked only the maintainer guide. The guide is a maintainer walkthrough covering the whole surface, including creating a `packages/plugin-transform-template/src/transforms/<version>` directory and copying a new `packages/templates/supporting-files/<version>` directory. `.agents/skills/upgrade-rn-version/SKILL.md` designates both of those as stop-and-report conditions and puts those trees out of bounds for an adoption, because each is a tooling change rather than a version addition. Neither directory has been added since 0.82 and 0.77 respectively, and 0.83 was adopted without either.

So whoever opens the issue reaches the broader document first and the constrained procedure not at all. The issue body now leads with the skill, keeps the guide as background, and states that the skill governs where the two differ. The link is built from `GITHUB_REPOSITORY` so it stays correct for a fork.

## 2. Step 8 pointed at a file that is never present

Step 8 said to read the previous minor's changeset if it disagreed with the listed packages. Changesets are consumed when the release publishes, so `.changeset/` holds only unreleased ones. For 0.84 that means 0.83's adoption changeset is not there and never will be. This skill treats a step it cannot run as a blocker, and this one sits immediately before the PR.

The same fact survives in the published changelogs, so step 8 now names that check and records why `.changeset/` does not hold it:

```
grep -rl "add support for react-native 0.YY" packages/*/CHANGELOG.md
```

For 0.83 this returns `cli`, `cli-kit`, `plugin-verify-dependencies` and `templates`, matching the four packages step 8 lists.

## 3. Step 9 left the tracking issue open and asked for a reviewer that cannot be derived

`develop` is the default branch, so `Closes #<issue>` in an adoption PR closes its tracking issue on merge. Step 9 never asked for it, leaving the last step of the loop manual. It is now part of step 9 and the definition of done.

Step 9 also asked for review from the repository's code owners. There is no `CODEOWNERS` file and `require_code_owner_reviews` is off on `develop`, so that instruction can only be satisfied by guessing at a name. Reviewer assignment is now left to maintainers.

## Verification

- `node --test scripts/rn-release-watch.test.mjs`: 15/15 pass. The existing `buildIssueBody` test now asserts the skill link alongside the guide link it already checked.
- Dry run against live npm and the GitHub API, which is what the Thursday schedule will do: highest adopted `0.83`, pending `0.84, 0.85, 0.86`, all three matched to existing issues, nothing filed.
- Rendered body checked for a synthetic pending minor; the generated skill URL resolves (HTTP 200).
- No changeset: no published package changes. `scripts/` and `.agents/` are outside the workspaces, and the root is private.
